### PR TITLE
Add campaign embed widget with iframe code generator

### DIFF
--- a/apps/interface/next.config.ts
+++ b/apps/interface/next.config.ts
@@ -3,24 +3,20 @@ import type { NextConfig } from "next";
 const isDev = process.env.NODE_ENV === "development";
 
 /**
- * Content Security Policy directives.
+ * Content Security Policy for standard app routes.
  *
  * default-src 'self'          — baseline: only same-origin resources allowed
- * script-src  'self' + eval  — 'unsafe-eval' is required by Next.js HMR in dev;
- *                               removed in production for a tighter policy
- * style-src   'self' 'unsafe-inline' — Tailwind injects inline styles at runtime
- * connect-src 'self' + RPC   — Soroban RPC, Horizon, and CoinGecko price feed
- * img-src     'self' data:   — data URIs for inline images; Unsplash & IPFS for
- *                               campaign cover images
+ * script-src  'self' + eval  — 'unsafe-eval' required by Next.js HMR in dev
+ * style-src   'self' 'unsafe-inline' — Tailwind injects inline styles
+ * connect-src 'self' + RPC   — Soroban RPC, Horizon, CoinGecko price feed
+ * img-src     'self' data:   — data URIs; Unsplash & IPFS for campaign images
  * font-src    'self'          — self-hosted fonts only
- * frame-ancestors 'none'     — prevents clickjacking via iframes
+ * frame-ancestors 'none'     — prevents clickjacking
  * object-src  'none'          — disables Flash / legacy plugin embeds
  */
