### PR TITLE
Add campaign preview mode before deployment

### DIFF
--- a/apps/interface/src/app/create/page.tsx
+++ b/apps/interface/src/app/create/page.tsx
@@ -6,7 +6,7 @@ import { Navbar } from "@/components/layout/Navbar";
 import { WalletGuard } from "@/components/WalletGuard";
 import { useWallet } from "@/context/WalletContext";
 import { buildInitializeTx, submitSignedTx } from "@/lib/soroban";
-import { Loader2, CheckCircle2, XCircle } from "lucide-react";
+import { Loader2, CheckCircle2, XCircle, FileText, X } from "lucide-react";
 import { uploadToPinata } from "@/lib/pinata";
 import {
   validateTitle,
@@ -18,6 +18,8 @@ import {
   sanitizeTitle,
   sanitizeDescription,
 } from "@/lib/validation";
+import { useCampaignDraft } from "@/hooks/useCampaignDraft";
+import { DraftIndicator } from "@/components/ui/DraftIndicator";
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 
@@ -88,42 +90,95 @@ function FieldWithError({ label, error, children }: FieldWithErrorProps) {
     <div>
       <label className={labelCls}>{label}</label>
       {children}
-      {error && <p className="text-red-500 dark:text-red-400 text-xs mt-1">{error}</p>}
+      {error && (
+        <p className="text-red-500 dark:text-red-400 text-xs mt-1">{error}</p>
+      )}
     </div>
   );
 }
 
