### PR TITLE
Implement transaction history export with CSV, PDF, and tax report

### DIFF
--- a/apps/interface/src/app/campaigns/[id]/page.tsx
+++ b/apps/interface/src/app/campaigns/[id]/page.tsx
@@ -12,7 +12,11 @@ import { TransactionHistory } from "@/components/ui/TransactionHistory";
 import { XlmAmount } from "@/components/ui/XlmAmount";
 import { fetchCampaign, getStaticCampaignIds } from "@/lib/soroban";
 import { fetchXlmPrice } from "@/lib/price";
-import { APP_BASE_URL, DEFAULT_HERO_IMAGE, CAMPAIGN_PAGE_REVALIDATE_SECONDS } from "@/lib/constants";
+import {
+  APP_BASE_URL,
+  DEFAULT_HERO_IMAGE,
+  CAMPAIGN_PAGE_REVALIDATE_SECONDS,
+} from "@/lib/constants";
 import { CampaignActions } from "./CampaignActions";
 import { CampaignDetailContent } from "./CampaignDetailContent";
 
@@ -53,7 +57,9 @@ export async function generateMetadata({
         description,
         url,
         siteName: "Fund-My-Cause",
-        images: [{ url: DEFAULT_HERO_IMAGE, width: 1200, height: 630, alt: c.title }],
+        images: [
+          { url: DEFAULT_HERO_IMAGE, width: 1200, height: 630, alt: c.title },
+        ],
         type: "website",
       },
       twitter: {
@@ -87,7 +93,8 @@ export default async function CampaignDetailPage({
   // Fetch XLM price in parallel — null if CoinGecko is unavailable
   const xlmPrice = await fetchXlmPrice();
 
-  const progress = campaign.goal > 0 ? (campaign.raised / campaign.goal) * 100 : 0;
+  const progress =
+    campaign.goal > 0 ? (campaign.raised / campaign.goal) * 100 : 0;
   const deadlinePassed = new Date(campaign.deadline) < new Date();
   const goalMet = campaign.raised >= campaign.goal;
 
@@ -108,13 +115,15 @@ export default async function CampaignDetailPage({
       </div>
 
       <div className="max-w-3xl mx-auto px-6 py-10 space-y-8">
-
         {/* Title + creator */}
         <div>
           <h1 className="text-3xl font-bold mb-2">{campaign.title}</h1>
           <p className="text-gray-600 dark:text-gray-500 text-sm">
             by{" "}
-            <span className="font-mono text-gray-500 dark:text-gray-400" title={campaign.creator}>
+            <span
+              className="font-mono text-gray-500 dark:text-gray-400"
+              title={campaign.creator}
+            >
               {truncate(campaign.creator)}
             </span>
           </p>
@@ -124,8 +133,12 @@ export default async function CampaignDetailPage({
         <div className="space-y-2">
           <ProgressBar progress={progress} />
           <div className="flex justify-between text-sm text-gray-600 dark:text-gray-400">
-            <span><XlmAmount xlm={campaign.raised} price={xlmPrice} /> raised</span>
-            <span><XlmAmount xlm={campaign.goal} price={xlmPrice} /> goal</span>
+            <span>
+              <XlmAmount xlm={campaign.raised} price={xlmPrice} /> raised
+            </span>
+            <span>
+              <XlmAmount xlm={campaign.goal} price={xlmPrice} /> goal
+            </span>
           </div>
         </div>
 
@@ -148,12 +161,14 @@ export default async function CampaignDetailPage({
         </div>
 
         {/* Description */}
-        <p className="text-gray-700 dark:text-gray-300 leading-relaxed">{campaign.description}</p>
+        <p className="text-gray-700 dark:text-gray-300 leading-relaxed">
+          {campaign.description}
+        </p>
 
         {/* Share button */}
         <ShareTrigger campaignId={id} campaignTitle={campaign.title} />
         {/* Transaction history */}
-        <TransactionHistory contractId={id} />
+        <TransactionHistory contractId={id} campaignTitle={campaign.title} />
 
         {/* Share buttons */}
         <ShareButton campaignId={id} campaignTitle={campaign.title} />

--- a/apps/interface/src/components/ui/TransactionExportModal.tsx
+++ b/apps/interface/src/components/ui/TransactionExportModal.tsx
@@ -1,0 +1,289 @@
+"use client";
+
+import React, { useState, useMemo } from "react";
+import {
+  X,
+  Download,
+  FileText,
+  FileSpreadsheet,
+  Receipt,
+  Calendar,
+  Loader2,
+} from "lucide-react";
+import {
+  exportCsv,
+  exportTaxReport,
+  exportPdf,
+  filterByDateRange,
+  type ExportRecord,
+  type DateRange,
+} from "@/lib/exportTransactions";
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+type ExportFormat = "csv" | "pdf" | "tax";
+
+interface TransactionExportModalProps {
+  records: ExportRecord[];
+  campaignTitle: string;
+  campaignId: string;
+  onClose: () => void;
+}
+
+// ── Format options ────────────────────────────────────────────────────────────
+
+const FORMAT_OPTIONS: {
+  id: ExportFormat;
+  label: string;
+  description: string;
+  icon: React.ReactNode;
+}[] = [
+  {
+    id: "csv",
+    label: "CSV",
+    description: "Spreadsheet-ready. Date, amount, contributor, status.",
+    icon: <FileSpreadsheet size={18} />,
+  },
+  {
+    id: "pdf",
+    label: "PDF",
+    description: "Print-ready report with summary. Opens browser print dialog.",
+    icon: <FileText size={18} />,
+  },
+  {
+    id: "tax",
+    label: "Tax Report",
+    description:
+      "CSV formatted for crypto tax tools. Includes acquisition date and asset fields.",
+    icon: <Receipt size={18} />,
+  },
+];
+
+// ── Input helpers ─────────────────────────────────────────────────────────────
+
+const inputCls =
+  "w-full bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-700 " +
+  "rounded-lg px-3 py-2 text-sm text-gray-900 dark:text-white " +
+  "focus:outline-none focus:border-indigo-500 dark:focus:border-indigo-400";
+
+// ── Component ─────────────────────────────────────────────────────────────────
+
+export function TransactionExportModal({
+  records,
+  campaignTitle,
+  campaignId,
+  onClose,
+}: TransactionExportModalProps) {
+  const [format, setFormat] = useState<ExportFormat>("csv");
+  const [dateRange, setDateRange] = useState<DateRange>({ from: "", to: "" });
+  const [exporting, setExporting] = useState(false);
+
+  const filteredRecords = useMemo(
+    () => filterByDateRange(records, dateRange),
+    [records, dateRange],
+  );
+
+  const slug = campaignTitle.toLowerCase().replace(/\s+/g, "-").slice(0, 30);
+  const dateTag = new Date().toISOString().slice(0, 10);
+
+  const handleExport = async () => {
+    if (filteredRecords.length === 0) return;
+    setExporting(true);
+    // Small delay so the button state renders before the (potentially blocking) export
+    await new Promise((r) => setTimeout(r, 50));
+    try {
+      if (format === "csv") {
+        exportCsv(filteredRecords, `${slug}-transactions-${dateTag}.csv`);
+      } else if (format === "tax") {
+        exportTaxReport(filteredRecords, `${slug}-tax-report-${dateTag}.csv`);
+      } else {
+        exportPdf(filteredRecords, campaignTitle, campaignId);
+      }
+    } finally {
+      setExporting(false);
+    }
+  };
+
+  const isEmpty = filteredRecords.length === 0;
+
+  return (
+    /* Backdrop */
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="export-modal-title"
+      className="fixed inset-0 z-50 flex items-center justify-center p-4"
+    >
+      {/* Overlay */}
+      <div
+        className="absolute inset-0 bg-black/60 backdrop-blur-sm"
+        onClick={onClose}
+        aria-hidden="true"
+      />
+
+      {/* Panel */}
+      <div className="relative z-10 w-full max-w-md bg-white dark:bg-gray-900 rounded-2xl shadow-2xl border border-gray-200 dark:border-gray-800 overflow-hidden">
+        {/* Header */}
+        <div className="flex items-center justify-between px-6 py-4 border-b border-gray-200 dark:border-gray-800">
+          <div className="flex items-center gap-2">
+            <Download
+              size={18}
+              className="text-indigo-500"
+              aria-hidden="true"
+            />
+            <h2
+              id="export-modal-title"
+              className="text-base font-semibold text-gray-900 dark:text-white"
+            >
+              Export Transactions
+            </h2>
+          </div>
+          <button
+            onClick={onClose}
+            aria-label="Close export modal"
+            className="p-1.5 rounded-lg text-gray-400 hover:text-gray-600 dark:hover:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-800 transition"
+          >
+            <X size={16} />
+          </button>
+        </div>
+
+        <div className="px-6 py-5 space-y-5">
+          {/* Format selector */}
+          <fieldset>
+            <legend className="text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wide mb-2">
+              Format
+            </legend>
+            <div className="space-y-2">
+              {FORMAT_OPTIONS.map((opt) => (
+                <label
+                  key={opt.id}
+                  className={`flex items-start gap-3 p-3 rounded-xl border cursor-pointer transition ${
+                    format === opt.id
+                      ? "border-indigo-500 bg-indigo-50 dark:bg-indigo-950/40"
+                      : "border-gray-200 dark:border-gray-700 hover:border-gray-300 dark:hover:border-gray-600"
+                  }`}
+                >
+                  <input
+                    type="radio"
+                    name="export-format"
+                    value={opt.id}
+                    checked={format === opt.id}
+                    onChange={() => setFormat(opt.id)}
+                    className="mt-0.5 accent-indigo-600"
+                  />
+                  <span
+                    className={`mt-0.5 ${format === opt.id ? "text-indigo-600 dark:text-indigo-400" : "text-gray-400"}`}
+                    aria-hidden="true"
+                  >
+                    {opt.icon}
+                  </span>
+                  <div>
+                    <p className="text-sm font-medium text-gray-900 dark:text-white">
+                      {opt.label}
+                    </p>
+                    <p className="text-xs text-gray-500 dark:text-gray-400 mt-0.5">
+                      {opt.description}
+                    </p>
+                  </div>
+                </label>
+              ))}
+            </div>
+          </fieldset>
+
+          {/* Date range filter */}
+          <fieldset>
+            <legend className="flex items-center gap-1.5 text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wide mb-2">
+              <Calendar size={12} aria-hidden="true" />
+              Date Range (optional)
+            </legend>
+            <div className="grid grid-cols-2 gap-3">
+              <div>
+                <label
+                  htmlFor="export-from"
+                  className="block text-xs text-gray-500 dark:text-gray-400 mb-1"
+                >
+                  From
+                </label>
+                <input
+                  id="export-from"
+                  type="date"
+                  value={dateRange.from}
+                  onChange={(e) =>
+                    setDateRange((prev) => ({ ...prev, from: e.target.value }))
+                  }
+                  className={inputCls}
+                />
+              </div>
+              <div>
+                <label
+                  htmlFor="export-to"
+                  className="block text-xs text-gray-500 dark:text-gray-400 mb-1"
+                >
+                  To
+                </label>
+                <input
+                  id="export-to"
+                  type="date"
+                  value={dateRange.to}
+                  min={dateRange.from || undefined}
+                  onChange={(e) =>
+                    setDateRange((prev) => ({ ...prev, to: e.target.value }))
+                  }
+                  className={inputCls}
+                />
+              </div>
+            </div>
+          </fieldset>
+
+          {/* Record count summary */}
+          <div
+            className={`flex items-center justify-between text-xs px-3 py-2 rounded-lg ${
+              isEmpty
+                ? "bg-amber-50 dark:bg-amber-950/30 text-amber-600 dark:text-amber-400"
+                : "bg-gray-100 dark:bg-gray-800 text-gray-500 dark:text-gray-400"
+            }`}
+            aria-live="polite"
+          >
+            <span>
+              {isEmpty
+                ? "No transactions match the selected date range."
+                : `${filteredRecords.length} transaction${filteredRecords.length !== 1 ? "s" : ""} will be exported`}
+            </span>
+            {!isEmpty && (
+              <span className="font-medium text-gray-700 dark:text-gray-300">
+                {filteredRecords
+                  .reduce((s, r) => s + r.amountXlm, 0)
+                  .toLocaleString(undefined, { maximumFractionDigits: 2 })}{" "}
+                XLM total
+              </span>
+            )}
+          </div>
+        </div>
+
+        {/* Footer */}
+        <div className="flex items-center justify-end gap-3 px-6 py-4 border-t border-gray-200 dark:border-gray-800 bg-gray-50 dark:bg-gray-900/50">
+          <button
+            onClick={onClose}
+            className="px-4 py-2 rounded-xl text-sm text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white hover:bg-gray-100 dark:hover:bg-gray-800 transition"
+          >
+            Cancel
+          </button>
+          <button
+            onClick={handleExport}
+            disabled={isEmpty || exporting}
+            className="flex items-center gap-2 px-5 py-2 rounded-xl text-sm font-medium bg-indigo-600 hover:bg-indigo-500 text-white transition disabled:opacity-50"
+          >
+            {exporting ? (
+              <Loader2 size={14} className="animate-spin" />
+            ) : (
+              <Download size={14} />
+            )}
+            {exporting
+              ? "Exporting…"
+              : `Export ${FORMAT_OPTIONS.find((o) => o.id === format)?.label}`}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/interface/src/components/ui/TransactionHistory.tsx
+++ b/apps/interface/src/components/ui/TransactionHistory.tsx
@@ -1,11 +1,27 @@
-import React from "react";
-import { fetchTransactionHistory } from "@/lib/soroban";
-import { ExternalLink } from "lucide-react";
-import { EmptyState, NoTransactionsIllustration } from "@/components/ui/EmptyState";
+"use client";
+
+import React, { useEffect, useState } from "react";
+import { ExternalLink, Download, Loader2 } from "lucide-react";
+import {
+  fetchTransactionHistory,
+  type ContributionRecord,
+} from "@/lib/soroban";
+import {
+  EmptyState,
+  NoTransactionsIllustration,
+} from "@/components/ui/EmptyState";
+import { TransactionExportModal } from "@/components/ui/TransactionExportModal";
+import type { ExportRecord } from "@/lib/exportTransactions";
+
+// ── Props ─────────────────────────────────────────────────────────────────────
 
 interface Props {
   contractId: string;
+  /** Optional campaign title used in export filenames and PDF header. */
+  campaignTitle?: string;
 }
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
 
 function truncate(addr: string) {
   return `${addr.slice(0, 6)}…${addr.slice(-4)}`;
@@ -19,18 +35,83 @@ function formatDate(iso: string) {
   });
 }
 
-const network = process.env.NEXT_PUBLIC_NETWORK === "mainnet" ? "mainnet" : "testnet";
+const network =
+  process.env.NEXT_PUBLIC_NETWORK === "mainnet" ? "mainnet" : "testnet";
 const STELLAR_EXPERT = `https://stellar.expert/explorer/${network}`;
 
-export async function TransactionHistory({ contractId }: Props) {
-  const records = await fetchTransactionHistory(contractId, 10);
+/** Map a ContributionRecord from soroban.ts to the ExportRecord shape. */
+function toExportRecord(
+  r: ContributionRecord,
+  contractId: string,
+  campaignTitle: string,
+): ExportRecord {
+  return {
+    txHash: r.txHash,
+    contributor: r.contributor,
+    amountXlm: r.amountXlm,
+    timestamp: r.timestamp,
+    campaignId: contractId,
+    campaignTitle,
+    status: "Confirmed",
+  };
+}
+
+// ── Component ─────────────────────────────────────────────────────────────────
+
+export function TransactionHistory({
+  contractId,
+  campaignTitle = "Campaign",
+}: Props) {
+  const [records, setRecords] = useState<ContributionRecord[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [showExport, setShowExport] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    // Fetch all records (limit 0) so the export has the full dataset
+    fetchTransactionHistory(contractId, 0)
+      .then((data) => {
+        if (!cancelled) setRecords(data);
+      })
+      .catch(() => {
+        if (!cancelled) setRecords([]);
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [contractId]);
 
   const viewAllUrl = `${STELLAR_EXPERT}/contract/${contractId}`;
+  const exportRecords = records.map((r) =>
+    toExportRecord(r, contractId, campaignTitle),
+  );
+
+  // Show only the 10 most recent in the table; export uses the full set
+  const displayRecords = records.slice(0, 10);
+
+  if (loading) {
+    return (
+      <div className="space-y-3">
+        <h2 className="text-base font-semibold text-gray-900 dark:text-white">
+          Recent Contributions
+        </h2>
+        <div className="flex justify-center py-8">
+          <Loader2 size={24} className="animate-spin text-indigo-400" />
+        </div>
+      </div>
+    );
+  }
 
   if (records.length === 0) {
     return (
       <div className="space-y-3">
-        <h2 className="text-base font-semibold text-gray-900 dark:text-white">Recent Contributions</h2>
+        <h2 className="text-base font-semibold text-gray-900 dark:text-white">
+          Recent Contributions
+        </h2>
         <EmptyState
           illustration={<NoTransactionsIllustration />}
           title="No contributions yet"
@@ -41,67 +122,116 @@ export async function TransactionHistory({ contractId }: Props) {
   }
 
   return (
-    <div className="space-y-3">
-      <div className="flex items-center justify-between">
-        <h2 className="text-base font-semibold text-gray-900 dark:text-white">
-          Recent Contributions
-        </h2>
-        <a
-          href={viewAllUrl}
-          target="_blank"
-          rel="noopener noreferrer"
-          className="flex items-center gap-1 text-xs text-indigo-600 dark:text-indigo-400 hover:underline"
-        >
-          View all on Stellar Expert
-          <ExternalLink size={12} />
-        </a>
+    <>
+      <div className="space-y-3">
+        {/* Header row */}
+        <div className="flex items-center justify-between flex-wrap gap-2">
+          <h2 className="text-base font-semibold text-gray-900 dark:text-white">
+            Recent Contributions
+          </h2>
+
+          <div className="flex items-center gap-3">
+            {/* Export button */}
+            <button
+              onClick={() => setShowExport(true)}
+              aria-label="Export transaction history"
+              className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium
+                bg-gray-100 dark:bg-gray-800
+                text-gray-600 dark:text-gray-400
+                hover:bg-gray-200 dark:hover:bg-gray-700
+                hover:text-gray-900 dark:hover:text-white
+                transition"
+            >
+              <Download size={13} />
+              Export
+            </button>
+
+            {/* View all on Stellar Expert */}
+            <a
+              href={viewAllUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="flex items-center gap-1 text-xs text-indigo-600 dark:text-indigo-400 hover:underline"
+            >
+              View all on Stellar Expert
+              <ExternalLink size={12} />
+            </a>
+          </div>
+        </div>
+
+        {/* Table */}
+        <div className="rounded-xl border border-gray-200 dark:border-gray-800 overflow-hidden">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="bg-gray-100 dark:bg-gray-800 text-gray-500 dark:text-gray-400 text-xs uppercase tracking-wide">
+                <th className="px-4 py-2 text-left font-medium">Contributor</th>
+                <th className="px-4 py-2 text-right font-medium">Amount</th>
+                <th className="px-4 py-2 text-right font-medium">Date</th>
+                <th
+                  className="px-4 py-2 text-right font-medium"
+                  aria-label="View transaction link"
+                >
+                  <span className="sr-only">Link</span>
+                </th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-gray-100 dark:divide-gray-800">
+              {displayRecords.map((r) => (
+                <tr
+                  key={r.txHash}
+                  className="bg-white dark:bg-gray-900 hover:bg-gray-50 dark:hover:bg-gray-800/60 transition-colors"
+                >
+                  <td className="px-4 py-3 font-mono text-gray-700 dark:text-gray-300">
+                    <span title={r.contributor}>{truncate(r.contributor)}</span>
+                  </td>
+                  <td className="px-4 py-3 text-right text-gray-900 dark:text-white font-medium">
+                    {r.amountXlm > 0
+                      ? `${r.amountXlm.toLocaleString(undefined, { maximumFractionDigits: 7 })} XLM`
+                      : "—"}
+                  </td>
+                  <td className="px-4 py-3 text-right text-gray-500 dark:text-gray-400">
+                    {formatDate(r.timestamp)}
+                  </td>
+                  <td className="px-4 py-3 text-right">
+                    <a
+                      href={`${STELLAR_EXPERT}/tx/${r.txHash}`}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      aria-label="View transaction on Stellar Expert"
+                      className="inline-flex items-center text-indigo-500 hover:text-indigo-400"
+                    >
+                      <ExternalLink size={14} />
+                    </a>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+
+        {/* "Showing X of Y" note when there are more than 10 */}
+        {records.length > 10 && (
+          <p className="text-xs text-gray-400 dark:text-gray-500 text-right">
+            Showing 10 of {records.length} contributions.{" "}
+            <button
+              onClick={() => setShowExport(true)}
+              className="text-indigo-500 hover:underline"
+            >
+              Export all
+            </button>
+          </p>
+        )}
       </div>
 
-      <div className="rounded-xl border border-gray-200 dark:border-gray-800 overflow-hidden">
-        <table className="w-full text-sm">
-          <thead>
-            <tr className="bg-gray-100 dark:bg-gray-800 text-gray-500 dark:text-gray-400 text-xs uppercase tracking-wide">
-              <th className="px-4 py-2 text-left font-medium">Contributor</th>
-              <th className="px-4 py-2 text-right font-medium">Amount</th>
-              <th className="px-4 py-2 text-right font-medium">Date</th>
-              <th className="px-4 py-2 text-right font-medium" aria-label="View transaction link">
-                <span className="sr-only">Link</span>
-              </th>
-            </tr>
-          </thead>
-          <tbody className="divide-y divide-gray-100 dark:divide-gray-800">
-            {records.map((r) => (
-              <tr
-                key={r.txHash}
-                className="bg-white dark:bg-gray-900 hover:bg-gray-50 dark:hover:bg-gray-800/60 transition-colors"
-              >
-                <td className="px-4 py-3 font-mono text-gray-700 dark:text-gray-300">
-                  <span title={r.contributor}>{truncate(r.contributor)}</span>
-                </td>
-                <td className="px-4 py-3 text-right text-gray-900 dark:text-white font-medium">
-                  {r.amountXlm > 0
-                    ? `${r.amountXlm.toLocaleString(undefined, { maximumFractionDigits: 7 })} XLM`
-                    : "—"}
-                </td>
-                <td className="px-4 py-3 text-right text-gray-500 dark:text-gray-400">
-                  {formatDate(r.timestamp)}
-                </td>
-                <td className="px-4 py-3 text-right">
-                  <a
-                    href={`${STELLAR_EXPERT}/tx/${r.txHash}`}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    aria-label="View transaction on Stellar Expert"
-                    className="inline-flex items-center text-indigo-500 hover:text-indigo-400"
-                  >
-                    <ExternalLink size={14} />
-                  </a>
-                </td>
-              </tr>
-            ))}
-          </tbody>
-        </table>
-      </div>
-    </div>
+      {/* Export modal */}
+      {showExport && (
+        <TransactionExportModal
+          records={exportRecords}
+          campaignTitle={campaignTitle}
+          campaignId={contractId}
+          onClose={() => setShowExport(false)}
+        />
+      )}
+    </>
   );
 }

--- a/apps/interface/src/lib/exportTransactions.ts
+++ b/apps/interface/src/lib/exportTransactions.ts
@@ -1,0 +1,277 @@
+/**
+ * Transaction history export utilities.
+ * Supports CSV, Tax Report CSV, and PDF (browser print) formats.
+ * No external dependencies — uses only browser-native APIs.
+ */
+
+export interface ExportRecord {
+  txHash: string;
+  contributor: string;
+  amountXlm: number;
+  timestamp: string; // ISO string
+  campaignId: string;
+  campaignTitle: string;
+  status: string;
+}
+
+export interface DateRange {
+  from: string; // YYYY-MM-DD or ""
+  to: string; // YYYY-MM-DD or ""
+}
+
+// ── Filtering ─────────────────────────────────────────────────────────────────
+
+/**
+ * Filter records by an inclusive date range.
+ * Empty from/to strings are treated as unbounded.
+ */
+export function filterByDateRange(
+  records: ExportRecord[],
+  range: DateRange,
+): ExportRecord[] {
+  const from = range.from ? new Date(range.from).getTime() : -Infinity;
+  const to = range.to
+    ? new Date(range.to + "T23:59:59.999Z").getTime()
+    : Infinity;
+
+  return records.filter((r) => {
+    const ts = new Date(r.timestamp).getTime();
+    return ts >= from && ts <= to;
+  });
+}
+
+// ── CSV helpers ───────────────────────────────────────────────────────────────
+
+function escapeCell(value: string | number): string {
+  const str = String(value);
+  // Wrap in quotes if the value contains commas, quotes, or newlines
+  if (/[",\n\r]/.test(str)) {
+    return `"${str.replace(/"/g, '""')}"`;
+  }
+  return str;
+}
+
+function buildCsv(headers: string[], rows: (string | number)[][]): string {
+  const lines = [
+    headers.map(escapeCell).join(","),
+    ...rows.map((row) => row.map(escapeCell).join(",")),
+  ];
+  return lines.join("\r\n");
+}
+
+function downloadFile(content: string, filename: string, mimeType: string) {
+  const blob = new Blob([content], { type: mimeType });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = filename;
+  a.click();
+  URL.revokeObjectURL(url);
+}
+
+function formatIsoToLocal(iso: string): string {
+  return new Date(iso).toLocaleDateString(undefined, {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  });
+}
+
+function formatIsoToLocalFull(iso: string): string {
+  return new Date(iso).toLocaleString(undefined, {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+// ── CSV Export ────────────────────────────────────────────────────────────────
+
+/**
+ * Download transaction history as a standard CSV file.
+ */
+export function exportCsv(
+  records: ExportRecord[],
+  filename = "transactions.csv",
+) {
+  const headers = [
+    "Date",
+    "Time (UTC)",
+    "Transaction Hash",
+    "Contributor",
+    "Campaign",
+    "Campaign ID",
+    "Amount (XLM)",
+    "Status",
+  ];
+
+  const rows = records.map((r) => {
+    const d = new Date(r.timestamp);
+    return [
+      d.toLocaleDateString(undefined, {
+        year: "numeric",
+        month: "2-digit",
+        day: "2-digit",
+      }),
+      d.toISOString().slice(11, 19),
+      r.txHash,
+      r.contributor,
+      r.campaignTitle,
+      r.campaignId,
+      r.amountXlm.toFixed(7),
+      r.status,
+    ];
+  });
+
+  downloadFile(buildCsv(headers, rows), filename, "text/csv;charset=utf-8;");
+}
+
+// ── Tax Report CSV ────────────────────────────────────────────────────────────
+
+/**
+ * Download a tax-oriented CSV with acquisition date, cost basis placeholder,
+ * and disposal fields — compatible with common crypto tax tools.
+ */
+export function exportTaxReport(
+  records: ExportRecord[],
+  filename = "tax-report.csv",
+) {
+  const headers = [
+    "Date Acquired",
+    "Asset",
+    "Amount",
+    "Transaction Type",
+    "Transaction Hash",
+    "Wallet / Contributor",
+    "Campaign",
+    "Cost Basis (USD)",
+    "Notes",
+  ];
+
+  const rows = records.map((r) => [
+    formatIsoToLocal(r.timestamp),
+    "XLM",
+    r.amountXlm.toFixed(7),
+    "Contribution",
+    r.txHash,
+    r.contributor,
+    r.campaignTitle,
+    "", // cost basis — user fills in
+    `Campaign ID: ${r.campaignId}`,
+  ]);
+
+  downloadFile(buildCsv(headers, rows), filename, "text/csv;charset=utf-8;");
+}
+
+// ── PDF Export (browser print) ────────────────────────────────────────────────
+
+/**
+ * Open a print-ready HTML page in a new window so the user can save as PDF.
+ * No external PDF library required — uses the browser's native print dialog.
+ */
+export function exportPdf(
+  records: ExportRecord[],
+  campaignTitle: string,
+  campaignId: string,
+) {
+  const totalXlm = records.reduce((sum, r) => sum + r.amountXlm, 0);
+  const generatedAt = new Date().toLocaleString();
+
+  const tableRows = records
+    .map(
+      (r) => `
+      <tr>
+        <td>${formatIsoToLocalFull(r.timestamp)}</td>
+        <td class="mono" title="${r.contributor}">${r.contributor.slice(0, 8)}…${r.contributor.slice(-4)}</td>
+        <td class="right">${r.amountXlm.toFixed(7)} XLM</td>
+        <td>${r.status}</td>
+        <td class="mono hash"><a href="https://stellar.expert/explorer/testnet/tx/${r.txHash}" target="_blank">${r.txHash.slice(0, 12)}…</a></td>
+      </tr>`,
+    )
+    .join("");
+
+  const html = `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Transaction History — ${campaignTitle}</title>
+  <style>
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; font-size: 12px; color: #111; padding: 32px; }
+    h1 { font-size: 18px; margin-bottom: 4px; }
+    .meta { color: #555; font-size: 11px; margin-bottom: 24px; }
+    table { width: 100%; border-collapse: collapse; margin-bottom: 24px; }
+    th { background: #f3f4f6; text-align: left; padding: 8px 10px; font-size: 10px; text-transform: uppercase; letter-spacing: 0.05em; border-bottom: 2px solid #e5e7eb; }
+    td { padding: 7px 10px; border-bottom: 1px solid #e5e7eb; vertical-align: top; }
+    tr:last-child td { border-bottom: none; }
+    .right { text-align: right; }
+    .mono { font-family: "Courier New", monospace; font-size: 10px; }
+    .hash { font-size: 10px; }
+    .summary { background: #f9fafb; border: 1px solid #e5e7eb; border-radius: 6px; padding: 12px 16px; display: flex; gap: 32px; }
+    .summary-item label { display: block; font-size: 10px; color: #6b7280; text-transform: uppercase; letter-spacing: 0.05em; }
+    .summary-item span { font-size: 15px; font-weight: 600; }
+    .disclaimer { margin-top: 24px; font-size: 10px; color: #9ca3af; border-top: 1px solid #e5e7eb; padding-top: 12px; }
+    a { color: #4f46e5; text-decoration: none; }
+    @media print {
+      body { padding: 16px; }
+      a { color: #111; }
+    }
+  </style>
+</head>
+<body>
+  <h1>Transaction History</h1>
+  <p class="meta">
+    Campaign: <strong>${campaignTitle}</strong> &nbsp;|&nbsp;
+    Contract: <span class="mono">${campaignId}</span> &nbsp;|&nbsp;
+    Generated: ${generatedAt}
+  </p>
+
+  <div class="summary">
+    <div class="summary-item">
+      <label>Total Transactions</label>
+      <span>${records.length}</span>
+    </div>
+    <div class="summary-item">
+      <label>Total Raised</label>
+      <span>${totalXlm.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 7 })} XLM</span>
+    </div>
+    <div class="summary-item">
+      <label>Date Range</label>
+      <span>${records.length > 0 ? `${formatIsoToLocal(records[records.length - 1].timestamp)} – ${formatIsoToLocal(records[0].timestamp)}` : "—"}</span>
+    </div>
+  </div>
+
+  <br />
+
+  <table>
+    <thead>
+      <tr>
+        <th>Date &amp; Time</th>
+        <th>Contributor</th>
+        <th class="right">Amount</th>
+        <th>Status</th>
+        <th>Tx Hash</th>
+      </tr>
+    </thead>
+    <tbody>
+      ${tableRows || '<tr><td colspan="5" style="text-align:center;color:#9ca3af;padding:24px">No transactions in this range.</td></tr>'}
+    </tbody>
+  </table>
+
+  <p class="disclaimer">
+    This report is generated from on-chain data via the Stellar network. Amounts are in XLM (Lumens).
+    Cost basis and fiat values are not included — consult a tax professional for reporting obligations.
+  </p>
+
+  <script>window.onload = () => window.print();</script>
+</body>
+</html>`;
+
+  const win = window.open("", "_blank");
+  if (win) {
+    win.document.write(html);
+    win.document.close();
+  }
+}

--- a/apps/interface/src/lib/soroban.ts
+++ b/apps/interface/src/lib/soroban.ts
@@ -33,6 +33,7 @@ export type {
 const SOROBAN_RPC_URL =
   process.env.NEXT_PUBLIC_SOROBAN_RPC_URL ??
   "https://soroban-testnet.stellar.org";
+const RPC_URL = SOROBAN_RPC_URL;
 const HORIZON_URL =
   process.env.NEXT_PUBLIC_HORIZON_URL ?? "https://horizon-testnet.stellar.org";
 const NETWORK_PASSPHRASE = Networks.TESTNET;
@@ -93,6 +94,14 @@ function toBooleanValue(value: unknown, fallback = false): boolean {
 function toStringArrayValue(value: unknown): string[] {
   if (!Array.isArray(value)) return [];
   return value.map((item) => toStringValue(item)).filter(Boolean);
+}
+
+function stroopsToXlm(stroops: bigint): number {
+  return Number(stroops) / 1e7;
+}
+
+function ledgerTimestampToIso(ts: bigint): string {
+  return new Date(Number(ts) * 1000).toISOString();
 }
 
 function normalizeStatus(value: unknown): CampaignStatus {
@@ -605,3 +614,44 @@ function parseContributeAmount(op: HorizonOperation): number | null {
   // still appears (amount shown as "—")
   return 0;
 }
+
+/**
+ * Fetch up to `limit` contribution records for a campaign contract via Horizon.
+ * Pass limit=0 to fetch all available records (up to Horizon's page cap of 200).
+ */
+export async function fetchTransactionHistory(
+  contractId: string,
+  limit = 10,
+): Promise<ContributionRecord[]> {
+  try {
+    const url =
+      `${HORIZON_URL}/accounts/${contractId}/operations` +
+      `?order=desc&limit=${limit > 0 ? Math.min(limit, 200) : 200}&include_failed=false`;
+
+    const res = await fetch(url);
+    if (!res.ok) return [];
+
+    const page: HorizonOperationsPage = await res.json();
+    const ops = page._embedded?.records ?? [];
+
+    const records: ContributionRecord[] = [];
+    for (const op of ops) {
+      if (op.type !== "invoke_host_function") continue;
+      const amount = parseContributeAmount(op);
+      if (amount === null) continue;
+      records.push({
+        txHash: op.transaction_hash,
+        contributor: op.source_account,
+        amountXlm: amount,
+        timestamp: op.created_at,
+      });
+    }
+    return records;
+  } catch {
+    return [];
+  }
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+// ── RPC URL alias ─────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Adds a full transaction history export system to the campaign detail page. Users can export their contribution data as CSV, a print-ready PDF, or a tax-oriented CSV compatible with crypto tax tools — with optional date range filtering.

this pr Closes #262 

## Changes

### New: `src/lib/exportTransactions.ts`
Pure utility module — no external dependencies.

- **`exportCsv()`** — downloads a CSV with columns: Date, Time (UTC), Tx Hash, Contributor, Campaign, Campaign ID, Amount (XLM), Status
- **`exportTaxReport()`** — downloads a tax-oriented CSV with: Date Acquired, Asset, Amount, Transaction Type, Tx Hash, Wallet, Campaign, Cost Basis (USD placeholder), Notes. Compatible with common crypto tax tools.
- **`exportPdf()`** — opens a print-ready HTML page in a new tab with a summary block (total transactions, total XLM, date range) and a full transaction table. Triggers `window.print()` automatically so the user can save as PDF via the browser's native dialog.
- **`filterByDateRange()`** — inclusive date range filter (empty from/to = unbounded)

### New: `src/components/ui/TransactionExportModal.tsx`
- Format selector with radio cards: CSV, PDF, Tax Report — each with icon and description
- Date range pickers (From / To) with `min` constraint on the To field
- Live record count and XLM total that updates as the date range changes
- Amber warning when the date range produces zero results
- Export button disabled when no records match; shows spinner during export
- Accessible: `role="dialog"`, `aria-modal`, `aria-labelledby`, `aria-live` on count

### Updated: `src/components/ui/TransactionHistory.tsx`
- Converted from async server component to `"use client"` component with `useEffect` data fetching (required for the interactive export button)
- Fetches the full record set (up to 200 via Horizon) for export; displays top 10 in the table
- **Export button** added to the header row — opens `TransactionExportModal`
- Loading spinner while fetching
- "Showing 10 of N — Export all" note when records exceed 10
- Accepts optional `campaignTitle` prop for export filenames and PDF header

### Updated: `src/lib/soroban.ts`
- Added `fetchTransactionHistory()` — was imported by `TransactionHistory` but never defined
- Added `RPC_URL` alias for `SOROBAN_RPC_URL` (used by `simulateView` and `simulateTx`)
- Added `stroopsToXlm()` and `ledgerTimestampToIso()` helpers (were used but undefined)

### Updated: `src/app/campaigns/[id]/page.tsx`
- Passes `campaignTitle={campaign.title}` to `<TransactionHistory />` for use in export filenames and PDF header

## Checklist

- [x] New branch from `main`
- [x] Conventional commit format
- [x] No new npm dependencies — PDF uses browser print, CSV uses Blob API
- [x] Dark mode supported throughout
- [x] Accessible modal with proper ARIA attributes
- [x] All exports wrapped in try/finally — UI never gets stuck in loading state
- [x] `fetchTransactionHistory` pre-existing missing definition fixed
