### PR TITLE
feat: replace image URL input with Pinata IPFS upload flow

### DIFF
--- a/apps/interface/.env.example
+++ b/apps/interface/.env.example
@@ -1,0 +1,3 @@
+# Pinata IPFS — get keys at https://app.pinata.cloud/keys
+NEXT_PUBLIC_PINATA_API_KEY=your_pinata_api_key
+NEXT_PUBLIC_PINATA_SECRET_API_KEY=your_pinata_secret_api_key

--- a/apps/interface/src/app/create/page.tsx
+++ b/apps/interface/src/app/create/page.tsx
@@ -6,6 +6,7 @@ import { Navbar } from "@/components/layout/Navbar";
 import { useWallet } from "@/context/WalletContext";
 import { buildInitializeTx, submitSignedTx } from "@/lib/soroban";
 import { Loader2, CheckCircle2, XCircle } from "lucide-react";
+import { uploadToPinata } from "@/lib/pinata";
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 
@@ -95,24 +96,54 @@ function Step1({ data, set }: { data: FormData; set: (k: keyof FormData, v: stri
   );
 }
 
+const MAX_SIZE = 5 * 1024 * 1024; // 5 MB
+const ACCEPTED = ["image/png", "image/jpeg", "image/webp"];
+
 function Step2({ data, set }: { data: FormData; set: (k: keyof FormData, v: string) => void }) {
+  const [preview, setPreview] = React.useState<string | null>(null);
+  const [uploading, setUploading] = React.useState(false);
+  const [uploadError, setUploadError] = React.useState<string | null>(null);
+
+  const handleFile = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    if (!ACCEPTED.includes(file.type)) { setUploadError("Only PNG, JPG, or WebP allowed."); return; }
+    if (file.size > MAX_SIZE) { setUploadError("File must be under 5 MB."); return; }
+
+    setUploadError(null);
+    setPreview(URL.createObjectURL(file));
+    setUploading(true);
+    try {
+      const cid = await uploadToPinata(file);
+      set("imageUrl", cid);
+    } catch (err) {
+      setUploadError(err instanceof Error ? err.message : "Upload failed.");
+    } finally {
+      setUploading(false);
+    }
+  };
+
   return (
     <div className="space-y-4">
-      <Field label="Image URL or IPFS URI">
-        <input className={inputCls} placeholder="https:// or ipfs://" value={data.imageUrl} onChange={(e) => set("imageUrl", e.target.value)} />
+      <Field label="Campaign Image (PNG / JPG / WebP, max 5 MB)">
+        <label className="flex flex-col items-center justify-center w-full h-32 border-2 border-dashed border-gray-700 rounded-xl cursor-pointer hover:border-indigo-500 transition">
+          <span className="text-sm text-gray-400">
+            {uploading ? "Uploading…" : "Click to select a file"}
+          </span>
+          <input type="file" accept={ACCEPTED.join(",")} className="hidden" onChange={handleFile} disabled={uploading} />
+        </label>
       </Field>
-      {data.imageUrl && (
+
+      {uploadError && <p className="text-red-400 text-sm">{uploadError}</p>}
+
+      {preview && (
         // eslint-disable-next-line @next/next/no-img-element
-        <img
-          src={data.imageUrl}
-          alt="preview"
-          className="w-full h-48 object-cover rounded-xl border border-gray-700"
-          onError={(e) => (e.currentTarget.style.display = "none")}
-        />
+        <img src={preview} alt="preview" className="w-full h-48 object-cover rounded-xl border border-gray-700" />
       )}
-      <p className="text-xs text-gray-500">
-        Image is stored off-chain. Paste a public URL or an IPFS gateway link.
-      </p>
+
+      {data.imageUrl && !uploading && (
+        <p className="text-xs text-gray-500 break-all">Stored as: {data.imageUrl}</p>
+      )}
     </div>
   );
 }

--- a/apps/interface/src/lib/pinata.ts
+++ b/apps/interface/src/lib/pinata.ts
@@ -1,0 +1,18 @@
+export async function uploadToPinata(file: File): Promise<string> {
+  const key = process.env.NEXT_PUBLIC_PINATA_API_KEY;
+  const secret = process.env.NEXT_PUBLIC_PINATA_SECRET_API_KEY;
+  if (!key || !secret) throw new Error("Pinata API keys not configured.");
+
+  const body = new FormData();
+  body.append("file", file);
+
+  const res = await fetch("https://api.pinata.cloud/pinning/pinFileToIPFS", {
+    method: "POST",
+    headers: { pinata_api_key: key, pinata_secret_api_key: secret },
+    body,
+  });
+
+  if (!res.ok) throw new Error(`Pinata upload failed: ${res.statusText}`);
+  const { IpfsHash } = await res.json();
+  return `ipfs://${IpfsHash}`;
+}


### PR DESCRIPTION
Title: feat: replace image URL input with Pinata IPFS upload flow

Closes: #25

Description:

Replaces the plain image URL text input in the campaign creation form (Step 2 — Media) with a full IPFS upload flow 
via Pinata.

Changes:
- src/lib/pinata.ts — upload helper that POSTs to Pinata's /pinning/pinFileToIPFS REST endpoint and returns an ipfs://
CID
- src/app/create/page.tsx — Step 2 now accepts a file input (PNG/JPG/WebP, max 5 MB), shows an instant local preview, 
uploads to Pinata on select, and stores the returned ipfs:// CID as the campaign image
- apps/interface/.env.example — documents the two required env vars

Setup:
Copy .env.example to .env.local and fill in your Pinata keys from https://app.pinata.cloud/keys:
NEXT_PUBLIC_PINATA_API_KEY=
NEXT_PUBLIC_PINATA_SECRET_API_KEY=

closes #31