-function Step1({ data, set }: { data: FormData; set: (k: keyof FormData, v: string) => void }) {
+function Step1({
+  data,
+  set,
+}: {
+  data: FormData;
+  set: (k: keyof FormData, v: string) => void;
+}) {
   const titleError = data.title ? validateTitle(data.title) : null;
-  const descError = data.description ? validateDescription(data.description) : null;
+  const descError = data.description
+    ? validateDescription(data.description)
+    : null;
   const goalError = data.goal ? validateGoal(data.goal) : null;
   const deadlineError = data.deadline ? validateDeadline(data.deadline) : null;
-  const minContribError = data.minContribution ? validateMinContribution(data.minContribution, data.goal) : null;
+  const minContribError = data.minContribution
+    ? validateMinContribution(data.minContribution, data.goal)
+    : null;
 
   return (
     <div className="space-y-4">
       <Field label="Contract ID">
-        <input className={inputCls} placeholder="C..." value={data.contractId} onChange={(e) => set("contractId", e.target.value)} />
+        <input
+          className={inputCls}
+          placeholder="C..."
+          value={data.contractId}
+          onChange={(e) => set("contractId", e.target.value)}
+        />
       </Field>
       <Field label="Token Address">
-        <input className={inputCls} placeholder="C..." value={data.token} onChange={(e) => set("token", e.target.value)} />
+        <input
+          className={inputCls}
+          placeholder="C..."
+          value={data.token}
+          onChange={(e) => set("token", e.target.value)}
+        />
       </Field>
       <FieldWithError label="Title" error={titleError}>
-        <input className={inputCls} placeholder="My Campaign" value={data.title} onChange={(e) => set("title", e.target.value)} />
+        <input
+          className={inputCls}
+          placeholder="My Campaign"
+          value={data.title}
+          onChange={(e) => set("title", e.target.value)}
+        />
       </FieldWithError>
       <FieldWithError label="Description" error={descError}>
-        <textarea rows={3} className={inputCls} placeholder="What are you raising funds for?" value={data.description} onChange={(e) => set("description", e.target.value)} />
+        <textarea
+          rows={3}
+          className={inputCls}
+          placeholder="What are you raising funds for?"
+          value={data.description}
+          onChange={(e) => set("description", e.target.value)}
+        />
       </FieldWithError>
       <div className="grid grid-cols-2 gap-4">
         <FieldWithError label="Goal (XLM)" error={goalError}>
-          <input type="number" min="1" className={inputCls} placeholder="10000" value={data.goal} onChange={(e) => set("goal", e.target.value)} />
+          <input
+            type="number"
+            min="1"
+            className={inputCls}
+            placeholder="10000"
+            value={data.goal}
+            onChange={(e) => set("goal", e.target.value)}
+          />
         </FieldWithError>
         <FieldWithError label="Min Contribution (XLM)" error={minContribError}>
-          <input type="number" min="1" className={inputCls} placeholder="1" value={data.minContribution} onChange={(e) => set("minContribution", e.target.value)} />
+          <input
+            type="number"
+            min="1"
+            className={inputCls}
+            placeholder="1"
+            value={data.minContribution}
+            onChange={(e) => set("minContribution", e.target.value)}
+          />
         </FieldWithError>
       </div>
       <FieldWithError label="Deadline" error={deadlineError}>
-        <input type="date" className={inputCls} value={data.deadline} min={new Date().toISOString().split("T")[0]} onChange={(e) => set("deadline", e.target.value)} />
+        <input
+          type="date"
+          className={inputCls}
+          value={data.deadline}
+          min={new Date().toISOString().split("T")[0]}
+          onChange={(e) => set("deadline", e.target.value)}
+        />
       </FieldWithError>
     </div>
   );
@@ -132,7 +187,13 @@ function Step1({ data, set }: { data: FormData; set: (k: keyof FormData, v: stri
 const MAX_SIZE = 5 * 1024 * 1024; // 5 MB
 const ACCEPTED = ["image/png", "image/jpeg", "image/webp"];
 
-function Step2({ data, set }: { data: FormData; set: (k: keyof FormData, v: string) => void }) {
+function Step2({
+  data,
+  set,
+}: {
+  data: FormData;
+  set: (k: keyof FormData, v: string) => void;
+}) {
   const [preview, setPreview] = React.useState<string | null>(null);
   const [uploading, setUploading] = React.useState(false);
   const [uploadError, setUploadError] = React.useState<string | null>(null);
@@ -140,8 +201,14 @@ function Step2({ data, set }: { data: FormData; set: (k: keyof FormData, v: stri
   const handleFile = async (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
     if (!file) return;
-    if (!ACCEPTED.includes(file.type)) { setUploadError("Only PNG, JPG, or WebP allowed."); return; }
-    if (file.size > MAX_SIZE) { setUploadError("File must be under 5 MB."); return; }
+    if (!ACCEPTED.includes(file.type)) {
+      setUploadError("Only PNG, JPG, or WebP allowed.");
+      return;
+    }
+    if (file.size > MAX_SIZE) {
+      setUploadError("File must be under 5 MB.");
+      return;
+    }
 
     setUploadError(null);
     setPreview(URL.createObjectURL(file));
@@ -163,7 +230,13 @@ function Step2({ data, set }: { data: FormData; set: (k: keyof FormData, v: stri
           <span className="text-sm text-gray-400">
             {uploading ? "Uploading…" : "Click to select a file"}
           </span>
-          <input type="file" accept={ACCEPTED.join(",")} className="hidden" onChange={handleFile} disabled={uploading} />
+          <input
+            type="file"
+            accept={ACCEPTED.join(",")}
+            className="hidden"
+            onChange={handleFile}
+            disabled={uploading}
+          />
         </label>
       </Field>
 
@@ -171,17 +244,29 @@ function Step2({ data, set }: { data: FormData; set: (k: keyof FormData, v: stri
 
       {preview && (
         // eslint-disable-next-line @next/next/no-img-element
-        <img src={preview} alt="preview" className="w-full h-48 object-cover rounded-xl border border-gray-700" />
+        <img
+          src={preview}
+          alt="preview"
+          className="w-full h-48 object-cover rounded-xl border border-gray-700"
+        />
       )}
 
       {data.imageUrl && !uploading && (
-        <p className="text-xs text-gray-500 break-all">Stored as: {data.imageUrl}</p>
+        <p className="text-xs text-gray-500 break-all">
+          Stored as: {data.imageUrl}
+        </p>
       )}
     </div>
   );
 }
 
-function Step3({ data, set }: { data: FormData; set: (k: keyof FormData, v: string) => void }) {
+function Step3({
+  data,
+  set,
+}: {
+  data: FormData;
+  set: (k: keyof FormData, v: string) => void;
+}) {
   const feeError = data.feeBps ? validateFeeBps(data.feeBps) : null;
 
   return (
@@ -190,10 +275,26 @@ function Step3({ data, set }: { data: FormData; set: (k: keyof FormData, v: stri
         Optional. Leave blank to skip the platform fee.
       </p>
       <Field label="Platform Fee Address">
-        <input className={inputCls} placeholder="G... or C..." value={data.feeAddress} onChange={(e) => set("feeAddress", e.target.value)} />
+        <input
+          className={inputCls}
+          placeholder="G... or C..."
+          value={data.feeAddress}
+          onChange={(e) => set("feeAddress", e.target.value)}
+        />
       </Field>
-      <FieldWithError label="Fee (basis points, e.g. 250 = 2.5%)" error={feeError}>
-        <input type="number" min="0" max="10000" className={inputCls} placeholder="0" value={data.feeBps} onChange={(e) => set("feeBps", e.target.value)} />
+      <FieldWithError
+        label="Fee (basis points, e.g. 250 = 2.5%)"
+        error={feeError}
+      >
+        <input
+          type="number"
+          min="0"
+          max="10000"
+          className={inputCls}
+          placeholder="0"
+          value={data.feeBps}
+          onChange={(e) => set("feeBps", e.target.value)}
+        />
       </FieldWithError>
     </div>
   );
@@ -203,13 +304,17 @@ function ReviewRow({ label, value }: { label: string; value: string }) {
   return (
     <div className="flex justify-between text-sm py-1 border-b border-gray-800">
       <span className="text-gray-400">{label}</span>
-      <span className="text-white max-w-xs truncate text-right">{value || "—"}</span>
+      <span className="text-white max-w-xs truncate text-right">
+        {value || "—"}
+      </span>
     </div>
   );
 }
 
 function Step4({ data }: { data: FormData }) {
-  const deadlineTs = data.deadline ? new Date(data.deadline).toLocaleDateString() : "—";
+  const deadlineTs = data.deadline
+    ? new Date(data.deadline).toLocaleDateString()
+    : "—";
   return (
     <div className="space-y-1">
       <ReviewRow label="Contract ID" value={data.contractId} />
@@ -217,7 +322,10 @@ function Step4({ data }: { data: FormData }) {
       <ReviewRow label="Title" value={data.title} />
       <ReviewRow label="Description" value={data.description} />
       <ReviewRow label="Goal" value={data.goal ? `${data.goal} XLM` : ""} />
-      <ReviewRow label="Min Contribution" value={data.minContribution ? `${data.minContribution} XLM` : ""} />
+      <ReviewRow
+        label="Min Contribution"
+        value={data.minContribution ? `${data.minContribution} XLM` : ""}
+      />
       <ReviewRow label="Deadline" value={deadlineTs} />
       <ReviewRow label="Image" value={data.imageUrl} />
       <ReviewRow label="Fee Address" value={data.feeAddress} />
@@ -232,25 +340,29 @@ function validateStep(step: number, data: FormData): string | null {
   if (step === 0) {
     if (!data.contractId.trim()) return "Contract ID is required.";
     if (!data.token.trim()) return "Token address is required.";
-    
+
     const titleErr = validateTitle(data.title);
     if (titleErr) return titleErr;
-    
+
     const descErr = validateDescription(data.description);
     if (descErr) return descErr;
-    
+
     const goalErr = validateGoal(data.goal);
     if (goalErr) return goalErr;
-    
+
     const deadlineErr = validateDeadline(data.deadline);
     if (deadlineErr) return deadlineErr;
-    
-    const minContribErr = validateMinContribution(data.minContribution, data.goal);
+
+    const minContribErr = validateMinContribution(
+      data.minContribution,
+      data.goal,
+    );
     if (minContribErr) return minContribErr;
   }
   if (step === 2) {
-    if (data.feeAddress && !data.feeBps) return "Provide fee bps when a fee address is set.";
-    
+    if (data.feeAddress && !data.feeBps)
+      return "Provide fee bps when a fee address is set.";
+
     const feeErr = validateFeeBps(data.feeBps);
     if (feeErr) return feeErr;
   }
@@ -269,30 +381,64 @@ export default function CreateCampaignPage() {
   const [txStatus, setTxStatus] = useState<TxStatus>("idle");
   const [txHash, setTxHash] = useState<string | null>(null);
   const [txError, setTxError] = useState<string | null>(null);
+  const [showResumeBanner, setShowResumeBanner] = useState(true);
+
+  const { hasDraft, loadDraft, saveDraft, clearDraft, saveStatus, lastSaved } =
+    useCampaignDraft({ ...data, step });
 
   const set = (k: keyof FormData, v: string) => {
     setData((prev) => ({ ...prev, [k]: v }));
     setValidationError(null);
   };
 
+  const handleResumeDraft = () => {
+    const draft = loadDraft();
+    if (!draft) return;
+    const { step: savedStep, ...formFields } = draft;
+    setData(formFields as FormData);
+    setStep(savedStep);
+    setShowResumeBanner(false);
+  };
+
+  const handleDismissDraft = () => {
+    clearDraft();
+    setShowResumeBanner(false);
+  };
+
+  const handleManualSave = () => {
+    saveDraft({ ...data, step });
+  };
+
   const next = () => {
     const err = validateStep(step, data);
-    if (err) { setValidationError(err); return; }
+    if (err) {
+      setValidationError(err);
+      return;
+    }
     setValidationError(null);
     setStep((s) => s + 1);
   };
 
-  const back = () => { setValidationError(null); setStep((s) => s - 1); };
+  const back = () => {
+    setValidationError(null);
+    setStep((s) => s - 1);
+  };
 
   const deploy = async () => {
     const err = validateStep(step, data);
-    if (err) { setValidationError(err); return; }
+    if (err) {
+      setValidationError(err);
+      return;
+    }
 
     setTxStatus("pending");
     setTxError(null);
     try {
-      const deadlineTs = BigInt(Math.floor(new Date(data.deadline).getTime() / 1000));
-      const xlmToStroops = (xlm: string) => BigInt(Math.round(Number(xlm) * 10_000_000));
+      const deadlineTs = BigInt(
+        Math.floor(new Date(data.deadline).getTime() / 1000),
+      );
+      const xlmToStroops = (xlm: string) =>
+        BigInt(Math.round(Number(xlm) * 10_000_000));
 
       const xdr = await buildInitializeTx({
         contractId: data.contractId,
@@ -314,9 +460,15 @@ export default function CreateCampaignPage() {
       try {
         const raw = localStorage.getItem("fmc:campaigns");
         const map: Record<string, string[]> = raw ? JSON.parse(raw) : {};
-        map[address!] = [...new Set([...(map[address!] ?? []), data.contractId])];
+        map[address!] = [
+          ...new Set([...(map[address!] ?? []), data.contractId]),
+        ];
         localStorage.setItem("fmc:campaigns", JSON.stringify(map));
-      } catch { /* non-critical */ }
+      } catch {
+        /* non-critical */
+      }
+      // Clear draft after successful deployment
+      clearDraft();
       setTxHash(hash);
       setTxStatus("success");
     } catch (e) {
@@ -333,16 +485,50 @@ export default function CreateCampaignPage() {
       <WalletGuard message="Connect your wallet to create a campaign.">
         {txStatus === "success" ? (
           <div className="flex flex-col items-center justify-center min-h-[70vh] gap-4 text-center px-6">
-            <CheckCircle2 size={48} className="text-green-500 dark:text-green-400" />
+            <CheckCircle2
+              size={48}
+              className="text-green-500 dark:text-green-400"
+            />
             <h2 className="text-2xl font-bold">Campaign Deployed!</h2>
-            <p className="text-gray-600 dark:text-gray-400 text-sm break-all">Tx: {txHash}</p>
-            <button onClick={() => router.push("/")} className="mt-2 bg-indigo-600 hover:bg-indigo-500 px-6 py-2 rounded-xl transition text-white">
+            <p className="text-gray-600 dark:text-gray-400 text-sm break-all">
+              Tx: {txHash}
+            </p>
+            <button
+              onClick={() => router.push("/")}
+              className="mt-2 bg-indigo-600 hover:bg-indigo-500 px-6 py-2 rounded-xl transition text-white"
+            >
               Back to Home
             </button>
           </div>
         ) : (
           <div className="max-w-xl mx-auto px-6 py-12">
-            <h1 className="text-3xl font-bold mb-8">Create Campaign</h1>
+            <h1 className="text-3xl font-bold mb-4">Create Campaign</h1>
+
+            {/* Resume Draft Banner */}
+            {hasDraft && showResumeBanner && (
+              <div className="flex items-center gap-3 mb-6 px-4 py-3 rounded-xl bg-indigo-50 dark:bg-indigo-950/40 border border-indigo-200 dark:border-indigo-800">
+                <FileText
+                  size={16}
+                  className="text-indigo-500 dark:text-indigo-400 shrink-0"
+                />
+                <p className="flex-1 text-sm text-indigo-700 dark:text-indigo-300">
+                  You have an unsaved draft. Want to pick up where you left off?
+                </p>
+                <button
+                  onClick={handleResumeDraft}
+                  className="text-sm font-medium text-indigo-600 dark:text-indigo-400 hover:text-indigo-800 dark:hover:text-indigo-200 transition whitespace-nowrap"
+                >
+                  Resume Draft
+                </button>
+                <button
+                  onClick={handleDismissDraft}
+                  aria-label="Dismiss draft"
+                  className="text-gray-400 hover:text-gray-600 dark:hover:text-gray-200 transition"
+                >
+                  <X size={16} />
+                </button>
+              </div>
+            )}
 
             {/* Step indicator */}
             <div className="flex items-center gap-2 mb-8">
@@ -354,16 +540,20 @@ export default function CreateCampaignPage() {
                         i < step
                           ? "bg-indigo-600 text-white"
                           : i === step
-                          ? "bg-indigo-500 text-white ring-2 ring-indigo-300"
-                          : "bg-gray-200 dark:bg-gray-800 text-gray-600 dark:text-gray-500"
+                            ? "bg-indigo-500 text-white ring-2 ring-indigo-300"
+                            : "bg-gray-200 dark:bg-gray-800 text-gray-600 dark:text-gray-500"
                       }`}
                     >
                       {i < step ? "✓" : i + 1}
                     </div>
-                    <span className="text-xs text-gray-500 hidden sm:block">{label}</span>
+                    <span className="text-xs text-gray-500 hidden sm:block">
+                      {label}
+                    </span>
                   </div>
                   {i < STEPS.length - 1 && (
-                    <div className={`flex-1 h-px ${i < step ? "bg-indigo-600" : "bg-gray-300 dark:bg-gray-700"}`} />
+                    <div
+                      className={`flex-1 h-px ${i < step ? "bg-indigo-600" : "bg-gray-300 dark:bg-gray-700"}`}
+                    />
                   )}
                 </React.Fragment>
               ))}
@@ -371,7 +561,14 @@ export default function CreateCampaignPage() {
 
             {/* Step content */}
             <div className="bg-gray-100 dark:bg-gray-900 border border-gray-200 dark:border-gray-800 rounded-2xl p-6 space-y-6">
-              <h2 className="text-lg font-semibold">{STEPS[step]}</h2>
+              <div className="flex items-center justify-between">
+                <h2 className="text-lg font-semibold">{STEPS[step]}</h2>
+                <DraftIndicator
+                  saveStatus={saveStatus}
+                  lastSaved={lastSaved}
+                  onSave={handleManualSave}
+                />
+              </div>
 
               {step === 0 && <Step1 data={data} set={set} />}
               {step === 1 && <Step2 data={data} set={set} />}
@@ -379,7 +576,9 @@ export default function CreateCampaignPage() {
               {step === 3 && <Step4 data={data} />}
 
               {validationError && (
-                <p className="text-red-500 dark:text-red-400 text-sm">{validationError}</p>
+                <p className="text-red-500 dark:text-red-400 text-sm">
+                  {validationError}
+                </p>
               )}
 
               {txStatus === "error" && txError && (
@@ -412,7 +611,9 @@ export default function CreateCampaignPage() {
                     disabled={txStatus === "pending" || networkMismatch}
                     className="flex items-center gap-2 bg-indigo-600 hover:bg-indigo-500 px-6 py-2 rounded-xl text-sm font-medium transition disabled:opacity-50 text-white"
                   >
-                    {txStatus === "pending" && <Loader2 size={16} className="animate-spin" />}
+                    {txStatus === "pending" && (
+                      <Loader2 size={16} className="animate-spin" />
+                    )}
                     {txStatus === "pending" ? "Deploying..." : "Sign & Deploy"}
                   </button>
                 )}

--- a/apps/interface/src/app/create/page.tsx
+++ b/apps/interface/src/app/create/page.tsx
@@ -6,7 +6,7 @@ import { Navbar } from "@/components/layout/Navbar";
 import { WalletGuard } from "@/components/WalletGuard";
 import { useWallet } from "@/context/WalletContext";
 import { buildInitializeTx, submitSignedTx } from "@/lib/soroban";
-import { Loader2, CheckCircle2, XCircle, FileText, X } from "lucide-react";
+import { Loader2, CheckCircle2, XCircle, FileText, X, Eye } from "lucide-react";
 import { uploadToPinata } from "@/lib/pinata";
 import {
   validateTitle,
@@ -20,6 +20,7 @@ import {
 } from "@/lib/validation";
 import { useCampaignDraft } from "@/hooks/useCampaignDraft";
 import { DraftIndicator } from "@/components/ui/DraftIndicator";
+import { CampaignPreview } from "@/components/ui/CampaignPreview";
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 
@@ -41,7 +42,16 @@ interface FormData {
 
 type TxStatus = "idle" | "pending" | "success" | "error";
 
-const STEPS = ["Basic Info", "Media", "Platform Config", "Review & Deploy"];
+const STEPS = [
+  "Basic Info",
+  "Media",
+  "Platform Config",
+  "Review & Deploy",
+  "Preview",
+];
+
+// Preview is step index 4 — rendered outside the narrow card
+const PREVIEW_STEP = 4;
 
 const INITIAL: FormData = {
   contractId: "",
@@ -369,6 +379,11 @@ function validateStep(step: number, data: FormData): string | null {
   return null;
 }
 
+/** Validate all steps before allowing preview or deploy. */
+function validateAllSteps(data: FormData): string | null {
+  return validateStep(0, data) ?? validateStep(2, data);
+}
+
 // ── Main Page ─────────────────────────────────────────────────────────────────
 
 export default function CreateCampaignPage() {
@@ -382,6 +397,7 @@ export default function CreateCampaignPage() {
   const [txHash, setTxHash] = useState<string | null>(null);
   const [txError, setTxError] = useState<string | null>(null);
   const [showResumeBanner, setShowResumeBanner] = useState(true);
+  const [showPreview, setShowPreview] = useState(false);
 
   const { hasDraft, loadDraft, saveDraft, clearDraft, saveStatus, lastSaved } =
     useCampaignDraft({ ...data, step });
@@ -416,11 +432,27 @@ export default function CreateCampaignPage() {
       return;
     }
     setValidationError(null);
+    // Step 3 (Review & Deploy) → validate everything then enter preview
+    if (step === STEPS.length - 2) {
+      const allErr = validateAllSteps(data);
+      if (allErr) {
+        setValidationError(allErr);
+        return;
+      }
+      setShowPreview(true);
+      setStep(PREVIEW_STEP);
+      return;
+    }
     setStep((s) => s + 1);
   };
 
   const back = () => {
     setValidationError(null);
+    if (showPreview) {
+      setShowPreview(false);
+      setStep(STEPS.length - 2); // back to Review & Deploy
+      return;
+    }
     setStep((s) => s - 1);
   };
 
@@ -501,11 +533,17 @@ export default function CreateCampaignPage() {
             </button>
           </div>
         ) : (
-          <div className="max-w-xl mx-auto px-6 py-12">
+          <div
+            className={
+              showPreview
+                ? "max-w-4xl mx-auto px-6 py-12"
+                : "max-w-xl mx-auto px-6 py-12"
+            }
+          >
             <h1 className="text-3xl font-bold mb-4">Create Campaign</h1>
 
             {/* Resume Draft Banner */}
-            {hasDraft && showResumeBanner && (
+            {hasDraft && showResumeBanner && !showPreview && (
               <div className="flex items-center gap-3 mb-6 px-4 py-3 rounded-xl bg-indigo-50 dark:bg-indigo-950/40 border border-indigo-200 dark:border-indigo-800">
                 <FileText
                   size={16}
@@ -544,7 +582,13 @@ export default function CreateCampaignPage() {
                             : "bg-gray-200 dark:bg-gray-800 text-gray-600 dark:text-gray-500"
                       }`}
                     >
-                      {i < step ? "✓" : i + 1}
+                      {i < step ? (
+                        "✓"
+                      ) : i === PREVIEW_STEP ? (
+                        <Eye size={14} />
+                      ) : (
+                        i + 1
+                      )}
                     </div>
                     <span className="text-xs text-gray-500 hidden sm:block">
                       {label}
@@ -559,66 +603,83 @@ export default function CreateCampaignPage() {
               ))}
             </div>
 
-            {/* Step content */}
-            <div className="bg-gray-100 dark:bg-gray-900 border border-gray-200 dark:border-gray-800 rounded-2xl p-6 space-y-6">
-              <div className="flex items-center justify-between">
-                <h2 className="text-lg font-semibold">{STEPS[step]}</h2>
-                <DraftIndicator
-                  saveStatus={saveStatus}
-                  lastSaved={lastSaved}
-                  onSave={handleManualSave}
-                />
-              </div>
-
-              {step === 0 && <Step1 data={data} set={set} />}
-              {step === 1 && <Step2 data={data} set={set} />}
-              {step === 2 && <Step3 data={data} set={set} />}
-              {step === 3 && <Step4 data={data} />}
-
-              {validationError && (
-                <p className="text-red-500 dark:text-red-400 text-sm">
-                  {validationError}
-                </p>
-              )}
-
-              {txStatus === "error" && txError && (
-                <div className="flex items-start gap-2 text-red-500 dark:text-red-400 text-sm bg-red-100 dark:bg-red-950/40 border border-red-300 dark:border-red-800 rounded-xl p-3">
-                  <XCircle size={16} className="mt-0.5 shrink-0" />
-                  {txError}
-                </div>
-              )}
-
-              {/* Navigation */}
-              <div className="flex justify-between pt-2">
-                <button
-                  onClick={back}
-                  disabled={step === 0}
-                  className="px-4 py-2 rounded-xl text-sm text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white disabled:opacity-30 transition"
-                >
-                  Back
-                </button>
-
-                {step < STEPS.length - 1 ? (
-                  <button
-                    onClick={next}
-                    className="bg-indigo-600 hover:bg-indigo-500 px-6 py-2 rounded-xl text-sm font-medium transition text-white"
-                  >
-                    Next
-                  </button>
-                ) : (
-                  <button
-                    onClick={deploy}
-                    disabled={txStatus === "pending" || networkMismatch}
-                    className="flex items-center gap-2 bg-indigo-600 hover:bg-indigo-500 px-6 py-2 rounded-xl text-sm font-medium transition disabled:opacity-50 text-white"
-                  >
-                    {txStatus === "pending" && (
-                      <Loader2 size={16} className="animate-spin" />
-                    )}
-                    {txStatus === "pending" ? "Deploying..." : "Sign & Deploy"}
-                  </button>
+            {/* Preview step — full-width, outside the narrow card */}
+            {showPreview ? (
+              <>
+                {txStatus === "error" && txError && (
+                  <div className="flex items-start gap-2 text-red-500 dark:text-red-400 text-sm bg-red-100 dark:bg-red-950/40 border border-red-300 dark:border-red-800 rounded-xl p-3 mb-4">
+                    <XCircle size={16} className="mt-0.5 shrink-0" />
+                    {txError}
+                  </div>
                 )}
+                <CampaignPreview
+                  data={{ ...data, creatorAddress: address ?? "" }}
+                  onEdit={back}
+                  onDeploy={deploy}
+                  deployDisabled={txStatus === "pending" || networkMismatch}
+                  deployPending={txStatus === "pending"}
+                />
+              </>
+            ) : (
+              /* Step content card */
+              <div className="bg-gray-100 dark:bg-gray-900 border border-gray-200 dark:border-gray-800 rounded-2xl p-6 space-y-6">
+                <div className="flex items-center justify-between">
+                  <h2 className="text-lg font-semibold">{STEPS[step]}</h2>
+                  <DraftIndicator
+                    saveStatus={saveStatus}
+                    lastSaved={lastSaved}
+                    onSave={handleManualSave}
+                  />
+                </div>
+
+                {step === 0 && <Step1 data={data} set={set} />}
+                {step === 1 && <Step2 data={data} set={set} />}
+                {step === 2 && <Step3 data={data} set={set} />}
+                {step === 3 && <Step4 data={data} />}
+
+                {validationError && (
+                  <p className="text-red-500 dark:text-red-400 text-sm">
+                    {validationError}
+                  </p>
+                )}
+
+                {txStatus === "error" && txError && (
+                  <div className="flex items-start gap-2 text-red-500 dark:text-red-400 text-sm bg-red-100 dark:bg-red-950/40 border border-red-300 dark:border-red-800 rounded-xl p-3">
+                    <XCircle size={16} className="mt-0.5 shrink-0" />
+                    {txError}
+                  </div>
+                )}
+
+                {/* Navigation */}
+                <div className="flex justify-between pt-2">
+                  <button
+                    onClick={back}
+                    disabled={step === 0}
+                    className="px-4 py-2 rounded-xl text-sm text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white disabled:opacity-30 transition"
+                  >
+                    Back
+                  </button>
+
+                  {step < STEPS.length - 2 ? (
+                    <button
+                      onClick={next}
+                      className="bg-indigo-600 hover:bg-indigo-500 px-6 py-2 rounded-xl text-sm font-medium transition text-white"
+                    >
+                      Next
+                    </button>
+                  ) : (
+                    /* Step 3 (Review & Deploy) — "Preview" button leads to preview step */
+                    <button
+                      onClick={next}
+                      className="flex items-center gap-2 bg-indigo-600 hover:bg-indigo-500 px-6 py-2 rounded-xl text-sm font-medium transition text-white"
+                    >
+                      <Eye size={15} />
+                      Preview
+                    </button>
+                  )}
+                </div>
               </div>
-            </div>
+            )}
           </div>
         )}
       </WalletGuard>

--- a/apps/interface/src/components/ui/CampaignPreview.tsx
+++ b/apps/interface/src/components/ui/CampaignPreview.tsx
@@ -1,0 +1,298 @@
+"use client";
+
+import React, { useState } from "react";
+import {
+  ArrowLeft,
+  Monitor,
+  Smartphone,
+  Eye,
+  AlertTriangle,
+  Loader2,
+} from "lucide-react";
+import { ProgressBar } from "@/components/ui/ProgressBar";
+import { CountdownTimer } from "@/components/ui/CountdownTimer";
+import { DEFAULT_HERO_IMAGE } from "@/lib/constants";
+import { formatAddress } from "@/lib/format";
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+export interface PreviewData {
+  contractId: string;
+  token: string;
+  title: string;
+  description: string;
+  goal: string;
+  deadline: string;
+  minContribution: string;
+  imageUrl: string;
+  feeAddress: string;
+  feeBps: string;
+  creatorAddress: string;
+}
+
+type ViewportMode = "desktop" | "mobile";
+
+interface CampaignPreviewProps {
+  data: PreviewData;
+  onEdit: () => void;
+  onDeploy: () => void;
+  deployDisabled?: boolean;
+  deployPending?: boolean;
+}
+
+// ── Disclaimer Banner ─────────────────────────────────────────────────────────
+
+function PreviewDisclaimer() {
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      className="flex items-start gap-3 px-4 py-3 rounded-xl
+        bg-amber-50 dark:bg-amber-950/40
+        border border-amber-200 dark:border-amber-800"
+    >
+      <AlertTriangle
+        size={16}
+        className="text-amber-500 dark:text-amber-400 shrink-0 mt-0.5"
+        aria-hidden="true"
+      />
+      <p className="text-sm text-amber-700 dark:text-amber-300">
+        <span className="font-semibold">Preview mode</span> — this is how your
+        campaign will appear to contributors. No data has been submitted to the
+        blockchain yet.
+      </p>
+    </div>
+  );
+}
+
+// ── Viewport Toggle ───────────────────────────────────────────────────────────
+
+function ViewportToggle({
+  mode,
+  onChange,
+}: {
+  mode: ViewportMode;
+  onChange: (m: ViewportMode) => void;
+}) {
+  return (
+    <div
+      role="group"
+      aria-label="Preview viewport"
+      className="flex items-center gap-1 p-1 rounded-xl bg-gray-100 dark:bg-gray-800"
+    >
+      <button
+        type="button"
+        onClick={() => onChange("desktop")}
+        aria-pressed={mode === "desktop"}
+        aria-label="Desktop preview"
+        className={`flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium transition ${
+          mode === "desktop"
+            ? "bg-white dark:bg-gray-700 text-gray-900 dark:text-white shadow-sm"
+            : "text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200"
+        }`}
+      >
+        <Monitor size={13} />
+        Desktop
+      </button>
+      <button
+        type="button"
+        onClick={() => onChange("mobile")}
+        aria-pressed={mode === "mobile"}
+        aria-label="Mobile preview"
+        className={`flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium transition ${
+          mode === "mobile"
+            ? "bg-white dark:bg-gray-700 text-gray-900 dark:text-white shadow-sm"
+            : "text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200"
+        }`}
+      >
+        <Smartphone size={13} />
+        Mobile
+      </button>
+    </div>
+  );
+}
+
+// ── Preview Content ───────────────────────────────────────────────────────────
+
+function PreviewContent({ data }: { data: PreviewData }) {
+  const goalNum = Number(data.goal) || 0;
+  const deadlineIso = data.deadline
+    ? new Date(data.deadline).toISOString()
+    : new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString();
+
+  const heroSrc = data.imageUrl
+    ? `https://ipfs.io/ipfs/${data.imageUrl}`
+    : DEFAULT_HERO_IMAGE;
+
+  return (
+    <article aria-label="Campaign preview">
+      {/* Hero image */}
+      {/* eslint-disable-next-line @next/next/no-img-element */}
+      <img
+        src={heroSrc}
+        alt={data.title || "Campaign image"}
+        className="w-full h-48 object-cover rounded-t-2xl"
+        onError={(e) => {
+          (e.currentTarget as HTMLImageElement).src = DEFAULT_HERO_IMAGE;
+        }}
+      />
+
+      <div className="p-6 space-y-6">
+        {/* Title + creator */}
+        <div>
+          <h2 className="text-2xl font-bold text-gray-900 dark:text-white">
+            {data.title || (
+              <span className="text-gray-400 italic">Untitled Campaign</span>
+            )}
+          </h2>
+          <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
+            by{" "}
+            <span className="font-mono" title={data.creatorAddress}>
+              {data.creatorAddress
+                ? formatAddress(data.creatorAddress)
+                : "your wallet"}
+            </span>
+          </p>
+        </div>
+
+        {/* Progress — always 0 for a draft */}
+        <div className="space-y-2">
+          <ProgressBar progress={0} />
+          <div className="flex justify-between text-sm text-gray-600 dark:text-gray-400">
+            <span>0 XLM raised</span>
+            <span>{goalNum.toLocaleString()} XLM goal</span>
+          </div>
+        </div>
+
+        {/* Stats row */}
+        <div className="grid grid-cols-3 gap-3 text-center">
+          <div className="rounded-xl bg-gray-100 dark:bg-gray-800 p-3">
+            <p className="text-lg font-semibold text-gray-900 dark:text-white">
+              0
+            </p>
+            <p className="text-xs text-gray-500 mt-0.5">Contributors</p>
+          </div>
+          <div className="rounded-xl bg-gray-100 dark:bg-gray-800 p-3">
+            <p className="text-lg font-semibold text-gray-900 dark:text-white">
+              {data.minContribution || "1"} XLM
+            </p>
+            <p className="text-xs text-gray-500 mt-0.5">Min. pledge</p>
+          </div>
+          <div className="rounded-xl bg-gray-100 dark:bg-gray-800 p-3">
+            <CountdownTimer deadline={deadlineIso} />
+            <p className="text-xs text-gray-500 mt-0.5">Remaining</p>
+          </div>
+        </div>
+
+        {/* Description */}
+        <p className="text-gray-700 dark:text-gray-300 leading-relaxed whitespace-pre-wrap">
+          {data.description || (
+            <span className="text-gray-400 italic">
+              No description provided.
+            </span>
+          )}
+        </p>
+
+        {/* Platform fee note */}
+        {data.feeAddress && data.feeBps && (
+          <p className="text-xs text-gray-400 dark:text-gray-500">
+            Platform fee: {(Number(data.feeBps) / 100).toFixed(2)}% on
+            withdrawal
+          </p>
+        )}
+
+        {/* Pledge button — disabled in preview */}
+        <button
+          type="button"
+          disabled
+          aria-disabled="true"
+          className="w-full py-3 rounded-xl font-medium bg-indigo-600 opacity-50 text-white cursor-not-allowed"
+        >
+          Pledge Now
+        </button>
+      </div>
+    </article>
+  );
+}
+
+// ── Main Component ────────────────────────────────────────────────────────────
+
+export function CampaignPreview({
+  data,
+  onEdit,
+  onDeploy,
+  deployDisabled = false,
+  deployPending = false,
+}: CampaignPreviewProps) {
+  const [viewport, setViewport] = useState<ViewportMode>("desktop");
+
+  return (
+    <div className="space-y-5">
+      {/* Disclaimer */}
+      <PreviewDisclaimer />
+
+      {/* Toolbar */}
+      <div className="flex items-center justify-between flex-wrap gap-3">
+        <div className="flex items-center gap-2 text-sm text-gray-500 dark:text-gray-400">
+          <Eye size={15} aria-hidden="true" />
+          <span>Campaign Preview</span>
+        </div>
+        <ViewportToggle mode={viewport} onChange={setViewport} />
+      </div>
+
+      {/* Preview frame */}
+      <div
+        className={`mx-auto transition-all duration-300 ${
+          viewport === "mobile" ? "max-w-sm" : "max-w-3xl"
+        }`}
+      >
+        <div
+          className={`
+            bg-white dark:bg-gray-900
+            border border-gray-200 dark:border-gray-700
+            rounded-2xl overflow-hidden shadow-sm
+            ${viewport === "mobile" ? "ring-4 ring-gray-300 dark:ring-gray-700" : ""}
+          `}
+        >
+          {/* Mobile notch decoration */}
+          {viewport === "mobile" && (
+            <div className="flex justify-center pt-3 pb-1">
+              <div className="w-16 h-1 rounded-full bg-gray-300 dark:bg-gray-600" />
+            </div>
+          )}
+          <PreviewContent data={data} />
+        </div>
+      </div>
+
+      {/* Action bar */}
+      <div className="flex items-center justify-between pt-2">
+        <button
+          type="button"
+          onClick={onEdit}
+          disabled={deployPending}
+          className="flex items-center gap-2 px-4 py-2 rounded-xl text-sm
+            text-gray-600 dark:text-gray-400
+            hover:text-gray-900 dark:hover:text-white
+            hover:bg-gray-100 dark:hover:bg-gray-800
+            disabled:opacity-40
+            transition"
+        >
+          <ArrowLeft size={15} />
+          Edit Campaign
+        </button>
+
+        <button
+          type="button"
+          onClick={onDeploy}
+          disabled={deployDisabled}
+          className="flex items-center gap-2 bg-indigo-600 hover:bg-indigo-500
+            px-6 py-2 rounded-xl text-sm font-medium text-white
+            transition disabled:opacity-50"
+        >
+          {deployPending && <Loader2 size={15} className="animate-spin" />}
+          {deployPending ? "Deploying..." : "Sign & Deploy"}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/apps/interface/src/components/ui/DraftIndicator.tsx
+++ b/apps/interface/src/components/ui/DraftIndicator.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+import React from "react";
+import { Save, CheckCircle2, AlertCircle, Clock } from "lucide-react";
+import type { DraftSaveStatus } from "@/hooks/useCampaignDraft";
+
+interface DraftIndicatorProps {
+  saveStatus: DraftSaveStatus;
+  lastSaved: Date | null;
+  onSave: () => void;
+}
+
+/**
+ * Shows the current draft save status and provides a manual save button.
+ */
+export function DraftIndicator({
+  saveStatus,
+  lastSaved,
+  onSave,
+}: DraftIndicatorProps) {
+  const formatTime = (date: Date) =>
+    date.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
+
+  return (
+    <div className="flex items-center gap-3">
+      {/* Status indicator */}
+      <span className="flex items-center gap-1.5 text-xs">
+        {saveStatus === "saving" && (
+          <>
+            <Clock size={12} className="text-gray-400 animate-pulse" />
+            <span className="text-gray-400">Saving…</span>
+          </>
+        )}
+        {saveStatus === "saved" && (
+          <>
+            <CheckCircle2 size={12} className="text-green-500" />
+            <span className="text-green-600 dark:text-green-400">
+              Draft saved
+            </span>
+          </>
+        )}
+        {saveStatus === "error" && (
+          <>
+            <AlertCircle size={12} className="text-red-500" />
+            <span className="text-red-500 dark:text-red-400">Save failed</span>
+          </>
+        )}
+        {saveStatus === "idle" && lastSaved && (
+          <>
+            <CheckCircle2 size={12} className="text-gray-400" />
+            <span className="text-gray-400">
+              Saved at {formatTime(lastSaved)}
+            </span>
+          </>
+        )}
+      </span>
+
+      {/* Manual save button */}
+      <button
+        type="button"
+        onClick={onSave}
+        disabled={saveStatus === "saving"}
+        aria-label="Save draft"
+        className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium
+          bg-gray-100 dark:bg-gray-800 text-gray-600 dark:text-gray-400
+          hover:bg-gray-200 dark:hover:bg-gray-700 hover:text-gray-900 dark:hover:text-white
+          disabled:opacity-50 transition"
+      >
+        <Save size={12} />
+        Save draft
+      </button>
+    </div>
+  );
+}

--- a/apps/interface/src/hooks/useCampaignDraft.ts
+++ b/apps/interface/src/hooks/useCampaignDraft.ts
@@ -1,0 +1,131 @@
+"use client";
+
+import { useState, useEffect, useCallback, useRef } from "react";
+
+const DRAFT_KEY = "fmc:campaign_draft";
+const AUTO_SAVE_INTERVAL_MS = 30_000; // 30 seconds
+
+export interface CampaignDraftData {
+  contractId: string;
+  token: string;
+  title: string;
+  description: string;
+  goal: string;
+  deadline: string;
+  minContribution: string;
+  imageUrl: string;
+  feeAddress: string;
+  feeBps: string;
+  step: number;
+}
+
+export type DraftSaveStatus = "idle" | "saving" | "saved" | "error";
+
+interface UseCampaignDraftReturn {
+  /** Whether a saved draft exists in localStorage */
+  hasDraft: boolean;
+  /** Load the saved draft data (returns null if none) */
+  loadDraft: () => CampaignDraftData | null;
+  /** Manually save the current form data as a draft */
+  saveDraft: (data: CampaignDraftData) => void;
+  /** Clear the draft from localStorage (call after successful deploy) */
+  clearDraft: () => void;
+  /** Current save status for UI feedback */
+  saveStatus: DraftSaveStatus;
+  /** Timestamp of the last successful save */
+  lastSaved: Date | null;
+}
+
+/**
+ * Manages campaign draft persistence in localStorage.
+ * Provides auto-save every 30 seconds and manual save capability.
+ */
+export function useCampaignDraft(
+  currentData: CampaignDraftData,
+): UseCampaignDraftReturn {
+  const [hasDraft, setHasDraft] = useState(false);
+  const [saveStatus, setSaveStatus] = useState<DraftSaveStatus>("idle");
+  const [lastSaved, setLastSaved] = useState<Date | null>(null);
+  const autoSaveTimerRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const currentDataRef = useRef(currentData);
+
+  // Keep ref in sync so the interval always has the latest data
+  useEffect(() => {
+    currentDataRef.current = currentData;
+  }, [currentData]);
+
+  // Check for existing draft on mount
+  useEffect(() => {
+    try {
+      const raw = localStorage.getItem(DRAFT_KEY);
+      setHasDraft(raw !== null);
+    } catch {
+      setHasDraft(false);
+    }
+  }, []);
+
+  const saveDraft = useCallback((data: CampaignDraftData) => {
+    setSaveStatus("saving");
+    try {
+      localStorage.setItem(DRAFT_KEY, JSON.stringify(data));
+      setHasDraft(true);
+      setLastSaved(new Date());
+      setSaveStatus("saved");
+    } catch {
+      setSaveStatus("error");
+    }
+  }, []);
+
+  const loadDraft = useCallback((): CampaignDraftData | null => {
+    try {
+      const raw = localStorage.getItem(DRAFT_KEY);
+      if (!raw) return null;
+      return JSON.parse(raw) as CampaignDraftData;
+    } catch {
+      return null;
+    }
+  }, []);
+
+  const clearDraft = useCallback(() => {
+    try {
+      localStorage.removeItem(DRAFT_KEY);
+      setHasDraft(false);
+      setLastSaved(null);
+      setSaveStatus("idle");
+    } catch {
+      // non-critical
+    }
+  }, []);
+
+  // Auto-save every 30 seconds — only when the form has meaningful content
+  useEffect(() => {
+    autoSaveTimerRef.current = setInterval(() => {
+      const data = currentDataRef.current;
+      const hasContent =
+        data.title.trim() ||
+        data.description.trim() ||
+        data.goal.trim() ||
+        data.contractId.trim();
+
+      if (hasContent) {
+        saveDraft(data);
+      }
+    }, AUTO_SAVE_INTERVAL_MS);
+
+    return () => {
+      if (autoSaveTimerRef.current) {
+        clearInterval(autoSaveTimerRef.current);
+      }
+    };
+  }, [saveDraft]);
+
+  // Reset "saved" status back to "idle" after 3 seconds
+  useEffect(() => {
+    if (saveStatus === "saved") {
+      const timer = setTimeout(() => setSaveStatus("idle"), 3000);
+      return () => clearTimeout(timer);
+    }
+  }, [saveStatus]);
+
+  return { hasDraft, loadDraft, saveDraft, clearDraft, saveStatus, lastSaved };
+}


### PR DESCRIPTION
## Summary

Adds a full campaign preview step to the creation wizard so creators can see exactly how their campaign will look to contributors before signing and deploying to the blockchain.

this pr Closes #261 

## Changes

### New: `CampaignPreview` component (`src/components/ui/CampaignPreview.tsx`)

**Preview disclaimer banner**
- Amber banner at the top of the preview clearly states this is a draft and nothing has been submitted on-chain yet.

**Full campaign detail render**
- Hero image — loads from IPFS CID if an image was uploaded, falls back to `DEFAULT_HERO_IMAGE` on error
- Title, creator address (formatted), progress bar at 0%, goal amount
- Live countdown timer using the draft deadline
- Stats row: 0 contributors, min pledge amount, time remaining
- Full description with whitespace preserved
- Platform fee note if configured
- Pledge button rendered but disabled (visual only)

**Desktop / Mobile viewport toggle**
- Toggle between desktop (max-w-3xl) and mobile (max-w-sm with phone frame ring) preview
- Smooth width transition via Tailwind

**Edit button**
- Returns the user to the "Review & Deploy" step with all form data intact

**Sign & Deploy button**
- Wired directly to the deploy function
- Shows spinner and "Deploying..." text while pending
- Disabled during deployment and on network mismatch

### Updated: `src/app/create/page.tsx`

- Added `"Preview"` as step 5 in the `STEPS` array with an Eye icon in the step indicator
- Added `validateAllSteps()` — runs validation across steps 0 and 2 before entering preview, so users can't preview an incomplete form
- "Next" button on the Review & Deploy step (step 3) now reads "Preview" with an Eye icon and triggers full validation before entering preview
- `showPreview` state flag controls whether the narrow card or the full-width preview is rendered
- `back()` from preview returns to step 3 (Review & Deploy) without losing any data
- Error banner from a failed deploy attempt is shown above the preview frame
- Container widens to `max-w-4xl` in preview mode to give the desktop frame room


## Checklist

- [x] Branch based on latest `main`
- [x] Follows `feat/<description>` branch naming convention  
- [x] Commit follows Conventional Commits format
- [x] No new dependencies introduced
- [x] Dark mode supported throughout
- [x] Accessible: `aria-pressed` on viewport toggle, `aria-disabled` on pledge button, `aria-live` on disclaimer
- [x] Image error fallback handled
- [x] Mobile preview frame included