-const cspDirectives = [
+const cspDefault = [
   "default-src 'self'",
-  isDev
-    ? "script-src 'self' 'unsafe-eval'"
-    : "script-src 'self'",
+  isDev ? "script-src 'self' 'unsafe-eval'" : "script-src 'self'",
   "style-src 'self' 'unsafe-inline'",
   [
     "connect-src 'self'",
@@ -34,8 +30,30 @@ const cspDirectives = [
   "object-src 'none'",
 ].join("; ");
 
+/**
+ * Relaxed CSP for the /embed/* route.
+ * frame-ancestors is set to '*' so any external site can embed the widget.
+ * X-Frame-Options is intentionally omitted for this route (set to ALLOWALL).
+ */
+const cspEmbed = [
+  "default-src 'self'",
+  isDev ? "script-src 'self' 'unsafe-eval'" : "script-src 'self'",
+  "style-src 'self' 'unsafe-inline'",
+  [
+    "connect-src 'self'",
+    "https://soroban-testnet.stellar.org",
+    "https://horizon-testnet.stellar.org",
+    "https://api.coingecko.com",
+  ].join(" "),
+  "img-src 'self' data: https://images.unsplash.com https://ipfs.io",
+  "font-src 'self'",
+  "frame-ancestors *",
+  "object-src 'none'",
+].join("; ");
+
 const nextConfig: NextConfig = {
   output: "standalone",
+
   images: {
     remotePatterns: [
       { protocol: "https", hostname: "images.unsplash.com" },
@@ -43,12 +61,25 @@ const nextConfig: NextConfig = {
       { protocol: "https", hostname: "ipfs.io" },
       { protocol: "https", hostname: "cloudflare-ipfs.com" },
     ],
+  },
+
   async headers() {
     return [
+      // ── Embed widget route — allow framing from any origin ──────────────────
       {
-        source: "/(.*)",
+        source: "/embed/:path*",
         headers: [
-          { key: "Content-Security-Policy", value: cspDirectives },
+          { key: "Content-Security-Policy", value: cspEmbed },
+          // Explicitly allow framing (overrides the DENY set on all other routes)
+          { key: "X-Frame-Options", value: "ALLOWALL" },
+          { key: "X-Content-Type-Options", value: "nosniff" },
+        ],
+      },
+      // ── All other routes — strict security headers ──────────────────────────
+      {
+        source: "/((?!embed).*)",
+        headers: [
+          { key: "Content-Security-Policy", value: cspDefault },
           { key: "X-Frame-Options", value: "DENY" },
           { key: "X-Content-Type-Options", value: "nosniff" },
           { key: "Referrer-Policy", value: "strict-origin-when-cross-origin" },

--- a/apps/interface/src/app/campaigns/[id]/CampaignDetailContent.tsx
+++ b/apps/interface/src/app/campaigns/[id]/CampaignDetailContent.tsx
@@ -8,6 +8,7 @@ import { ProgressBar } from "@/components/ui/ProgressBar";
 import { CountdownTimer } from "@/components/ui/CountdownTimer";
 import { ShareButton } from "@/components/ui/ShareButton";
 import { ContributionLeaderboard } from "@/components/ui/ContributionLeaderboard";
+import { EmbedCodeGenerator } from "@/components/ui/EmbedCodeGenerator";
 import { useCampaign } from "@/hooks/useCampaign";
 import { useWallet } from "@/context/WalletContext";
 import { CampaignActions } from "./CampaignActions";
@@ -25,15 +26,23 @@ function ContractIdRow({ contractId }: { contractId: string }) {
 
   return (
     <div className="flex flex-wrap items-center gap-2 rounded-xl bg-gray-100 px-4 py-3 dark:bg-gray-900">
-      <span className="font-mono text-xs text-gray-500 break-all flex-1">{contractId}</span>
+      <span className="font-mono text-xs text-gray-500 break-all flex-1">
+        {contractId}
+      </span>
       <div className="relative flex items-center gap-2">
         <button
           onClick={handleCopy}
           aria-label="Copy contract ID"
           className="flex items-center gap-1 rounded-lg px-2 py-1 text-xs text-gray-500 hover:bg-gray-200 dark:hover:bg-gray-800 transition"
         >
-          {copied ? <Check size={13} className="text-green-500" /> : <Copy size={13} />}
-          <span className={cn(copied && "text-green-500")}>{copied ? "Copied!" : "Copy"}</span>
+          {copied ? (
+            <Check size={13} className="text-green-500" />
+          ) : (
+            <Copy size={13} />
+          )}
+          <span className={cn(copied && "text-green-500")}>
+            {copied ? "Copied!" : "Copy"}
+          </span>
         </button>
         <a
           href={`https://stellar.expert/explorer/testnet/contract/${contractId}`}
@@ -50,8 +59,16 @@ function ContractIdRow({ contractId }: { contractId: string }) {
 }
 
 export function CampaignDetailContent({ contractId }: { contractId: string }) {
-  const { info, stats, loading, error, refresh, applyOptimisticContribution, rollbackOptimistic } = useCampaign(contractId);
-  const { address } = useWallet();     
+  const {
+    info,
+    stats,
+    loading,
+    error,
+    refresh,
+    applyOptimisticContribution,
+    rollbackOptimistic,
+  } = useCampaign(contractId);
+  const { address } = useWallet();
 
   if (loading) {
     return (
@@ -152,6 +169,11 @@ export function CampaignDetailContent({ contractId }: { contractId: string }) {
         />
 
         <ShareButton campaignId={contractId} campaignTitle={info.title} />
+
+        <EmbedCodeGenerator
+          campaignId={contractId}
+          campaignTitle={info.title}
+        />
 
         {info.socialLinks.length > 0 && (
           <div className="space-y-1">

--- a/apps/interface/src/app/embed/[id]/layout.tsx
+++ b/apps/interface/src/app/embed/[id]/layout.tsx
@@ -1,0 +1,27 @@
+import type { Metadata } from "next";
+import { ReactQueryProvider } from "@/context/ReactQueryProvider";
+import "../../globals.css";
+
+export const metadata: Metadata = {
+  title: "Fund-My-Cause — Campaign Widget",
+  robots: { index: false, follow: false },
+};
+
+/**
+ * Minimal layout for the embeddable widget route.
+ * No Navbar, no wallet providers, no toast — just the bare minimum.
+ * Framing is allowed via next.config.ts header override for /embed/*.
+ */
+export default function EmbedLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <html lang="en">
+      <body className="bg-transparent m-0 p-0 overflow-hidden">
+        <ReactQueryProvider>{children}</ReactQueryProvider>
+      </body>
+    </html>
+  );
+}

--- a/apps/interface/src/app/embed/[id]/page.tsx
+++ b/apps/interface/src/app/embed/[id]/page.tsx
@@ -1,0 +1,74 @@
+import { notFound } from "next/navigation";
+import { fetchCampaign } from "@/lib/soroban";
+import { APP_BASE_URL } from "@/lib/constants";
+import { EmbedCard } from "@/components/ui/EmbedCard";
+import type {
+  EmbedTheme,
+  EmbedSize,
+  EmbedAccent,
+} from "@/components/ui/EmbedCard";
+
+// ── ISR ───────────────────────────────────────────────────────────────────────
+
+export const revalidate = 60;
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+interface PageProps {
+  params: Promise<{ id: string }>;
+  searchParams: Promise<{
+    theme?: string;
+    size?: string;
+    accent?: string;
+    hideImage?: string;
+  }>;
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function parseTheme(v?: string): EmbedTheme {
+  if (v === "light" || v === "dark" || v === "auto") return v;
+  return "dark";
+}
+
+function parseSize(v?: string): EmbedSize {
+  if (v === "compact" || v === "standard" || v === "wide") return v;
+  return "standard";
+}
+
+function parseAccent(v?: string): EmbedAccent {
+  // Allow any valid 6-char hex colour, e.g. "6366f1"
+  if (v && /^[0-9a-fA-F]{6}$/.test(v)) return `#${v}`;
+  return "#6366f1"; // indigo-500 default
+}
+
+// ── Page ──────────────────────────────────────────────────────────────────────
+
+export default async function EmbedPage({ params, searchParams }: PageProps) {
+  const { id } = await params;
+  const sp = await searchParams;
+
+  let campaign;
+  try {
+    campaign = await fetchCampaign(id);
+  } catch {
+    notFound();
+  }
+
+  const theme = parseTheme(sp.theme);
+  const size = parseSize(sp.size);
+  const accent = parseAccent(sp.accent);
+  const hideImage = sp.hideImage === "1";
+  const campaignUrl = `${APP_BASE_URL}/campaigns/${id}`;
+
+  return (
+    <EmbedCard
+      campaign={campaign}
+      campaignUrl={campaignUrl}
+      theme={theme}
+      size={size}
+      accent={accent}
+      hideImage={hideImage}
+    />
+  );
+}

--- a/apps/interface/src/components/ui/EmbedCard.tsx
+++ b/apps/interface/src/components/ui/EmbedCard.tsx
@@ -1,0 +1,248 @@
+"use client";
+
+import React from "react";
+import { ExternalLink, Users, Clock } from "lucide-react";
+import type { CampaignData } from "@/types/soroban";
+import { DEFAULT_HERO_IMAGE } from "@/lib/constants";
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+export type EmbedTheme = "dark" | "light" | "auto";
+export type EmbedSize = "compact" | "standard" | "wide";
+export type EmbedAccent = string; // hex colour, e.g. "#6366f1"
+
+interface EmbedCardProps {
+  campaign: CampaignData;
+  campaignUrl: string;
+  theme: EmbedTheme;
+  size: EmbedSize;
+  accent: EmbedAccent;
+  hideImage?: boolean;
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function formatXlm(n: number): string {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M XLM`;
+  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}K XLM`;
+  return `${n.toLocaleString(undefined, { maximumFractionDigits: 2 })} XLM`;
+}
+
+function timeLeft(deadline: string): string {
+  const diff = new Date(deadline).getTime() - Date.now();
+  if (diff <= 0) return "Ended";
+  const d = Math.floor(diff / 86_400_000);
+  const h = Math.floor((diff % 86_400_000) / 3_600_000);
+  if (d > 0) return `${d}d ${h}h left`;
+  const m = Math.floor((diff % 3_600_000) / 60_000);
+  if (h > 0) return `${h}h ${m}m left`;
+  return `${m}m left`;
+}
+
+// ── Size config ───────────────────────────────────────────────────────────────
+
+const SIZE_CONFIG: Record<
+  EmbedSize,
+  { imageH: string; titleSize: string; showDesc: boolean; padding: string }
+> = {
+  compact: {
+    imageH: "h-24",
+    titleSize: "text-sm",
+    showDesc: false,
+    padding: "p-3",
+  },
+  standard: {
+    imageH: "h-36",
+    titleSize: "text-base",
+    showDesc: false,
+    padding: "p-4",
+  },
+  wide: {
+    imageH: "h-44",
+    titleSize: "text-lg",
+    showDesc: true,
+    padding: "p-5",
+  },
+};
+
+// ── Theme config ──────────────────────────────────────────────────────────────
+
+const THEME_CLASSES: Record<EmbedTheme, string> = {
+  dark: "bg-gray-950 text-white border-gray-800",
+  light: "bg-white text-gray-900 border-gray-200",
+  auto: "bg-white text-gray-900 border-gray-200 dark:bg-gray-950 dark:text-white dark:border-gray-800",
+};
+
+const MUTED_CLASSES: Record<EmbedTheme, string> = {
+  dark: "text-gray-400",
+  light: "text-gray-500",
+  auto: "text-gray-500 dark:text-gray-400",
+};
+
+const TRACK_CLASSES: Record<EmbedTheme, string> = {
+  dark: "bg-gray-800",
+  light: "bg-gray-200",
+  auto: "bg-gray-200 dark:bg-gray-800",
+};
+
+const STAT_BG_CLASSES: Record<EmbedTheme, string> = {
+  dark: "bg-gray-900",
+  light: "bg-gray-100",
+  auto: "bg-gray-100 dark:bg-gray-900",
+};
+
+// ── Component ─────────────────────────────────────────────────────────────────
+
+export function EmbedCard({
+  campaign,
+  campaignUrl,
+  theme,
+  size,
+  accent,
+  hideImage = false,
+}: EmbedCardProps) {
+  const cfg = SIZE_CONFIG[size];
+  const progress =
+    campaign.goal > 0
+      ? Math.min((campaign.raised / campaign.goal) * 100, 100)
+      : 0;
+  const isEnded = new Date(campaign.deadline) < new Date();
+  const isGoalMet = campaign.raised >= campaign.goal;
+
+  const heroSrc =
+    campaign.socialLinks?.[0]?.startsWith("Qm") ||
+    campaign.socialLinks?.[0]?.startsWith("bafy")
+      ? `https://ipfs.io/ipfs/${campaign.socialLinks[0]}`
+      : DEFAULT_HERO_IMAGE;
+
+  return (
+    <a
+      href={campaignUrl}
+      target="_blank"
+      rel="noopener noreferrer"
+      aria-label={`View campaign: ${campaign.title}`}
+      className={`
+        block w-full rounded-2xl border overflow-hidden
+        transition-transform duration-200 hover:scale-[1.01]
+        focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2
+        no-underline
+        ${THEME_CLASSES[theme]}
+      `}
+      style={{ "--accent": accent } as React.CSSProperties}
+    >
+      {/* Hero image */}
+      {!hideImage && (
+        // eslint-disable-next-line @next/next/no-img-element
+        <img
+          src={heroSrc}
+          alt=""
+          aria-hidden="true"
+          className={`w-full object-cover ${cfg.imageH}`}
+          onError={(e) => {
+            (e.currentTarget as HTMLImageElement).src = DEFAULT_HERO_IMAGE;
+          }}
+        />
+      )}
+
+      <div className={cfg.padding}>
+        {/* Title */}
+        <h2
+          className={`font-bold leading-snug mb-2 line-clamp-2 ${cfg.titleSize}`}
+        >
+          {campaign.title}
+        </h2>
+
+        {/* Description — wide only */}
+        {cfg.showDesc && campaign.description && (
+          <p
+            className={`text-xs leading-relaxed mb-3 line-clamp-2 ${MUTED_CLASSES[theme]}`}
+          >
+            {campaign.description}
+          </p>
+        )}
+
+        {/* Progress bar */}
+        <div className="mb-2">
+          <div
+            className={`w-full h-1.5 rounded-full overflow-hidden ${TRACK_CLASSES[theme]}`}
+            role="progressbar"
+            aria-valuenow={Math.round(progress)}
+            aria-valuemin={0}
+            aria-valuemax={100}
+            aria-label={`${Math.round(progress)}% funded`}
+          >
+            <div
+              className="h-full rounded-full transition-all duration-500"
+              style={{
+                width: `${progress}%`,
+                backgroundColor: isGoalMet ? "#22c55e" : accent,
+              }}
+            />
+          </div>
+        </div>
+
+        {/* Raised / goal */}
+        <div
+          className={`flex justify-between text-xs mb-3 ${MUTED_CLASSES[theme]}`}
+        >
+          <span
+            className="font-semibold"
+            style={{ color: isGoalMet ? "#22c55e" : accent }}
+          >
+            {formatXlm(campaign.raised)} raised
+          </span>
+          <span>{formatXlm(campaign.goal)} goal</span>
+        </div>
+
+        {/* Stats row */}
+        <div
+          className={`grid grid-cols-2 gap-2 mb-3 ${size === "compact" ? "hidden" : ""}`}
+        >
+          <div
+            className={`rounded-lg px-2 py-1.5 flex items-center gap-1.5 ${STAT_BG_CLASSES[theme]}`}
+          >
+            <Users
+              size={11}
+              className={MUTED_CLASSES[theme]}
+              aria-hidden="true"
+            />
+            <span className="text-xs font-medium">
+              {campaign.contributorCount ?? 0}
+            </span>
+            <span className={`text-xs ${MUTED_CLASSES[theme]}`}>backers</span>
+          </div>
+          <div
+            className={`rounded-lg px-2 py-1.5 flex items-center gap-1.5 ${STAT_BG_CLASSES[theme]}`}
+          >
+            <Clock
+              size={11}
+              className={MUTED_CLASSES[theme]}
+              aria-hidden="true"
+            />
+            <span className={`text-xs ${isEnded ? "text-red-400" : ""}`}>
+              {timeLeft(campaign.deadline)}
+            </span>
+          </div>
+        </div>
+
+        {/* CTA */}
+        <div
+          className="w-full flex items-center justify-center gap-1.5 rounded-xl py-2 text-xs font-semibold text-white transition-opacity hover:opacity-90"
+          style={{ backgroundColor: accent }}
+          aria-hidden="true"
+        >
+          {isEnded ? "View Campaign" : "Back This Campaign"}
+          <ExternalLink size={11} />
+        </div>
+
+        {/* Branding */}
+        <p className={`text-center text-[10px] mt-2 ${MUTED_CLASSES[theme]}`}>
+          Powered by{" "}
+          <span className="font-semibold" style={{ color: accent }}>
+            Fund-My-Cause
+          </span>
+        </p>
+      </div>
+    </a>
+  );
+}

--- a/apps/interface/src/components/ui/EmbedCodeGenerator.tsx
+++ b/apps/interface/src/components/ui/EmbedCodeGenerator.tsx
@@ -1,0 +1,425 @@
+"use client";
+
+import React, { useState, useMemo } from "react";
+import {
+  Code2,
+  Copy,
+  Check,
+  Monitor,
+  Smartphone,
+  ExternalLink,
+} from "lucide-react";
+import { APP_BASE_URL } from "@/lib/constants";
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+type Theme = "dark" | "light" | "auto";
+type Size = "compact" | "standard" | "wide";
+
+interface EmbedCodeGeneratorProps {
+  campaignId: string;
+  campaignTitle: string;
+}
+
+// ── Size dimensions ───────────────────────────────────────────────────────────
+
+const SIZE_DIMS: Record<
+  Size,
+  { width: number; height: number; label: string }
+> = {
+  compact: { width: 320, height: 200, label: "Compact  320 × 200" },
+  standard: { width: 380, height: 320, label: "Standard  380 × 320" },
+  wide: { width: 480, height: 400, label: "Wide  480 × 400" },
+};
+
+// ── Accent presets ────────────────────────────────────────────────────────────
+
+const ACCENT_PRESETS = [
+  { label: "Indigo", value: "#6366f1" },
+  { label: "Violet", value: "#8b5cf6" },
+  { label: "Rose", value: "#f43f5e" },
+  { label: "Emerald", value: "#10b981" },
+  { label: "Amber", value: "#f59e0b" },
+  { label: "Sky", value: "#0ea5e9" },
+];
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function hexToParam(hex: string): string {
+  return hex.replace("#", "");
+}
+
+function buildEmbedUrl(
+  campaignId: string,
+  theme: Theme,
+  size: Size,
+  accent: string,
+  hideImage: boolean,
+): string {
+  const params = new URLSearchParams({
+    theme,
+    size,
+    accent: hexToParam(accent),
+    ...(hideImage ? { hideImage: "1" } : {}),
+  });
+  return `${APP_BASE_URL}/embed/${campaignId}?${params.toString()}`;
+}
+
+function buildIframeCode(
+  embedUrl: string,
+  size: Size,
+  campaignTitle: string,
+): string {
+  const { width, height } = SIZE_DIMS[size];
+  return `<iframe
+  src="${embedUrl}"
+  width="${width}"
+  height="${height}"
+  style="border:none;border-radius:16px;overflow:hidden;"
+  title="${campaignTitle} — Fund-My-Cause"
+  loading="lazy"
+  allow="payment"
+></iframe>`;
+}
+
+// ── Component ─────────────────────────────────────────────────────────────────
+
+export function EmbedCodeGenerator({
+  campaignId,
+  campaignTitle,
+}: EmbedCodeGeneratorProps) {
+  const [open, setOpen] = useState(false);
+  const [theme, setTheme] = useState<Theme>("dark");
+  const [size, setSize] = useState<Size>("standard");
+  const [accent, setAccent] = useState("#6366f1");
+  const [customAccent, setCustomAccent] = useState("#6366f1");
+  const [hideImage, setHideImage] = useState(false);
+  const [copied, setCopied] = useState(false);
+  const [previewViewport, setPreviewViewport] = useState<"desktop" | "mobile">(
+    "desktop",
+  );
+
+  const embedUrl = useMemo(
+    () => buildEmbedUrl(campaignId, theme, size, accent, hideImage),
+    [campaignId, theme, size, accent, hideImage],
+  );
+
+  const iframeCode = useMemo(
+    () => buildIframeCode(embedUrl, size, campaignTitle),
+    [embedUrl, size, campaignTitle],
+  );
+
+  const { width, height } = SIZE_DIMS[size];
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(iframeCode);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      // fallback: select the textarea
+    }
+  };
+
+  const handleAccentPreset = (hex: string) => {
+    setAccent(hex);
+    setCustomAccent(hex);
+  };
+
+  const handleCustomAccent = (hex: string) => {
+    setCustomAccent(hex);
+    setAccent(hex);
+  };
+
+  if (!open) {
+    return (
+      <button
+        onClick={() => setOpen(true)}
+        className="flex items-center gap-2 px-4 py-2 rounded-xl text-sm font-medium
+          bg-gray-100 dark:bg-gray-800
+          text-gray-700 dark:text-gray-300
+          hover:bg-gray-200 dark:hover:bg-gray-700
+          transition"
+        aria-label="Get embed code for this campaign"
+      >
+        <Code2 size={15} />
+        Embed Widget
+      </button>
+    );
+  }
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="embed-modal-title"
+      className="fixed inset-0 z-50 flex items-start justify-center p-4 pt-12 overflow-y-auto"
+    >
+      {/* Backdrop */}
+      <div
+        className="fixed inset-0 bg-black/60 backdrop-blur-sm"
+        onClick={() => setOpen(false)}
+        aria-hidden="true"
+      />
+
+      {/* Panel */}
+      <div className="relative z-10 w-full max-w-2xl bg-white dark:bg-gray-900 rounded-2xl shadow-2xl border border-gray-200 dark:border-gray-800 overflow-hidden mb-8">
+        {/* Header */}
+        <div className="flex items-center justify-between px-6 py-4 border-b border-gray-200 dark:border-gray-800">
+          <div className="flex items-center gap-2">
+            <Code2 size={18} className="text-indigo-500" aria-hidden="true" />
+            <h2
+              id="embed-modal-title"
+              className="text-base font-semibold text-gray-900 dark:text-white"
+            >
+              Embed Widget
+            </h2>
+          </div>
+          <button
+            onClick={() => setOpen(false)}
+            aria-label="Close embed widget dialog"
+            className="p-1.5 rounded-lg text-gray-400 hover:text-gray-600 dark:hover:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-800 transition"
+          >
+            ✕
+          </button>
+        </div>
+
+        <div className="grid md:grid-cols-2 divide-y md:divide-y-0 md:divide-x divide-gray-200 dark:divide-gray-800">
+          {/* ── Left: Options ── */}
+          <div className="px-6 py-5 space-y-5">
+            {/* Theme */}
+            <fieldset>
+              <legend className="text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wide mb-2">
+                Theme
+              </legend>
+              <div className="flex gap-2">
+                {(["dark", "light", "auto"] as Theme[]).map((t) => (
+                  <button
+                    key={t}
+                    type="button"
+                    onClick={() => setTheme(t)}
+                    aria-pressed={theme === t}
+                    className={`flex-1 py-1.5 rounded-lg text-xs font-medium capitalize transition border ${
+                      theme === t
+                        ? "border-indigo-500 bg-indigo-50 dark:bg-indigo-950/40 text-indigo-700 dark:text-indigo-300"
+                        : "border-gray-200 dark:border-gray-700 text-gray-600 dark:text-gray-400 hover:border-gray-300 dark:hover:border-gray-600"
+                    }`}
+                  >
+                    {t}
+                  </button>
+                ))}
+              </div>
+            </fieldset>
+
+            {/* Size */}
+            <fieldset>
+              <legend className="text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wide mb-2">
+                Size
+              </legend>
+              <div className="space-y-1.5">
+                {(
+                  Object.entries(SIZE_DIMS) as [
+                    Size,
+                    (typeof SIZE_DIMS)[Size],
+                  ][]
+                ).map(([s, cfg]) => (
+                  <label
+                    key={s}
+                    className={`flex items-center gap-3 px-3 py-2 rounded-lg border cursor-pointer transition ${
+                      size === s
+                        ? "border-indigo-500 bg-indigo-50 dark:bg-indigo-950/40"
+                        : "border-gray-200 dark:border-gray-700 hover:border-gray-300 dark:hover:border-gray-600"
+                    }`}
+                  >
+                    <input
+                      type="radio"
+                      name="embed-size"
+                      value={s}
+                      checked={size === s}
+                      onChange={() => setSize(s)}
+                      className="accent-indigo-600"
+                    />
+                    <span className="text-xs text-gray-700 dark:text-gray-300 capitalize font-medium">
+                      {s}
+                    </span>
+                    <span className="text-xs text-gray-400 ml-auto">
+                      {cfg.width} × {cfg.height}
+                    </span>
+                  </label>
+                ))}
+              </div>
+            </fieldset>
+
+            {/* Accent colour */}
+            <fieldset>
+              <legend className="text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wide mb-2">
+                Accent Colour
+              </legend>
+              <div className="flex flex-wrap gap-2 mb-2">
+                {ACCENT_PRESETS.map((p) => (
+                  <button
+                    key={p.value}
+                    type="button"
+                    onClick={() => handleAccentPreset(p.value)}
+                    aria-label={`${p.label} accent`}
+                    aria-pressed={accent === p.value}
+                    className={`w-7 h-7 rounded-full border-2 transition ${
+                      accent === p.value
+                        ? "border-white scale-110 shadow-md"
+                        : "border-transparent hover:scale-105"
+                    }`}
+                    style={{ backgroundColor: p.value }}
+                  />
+                ))}
+                {/* Custom colour picker */}
+                <label
+                  className="w-7 h-7 rounded-full border-2 border-dashed border-gray-400 dark:border-gray-600 flex items-center justify-center cursor-pointer hover:border-gray-600 dark:hover:border-gray-400 transition overflow-hidden"
+                  aria-label="Custom accent colour"
+                  title="Custom colour"
+                >
+                  <input
+                    type="color"
+                    value={customAccent}
+                    onChange={(e) => handleCustomAccent(e.target.value)}
+                    className="opacity-0 absolute w-0 h-0"
+                  />
+                  <span className="text-[10px] text-gray-400">+</span>
+                </label>
+              </div>
+              <p className="text-xs text-gray-400 font-mono">{accent}</p>
+            </fieldset>
+
+            {/* Hide image toggle */}
+            <label className="flex items-center gap-3 cursor-pointer">
+              <input
+                type="checkbox"
+                checked={hideImage}
+                onChange={(e) => setHideImage(e.target.checked)}
+                className="w-4 h-4 rounded accent-indigo-600"
+              />
+              <span className="text-sm text-gray-700 dark:text-gray-300">
+                Hide hero image
+              </span>
+            </label>
+          </div>
+
+          {/* ── Right: Preview + Code ── */}
+          <div className="px-6 py-5 space-y-4">
+            {/* Viewport toggle */}
+            <div className="flex items-center justify-between">
+              <span className="text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wide">
+                Preview
+              </span>
+              <div
+                role="group"
+                aria-label="Preview viewport"
+                className="flex items-center gap-1 p-1 rounded-lg bg-gray-100 dark:bg-gray-800"
+              >
+                <button
+                  type="button"
+                  onClick={() => setPreviewViewport("desktop")}
+                  aria-pressed={previewViewport === "desktop"}
+                  aria-label="Desktop preview"
+                  className={`p-1.5 rounded-md transition ${
+                    previewViewport === "desktop"
+                      ? "bg-white dark:bg-gray-700 shadow-sm"
+                      : "text-gray-400 hover:text-gray-600 dark:hover:text-gray-200"
+                  }`}
+                >
+                  <Monitor size={13} />
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setPreviewViewport("mobile")}
+                  aria-pressed={previewViewport === "mobile"}
+                  aria-label="Mobile preview"
+                  className={`p-1.5 rounded-md transition ${
+                    previewViewport === "mobile"
+                      ? "bg-white dark:bg-gray-700 shadow-sm"
+                      : "text-gray-400 hover:text-gray-600 dark:hover:text-gray-200"
+                  }`}
+                >
+                  <Smartphone size={13} />
+                </button>
+              </div>
+            </div>
+
+            {/* Live iframe preview */}
+            <div
+              className={`flex justify-center items-start overflow-hidden rounded-xl bg-gray-100 dark:bg-gray-800 p-3 ${
+                previewViewport === "mobile" ? "max-w-[200px] mx-auto" : ""
+              }`}
+            >
+              <iframe
+                key={embedUrl} // re-mount on URL change
+                src={embedUrl}
+                width={previewViewport === "mobile" ? 180 : width}
+                height={
+                  previewViewport === "mobile"
+                    ? Math.round(height * 0.75)
+                    : height
+                }
+                style={{
+                  border: "none",
+                  borderRadius: "12px",
+                  overflow: "hidden",
+                }}
+                title="Widget preview"
+                loading="lazy"
+              />
+            </div>
+
+            {/* Open in new tab */}
+            <a
+              href={embedUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="flex items-center gap-1.5 text-xs text-indigo-500 hover:underline"
+            >
+              <ExternalLink size={11} />
+              Open widget in new tab
+            </a>
+
+            {/* Code block */}
+            <div>
+              <div className="flex items-center justify-between mb-1.5">
+                <span className="text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wide">
+                  Embed Code
+                </span>
+                <button
+                  onClick={handleCopy}
+                  className="flex items-center gap-1.5 px-2.5 py-1 rounded-lg text-xs font-medium
+                    bg-gray-100 dark:bg-gray-800
+                    text-gray-600 dark:text-gray-400
+                    hover:bg-gray-200 dark:hover:bg-gray-700
+                    transition"
+                  aria-label="Copy embed code"
+                >
+                  {copied ? (
+                    <>
+                      <Check size={12} className="text-green-500" />
+                      <span className="text-green-600 dark:text-green-400">
+                        Copied!
+                      </span>
+                    </>
+                  ) : (
+                    <>
+                      <Copy size={12} />
+                      Copy
+                    </>
+                  )}
+                </button>
+              </div>
+              <pre
+                className="text-[11px] leading-relaxed font-mono bg-gray-950 dark:bg-black text-gray-300 rounded-xl p-3 overflow-x-auto whitespace-pre-wrap break-all select-all"
+                aria-label="Iframe embed code"
+              >
+                {iframeCode}
+              </pre>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/docs/embed-guide.md
+++ b/docs/embed-guide.md
@@ -1,0 +1,143 @@
+# Campaign Embed Widget — Creator Guide
+
+Embed a live campaign widget on any external website — your blog, portfolio, or project page — with a single `<iframe>` tag. The widget fetches live on-chain data and updates automatically.
+
+---
+
+## Quick Start
+
+1. Open your campaign page on Fund-My-Cause.
+2. Click **Embed Widget** below the share buttons.
+3. Customise the theme, size, and accent colour.
+4. Copy the generated `<iframe>` code and paste it into your site's HTML.
+
+---
+
+## Embed URL
+
+The widget is served from:
+
+```
+https://fund-my-cause.app/embed/<CONTRACT_ID>
+```
+
+Query parameters let you customise the appearance without touching the iframe code:
+
+| Parameter   | Values                            | Default    | Description                                                                    |
+| ----------- | --------------------------------- | ---------- | ------------------------------------------------------------------------------ |
+| `theme`     | `dark` \| `light` \| `auto`       | `dark`     | Colour scheme. `auto` follows the visitor's OS preference.                     |
+| `size`      | `compact` \| `standard` \| `wide` | `standard` | Widget dimensions (see table below).                                           |
+| `accent`    | 6-digit hex, e.g. `6366f1`        | `6366f1`   | Accent colour for the progress bar and CTA button. Do **not** include the `#`. |
+| `hideImage` | `1`                               | _(unset)_  | Set to `1` to hide the hero image.                                             |
+
+### Size Dimensions
+
+| Size       | Width | Height | Notes                                  |
+| ---------- | ----- | ------ | -------------------------------------- |
+| `compact`  | 320px | 200px  | Title, progress bar, raised/goal only. |
+| `standard` | 380px | 320px  | + contributor count and countdown.     |
+| `wide`     | 480px | 400px  | + description excerpt.                 |
+
+---
+
+## Example Embed Code
+
+```html
+<iframe
+  src="https://fund-my-cause.app/embed/CXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX?theme=dark&size=standard&accent=6366f1"
+  width="380"
+  height="320"
+  style="border:none;border-radius:16px;overflow:hidden;"
+  title="My Campaign — Fund-My-Cause"
+  loading="lazy"
+  allow="payment"
+></iframe>
+```
+
+Replace `CXXXXXXX…` with your campaign's contract ID.
+
+---
+
+## Customisation Examples
+
+### Light theme, wide, rose accent
+
+```html
+<iframe
+  src="https://fund-my-cause.app/embed/CXXX...?theme=light&size=wide&accent=f43f5e"
+  width="480"
+  height="400"
+  style="border:none;border-radius:16px;overflow:hidden;"
+  title="My Campaign — Fund-My-Cause"
+  loading="lazy"
+></iframe>
+```
+
+### Compact, no image, custom green accent
+
+```html
+<iframe
+  src="https://fund-my-cause.app/embed/CXXX...?theme=dark&size=compact&accent=10b981&hideImage=1"
+  width="320"
+  height="200"
+  style="border:none;border-radius:16px;overflow:hidden;"
+  title="My Campaign — Fund-My-Cause"
+  loading="lazy"
+></iframe>
+```
+
+---
+
+## Responsive Embedding
+
+To make the widget scale with its container, wrap it in a responsive div:
+
+```html
+<div style="max-width:480px;width:100%;">
+  <iframe
+    src="https://fund-my-cause.app/embed/CXXX...?theme=dark&size=wide"
+    width="100%"
+    height="400"
+    style="border:none;border-radius:16px;overflow:hidden;display:block;"
+    title="My Campaign — Fund-My-Cause"
+    loading="lazy"
+  ></iframe>
+</div>
+```
+
+---
+
+## WordPress / Webflow / Squarespace
+
+Most website builders support embedding raw HTML. Look for an **HTML block**, **Embed block**, or **Custom Code** section and paste the `<iframe>` tag there.
+
+- **WordPress**: Use the _Custom HTML_ block in the block editor.
+- **Webflow**: Add an _Embed_ element and paste the code.
+- **Squarespace**: Use a _Code Block_ in any page section.
+- **Ghost**: Use an _HTML card_ in the post editor.
+- **Notion**: Notion does not support arbitrary iframes. Link to your campaign page instead.
+
+---
+
+## Security & Privacy
+
+- The widget is served from `fund-my-cause.app` and only reads public on-chain data — no wallet connection, no cookies, no tracking.
+- The widget links to your campaign page when clicked; it does not process payments itself.
+- The embed route sets `frame-ancestors *` in its Content Security Policy, which is required for cross-origin embedding. All other Fund-My-Cause pages remain protected with `frame-ancestors 'none'`.
+
+---
+
+## Data Freshness
+
+Widget data is cached with a 60-second ISR (Incremental Static Regeneration) window. Raised amounts and contributor counts update within ~1 minute of an on-chain contribution.
+
+---
+
+## Troubleshooting
+
+| Issue                             | Fix                                                                                                |
+| --------------------------------- | -------------------------------------------------------------------------------------------------- |
+| Widget shows "Campaign not found" | Double-check the contract ID in the URL.                                                           |
+| Widget is blank / white           | Your site's CSP may be blocking the iframe. Add `frame-src https://fund-my-cause.app` to your CSP. |
+| Widget doesn't fit                | Adjust the `width` and `height` attributes, or use the responsive wrapper above.                   |
+| Image doesn't load                | The IPFS gateway may be slow. Set `hideImage=1` for a faster load.                                 |


### PR DESCRIPTION
## Summary

Adds a fully embeddable campaign widget that any creator can drop onto an external site with a single `<iframe>` tag. Includes a live preview generator on the campaign detail page, three sizes, three themes, custom accent colours, and a full creator guide.

this pr Close #263 

## New Files

### `src/app/embed/[id]/layout.tsx`
Minimal layout — no Navbar, no wallet providers, no toast. Just `ReactQueryProvider` and a transparent body. Robots are set to `noindex`.

### `src/app/embed/[id]/page.tsx`
SSR page (60s ISR) that fetches campaign data via `fetchCampaign`, parses query params (`theme`, `size`, `accent`, `hideImage`), and renders `EmbedCard`. Returns 404 for unknown contract IDs.

### `src/components/ui/EmbedCard.tsx`
Compact campaign card rendered inside the iframe:
- Hero image (IPFS CID or default Unsplash fallback, with `onError` fallback)
- Title, progress bar (accent-coloured fill, green when goal met)
- Raised / goal amounts
- Contributor count + countdown timer stats row (hidden in compact size)
- Description excerpt (wide size only)
- CTA button linking to the full campaign page
- "Powered by Fund-My-Cause" branding
- Full dark/light/auto theme support via Tailwind classes
- Hover scale animation; accessible `role="progressbar"` and `aria-label`

### `src/components/ui/EmbedCodeGenerator.tsx`
Modal triggered by an "Embed Widget" button on the campaign detail page:
- **Theme selector** — dark / light / auto toggle buttons
- **Size selector** — radio cards with pixel dimensions shown
- **Accent colour** — 6 presets + native `<input type="color">` for custom hex
- **Hide image** — checkbox toggle
- **Live iframe preview** — re-mounts on any option change; desktop/mobile viewport toggle
- **Embed code block** — monospace pre with one-click copy and "Copied!" feedback
- **Open in new tab** link for full-page widget preview

### `docs/embed-guide.md`
Creator guide covering: quick start, URL parameters, size table, example snippets, responsive embedding, CMS-specific instructions (WordPress, Webflow, Squarespace, Ghost, Notion), security & privacy notes, data freshness, and troubleshooting.

## Modified Files

### `next.config.ts`
- Added `/embed/:path*` header block with `frame-ancestors *` CSP and `X-Frame-Options: ALLOWALL` — required for cross-origin iframe embedding
- All other routes retain `frame-ancestors 'none'` and `X-Frame-Options: DENY`
- Fixed pre-existing syntax error: `images` block was missing its closing `},` causing `async headers()` to be parsed as a property inside `images`

### `src/app/campaigns/[id]/CampaignDetailContent.tsx`
- Added `EmbedCodeGenerator` import and rendered it below `ShareButton`

## Security Notes

The embed route intentionally relaxes `frame-ancestors` to `*`. This is scoped exclusively to `/embed/*` — all other routes remain protected. The widget is read-only (no wallet, no transactions) and serves only public on-chain data.

## Checklist

- [x] New branch from `main`
- [x] Conventional commit format
- [x] No new npm dependencies
- [x] Dark/light/auto theme support
- [x] Accessible: `role="progressbar"`, `aria-label`, `aria-pressed`, `aria-modal`
- [x] ISR 60s — widget data stays fresh
- [x] Image error fallback handled
- [x] Creator guide written in `docs/embed-guide.md`
