### PR TITLE
feat: add on-chain campaign registry and auto-registration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -973,6 +973,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "registry"
+version = "0.1.0"
+dependencies = [
+ "soroban-sdk",
+]
+
+[[package]]
 name = "rfc6979"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/README.md
+++ b/README.md
@@ -31,6 +31,10 @@ Fund-My-Cause/
 │       ├── src/
 │       │   └── lib.rs      # Core contract logic
 │       └── Cargo.toml
+│   └── registry/           # Soroban registry contract for campaign discovery
+│       ├── src/
+│       │   └── lib.rs      # register/list campaign contract IDs
+│       └── Cargo.toml
 ├── scripts/
 │   └── deploy.sh           # Automated deploy + initialize script
 ├── .github/
@@ -47,22 +51,22 @@ Fund-My-Cause/
 
 The Soroban contract lives in `contracts/crowdfund/src/lib.rs` and exposes the following interface:
 
-| Function | Description |
-|---|---|
-| `initialize(creator, token, goal, deadline, min_contribution, title, description, social_links, platform_config)` | Create a new campaign |
-| `contribute(contributor, amount)` | Pledge tokens before the deadline |
-| `update_metadata(title, description, social_links)` | Update campaign metadata if status is Active |
-| `withdraw()` | Creator claims funds after a successful campaign |
-| `refund_single(contributor)` | Contributor claims their own refund if goal not met |
-| `get_stats()` | Returns `CampaignStats` (total raised, progress bps, contributor count, etc.) |
-| `total_raised()` | Current total raised |
-| `goal()` | Campaign funding goal |
-| `deadline()` | Campaign deadline (ledger timestamp) |
-| `contribution(contributor)` | Contribution amount for a specific address |
-| `min_contribution()` | Minimum allowed contribution |
-| `title()` / `description()` | Campaign metadata |
-| `social_links()` | Campaign social URLs |
-| `version()` | Contract version number |
+| Function                                                                                                          | Description                                                                   |
+| ----------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------- |
+| `initialize(creator, token, goal, deadline, min_contribution, title, description, social_links, platform_config)` | Create a new campaign                                                         |
+| `contribute(contributor, amount)`                                                                                 | Pledge tokens before the deadline                                             |
+| `update_metadata(title, description, social_links)`                                                               | Update campaign metadata if status is Active                                  |
+| `withdraw()`                                                                                                      | Creator claims funds after a successful campaign                              |
+| `refund_single(contributor)`                                                                                      | Contributor claims their own refund if goal not met                           |
+| `get_stats()`                                                                                                     | Returns `CampaignStats` (total raised, progress bps, contributor count, etc.) |
+| `total_raised()`                                                                                                  | Current total raised                                                          |
+| `goal()`                                                                                                          | Campaign funding goal                                                         |
+| `deadline()`                                                                                                      | Campaign deadline (ledger timestamp)                                          |
+| `contribution(contributor)`                                                                                       | Contribution amount for a specific address                                    |
+| `min_contribution()`                                                                                              | Minimum allowed contribution                                                  |
+| `title()` / `description()`                                                                                       | Campaign metadata                                                             |
+| `social_links()`                                                                                                  | Campaign social URLs                                                          |
+| `version()`                                                                                                       | Contract version number                                                       |
 
 ### Pull-based Refund Model
 
@@ -79,6 +83,7 @@ An optional `PlatformConfig` can be set at initialization with a fee in basis po
 The interface is a Next.js 16 app using the App Router, Tailwind CSS v4, and Freighter wallet integration.
 
 Key components:
+
 - `Navbar` — wallet connect/disconnect via Freighter
 - `ProgressBar` — visual funding progress
 - `CountdownTimer` — live countdown to campaign deadline
