### PR TITLE
feat: add 404, error boundary, and loading skeleton pages

### DIFF
--- a/apps/interface/src/app/error.tsx
+++ b/apps/interface/src/app/error.tsx
@@ -1,0 +1,22 @@
+"use client";
+
+export default function Error({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  return (
+    <div className="min-h-screen flex flex-col items-center justify-center gap-4 text-center px-4">
+      <h2 className="text-2xl font-bold text-white">Something went wrong</h2>
+      <p className="text-gray-400 max-w-md">{error.message || "An unexpected error occurred."}</p>
+      <button
+        onClick={reset}
+        className="mt-2 px-6 py-2 bg-indigo-600 hover:bg-indigo-500 text-white rounded-lg transition-colors"
+      >
+        Try Again
+      </button>
+    </div>
+  );
+}

--- a/apps/interface/src/app/loading.tsx
+++ b/apps/interface/src/app/loading.tsx
@@ -1,0 +1,12 @@
+export default function Loading() {
+  return (
+    <div className="min-h-screen flex flex-col gap-6 p-8 max-w-4xl mx-auto animate-pulse">
+      <div className="h-8 w-48 bg-gray-800 rounded" />
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
+        {Array.from({ length: 6 }).map((_, i) => (
+          <div key={i} className="bg-gray-800 rounded-xl h-52" />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/interface/src/app/not-found.tsx
+++ b/apps/interface/src/app/not-found.tsx
@@ -1,0 +1,16 @@
+import Link from "next/link";
+
+export default function NotFound() {
+  return (
+    <div className="min-h-screen flex flex-col items-center justify-center gap-4 text-center px-4">
+      <h1 className="text-6xl font-bold text-white">404</h1>
+      <p className="text-gray-400 text-lg">This page doesn&apos;t exist.</p>
+      <Link
+        href="/"
+        className="mt-2 px-6 py-2 bg-indigo-600 hover:bg-indigo-500 text-white rounded-lg transition-colors"
+      >
+        Go Home
+      </Link>
+    </div>
+  );
+}


### PR DESCRIPTION
Title: feat: add 404, error boundary, and loading skeleton pages

Description:

Improves UX for broken routes and failed data fetches by adding three Next.js special files:

- not-found.tsx — custom 404 page with a "Go Home" button
- error.tsx — global error boundary that displays the error message and a "Try Again" button to trigger reset()
- loading.tsx — global loading skeleton with an animated pulse matching the campaigns grid layout

No dependencies added. All styles use existing Tailwind classes consistent with the app's dark theme.
closes #30