### PR TITLE
ci: add frontend lint and type-check workflow (#113)

### DIFF
--- a/.github/workflows/frontend_ci.yml
+++ b/.github/workflows/frontend_ci.yml
@@ -1,0 +1,40 @@
+name: Frontend CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  frontend:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Use Node.js 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Cache node_modules
+        id: cache-node-modules
+        uses: actions/cache@v4
+        with:
+          path: |
+            node_modules
+            apps/interface/node_modules
+          key: ${{ runner.os }}-node20-modules-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node20-modules-
+
+      - name: Install dependencies (root)
+        run: npm ci
+
+      - name: Lint (root)
+        run: npm run lint
+
+      - name: Typecheck (apps/interface)
+        working-directory: apps/interface
+        run: npx tsc --noEmit


### PR DESCRIPTION
Closes #113

This PR adds a dedicated frontend GitHub Actions workflow.

What it does:
- runs on push and pull_request
- uses Node.js 20
- installs dependencies with npm ci
- runs frontend linting with npm run lint
- runs TypeScript type-checking with npx tsc --noEmit in apps/interface
- caches node_modules with actions/cache

This ensures pull requests fail automatically if frontend linting or type-checking fails.