@@ -93,11 +98,13 @@ The app uses `@stellar/freighter-api` for wallet connectivity. The `WalletContex
 ## Prerequisites
 
 **Contracts:**
+
 - [Rust](https://rustup.rs/) (stable)
 - `wasm32-unknown-unknown` target: `rustup target add wasm32-unknown-unknown`
 - [Stellar CLI](https://developers.stellar.org/docs/tools/developer-tools/cli/stellar-cli)
 
 **Frontend:**
+
 - Node.js 18+
 - [Freighter browser extension](https://www.freighter.app/)
 
@@ -126,10 +133,13 @@ cargo test --workspace
 
 ```bash
 DEADLINE=$(date -d "+30 days" +%s)
-./scripts/deploy.sh <CREATOR_ADDRESS> <TOKEN_ADDRESS> 1000 $DEADLINE 10 "My Campaign" "A great cause" null
+./scripts/deploy.sh <CREATOR_ADDRESS> <TOKEN_ADDRESS> 1000 $DEADLINE 10 "My Campaign" "A great cause" null [REGISTRY_CONTRACT_ID]
 ```
 
-Save the printed `Contract ID` — you'll need it in the frontend config.
+If `REGISTRY_CONTRACT_ID` is omitted, the script deploys a new registry contract.
+After campaign initialization, the script calls `registry.register(campaign_id)` automatically.
+
+Save the printed `Contract ID` and `Registry ID` — you'll need them in frontend config.
 
 ### 4. Run the frontend
 
@@ -146,6 +156,7 @@ Open [http://localhost:3000](http://localhost:3000).
 ## CI/CD
 
 GitHub Actions runs on every push/PR to `main`:
+
 - Builds the WASM binary
 - Runs all Rust unit tests
 

--- a/contracts/registry/Cargo.toml
+++ b/contracts/registry/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "registry"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+doctest = false
+
+[dependencies]
+soroban-sdk = { workspace = true }
+
+[dev-dependencies]
+soroban-sdk = { workspace = true, features = ["testutils"] }

--- a/contracts/registry/src/lib.rs
+++ b/contracts/registry/src/lib.rs
@@ -1,0 +1,94 @@
+#![no_std]
+#![allow(missing_docs)]
+
+use soroban_sdk::{contract, contractimpl, symbol_short, Address, Env, Symbol, Vec};
+
+const KEY_CAMPAIGNS: Symbol = symbol_short!("CMPLIST");
+
+#[contract]
+pub struct RegistryContract;
+
+#[contractimpl]
+impl RegistryContract {
+    /// Register a campaign contract ID if it is not already present.
+    pub fn register(env: Env, campaign_id: Address) {
+        let mut campaigns: Vec<Address> = env
+            .storage()
+            .instance()
+            .get(&KEY_CAMPAIGNS)
+            .unwrap_or_else(|| Vec::new(&env));
+
+        if !campaigns.contains(&campaign_id) {
+            campaigns.push_back(campaign_id.clone());
+            env.storage().instance().set(&KEY_CAMPAIGNS, &campaigns);
+            env.events().publish(("registry", "registered"), campaign_id);
+        }
+    }
+
+    /// Return a paginated slice of registered campaign IDs.
+    pub fn list(env: Env, offset: u32, limit: u32) -> Vec<Address> {
+        if limit == 0 {
+            return Vec::new(&env);
+        }
+
+        let campaigns: Vec<Address> = env
+            .storage()
+            .instance()
+            .get(&KEY_CAMPAIGNS)
+            .unwrap_or_else(|| Vec::new(&env));
+
+        let total = campaigns.len();
+        if offset >= total {
+            return Vec::new(&env);
+        }
+
+        let end = offset.saturating_add(limit).min(total);
+        let mut out = Vec::new(&env);
+
+        let mut i = offset;
+        while i < end {
+            if let Some(addr) = campaigns.get(i) {
+                out.push_back(addr);
+            }
+            i += 1;
+        }
+
+        out
+    }
+}
+
+#[cfg(test)]
+#[allow(deprecated)]
+mod tests {
+    use super::*;
+    use soroban_sdk::{testutils::Address as _, Address};
+
+    #[test]
+    fn register_deduplicates_and_lists_with_pagination() {
+        let env = Env::default();
+
+        let registry_id = env.register_contract(None, RegistryContract);
+        let client = RegistryContractClient::new(&env, &registry_id);
+
+        let a = Address::generate(&env);
+        let b = Address::generate(&env);
+        let c = Address::generate(&env);
+
+        client.register(&a);
+        client.register(&b);
+        client.register(&a);
+        client.register(&c);
+
+        let first_two = client.list(&0, &2);
+        assert_eq!(first_two.len(), 2);
+        assert_eq!(first_two.get(0), Some(a.clone()));
+        assert_eq!(first_two.get(1), Some(b.clone()));
+
+        let next_two = client.list(&2, &2);
+        assert_eq!(next_two.len(), 1);
+        assert_eq!(next_two.get(0), Some(c));
+
+        let empty = client.list(&99, &10);
+        assert_eq!(empty.len(), 0);
+    }
+}

--- a/contracts/registry/test_snapshots/tests/register_deduplicates_and_lists_with_pagination.1.json
+++ b/contracts/registry/test_snapshots/tests/register_deduplicates_and_lists_with_pagination.1.json
@@ -1,0 +1,101 @@
+{
+  "generators": {
+    "address": 4,
+    "nonce": 0
+  },
+  "auth": [
+    [],
+    [],
+    [],
+    [],
+    [],
+    [],
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 22,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": [
+                      {
+                        "key": {
+                          "symbol": "CMPLIST"
+                        },
+                        "val": {
+                          "vec": [
+                            {
+                              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                            },
+                            {
+                              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                            },
+                            {
+                              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                            }
+                          ]
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": []
+}

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Deploy Fund-My-Cause crowdfund contract to Stellar testnet
-# Usage: ./scripts/deploy.sh <creator> <token> <goal> <deadline> <min_contribution> <title> <description> <social_links>
+# Usage: ./scripts/deploy.sh <creator> <token> <goal> <deadline> <min_contribution> <title> <description> <social_links> [registry_contract_id]
 
 set -e
 
@@ -12,9 +12,22 @@ MIN_CONTRIBUTION=${5:-1}
 TITLE=${6:-"Default Title"}
 DESCRIPTION=${7:-"Default Description"}
 SOCIAL_LINKS=${8:-"null"}
+REGISTRY_ID=${9:-${REGISTRY_ID:-}}
 
-echo "Building WASM..."
+echo "Building WASM artifacts..."
 cargo build --release --target wasm32-unknown-unknown --manifest-path contracts/crowdfund/Cargo.toml
+cargo build --release --target wasm32-unknown-unknown --manifest-path contracts/registry/Cargo.toml
+
+if [ -z "$REGISTRY_ID" ]; then
+  echo "No registry ID provided. Deploying registry contract..."
+  REGISTRY_ID=$(stellar contract deploy \
+    --wasm target/wasm32-unknown-unknown/release/registry.wasm \
+    --network testnet \
+    --source "$CREATOR")
+  echo "Registry deployed: $REGISTRY_ID"
+else
+  echo "Using existing registry: $REGISTRY_ID"
+fi
 
 echo "Deploying contract to testnet..."
 CONTRACT_ID=$(stellar contract deploy \
@@ -40,6 +53,15 @@ stellar contract invoke \
   --social_links "$SOCIAL_LINKS" \
   --platform_config null
 
+echo "Registering campaign in registry..."
+stellar contract invoke \
+  --id "$REGISTRY_ID" \
+  --network testnet \
+  --source "$CREATOR" \
+  -- register \
+  --campaign_id "$CONTRACT_ID"
+
 echo "Campaign initialized successfully."
 echo "Contract ID: $CONTRACT_ID"
-echo "Save this Contract ID for interacting with the campaign."
+echo "Registry ID: $REGISTRY_ID"
+echo "Save these IDs for frontend discovery and interaction."


### PR DESCRIPTION
## Summary
- add a new Soroban registry contract under contracts/registry
- implement register(campaign_id) with deduplication
- implement paginated list(offset, limit) for campaign discovery
- update deploy script to deploy/reuse registry and auto-register each new campaign
- update README deploy instructions for registry usage

## Validation
- cargo test -p registry
- bash -n scripts/deploy.sh
closes #58