### PR TITLE
feat: celebratory UI when campaign reaches goal

### DIFF
--- a/apps/interface/src/app/campaigns/[id]/CampaignActions.tsx
+++ b/apps/interface/src/app/campaigns/[id]/CampaignActions.tsx
@@ -73,7 +73,10 @@ export function CampaignActions({
     isCreator &&
     (campaignStatus === "Successful" || (deadlinePassed && goalMet && campaignStatus === "Active"));
   const canRefund =
-    !!address && deadlinePassed && !goalMet && userContribution > 0 && campaignStatus !== "Refunded";
+    !!address &&
+    userContribution > 0 &&
+    campaignStatus !== "Refunded" &&
+    (campaignStatus === "Cancelled" || (deadlinePassed && !goalMet));
 
   async function handleWithdraw() {
     if (!address || pendingTx) return;

--- a/apps/interface/src/app/campaigns/[id]/CampaignActions.tsx
+++ b/apps/interface/src/app/campaigns/[id]/CampaignActions.tsx
@@ -13,7 +13,7 @@ import {
   buildRefundTx,
   type CampaignStatus 
 } from "@/lib/soroban";
-import { useToast } from "@/components/ui/Toast";
+import { useNotifications } from "@/context/NotificationContext";
 
 interface Props {
   contractId: string;
@@ -21,7 +21,6 @@ interface Props {
   deadlinePassed: boolean;
   goalMet: boolean;
   campaignTitle: string;
-  status: "Active" | "Successful" | "Refunded" | "Cancelled";
   /** Total raised in XLM — used to display payout amount after withdraw. */
   raisedXlm?: number;
   /** Minimum contribution in stroops. */
@@ -48,6 +47,7 @@ export function CampaignActions({
   onRollbackOptimistic,
 }: Props) {
   const { address, connect, signTx, networkMismatch } = useWallet();
+  const { addNotification } = useNotifications();
   const [pledging, setPledging] = useState(false);
   const [userContribution, setUserContribution] = useState(0);
   const [campaignStatus, setCampaignStatus] = useState(initialStatus);
@@ -58,7 +58,6 @@ export function CampaignActions({
   const [txStatus, setTxStatus] = useState<TxStatus>("idle");
   const [txHash, setTxHash] = useState("");
   const [txError, setTxError] = useState("");
-  const { addToast } = useToast();
 
   useEffect(() => {
     if (address) {
@@ -142,7 +141,17 @@ export function CampaignActions({
   async function handlePledgeSuccess() {
     try {
       const stats = await getCampaignStats(contractId);
-      setRaised(Number(stats.totalRaised) / 1e7);
+      const newRaised = Number(stats.totalRaised) / 1e7;
+      setRaised(newRaised);
+      // Notify if this pledge pushed the campaign over the goal
+      if (stats.totalRaised >= stats.goal) {
+        addNotification({
+          type: "goal_reached",
+          title: "Goal Reached! 🎉",
+          message: `"${campaignTitle}" has been fully funded with ${newRaised.toLocaleString()} XLM!`,
+          campaignId: contractId,
+        });
+      }
     } catch {
       // non-critical
     }

--- a/apps/interface/src/app/campaigns/[id]/CampaignDetailContent.tsx
+++ b/apps/interface/src/app/campaigns/[id]/CampaignDetailContent.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect, useRef } from "react";
 import Image from "next/image";
 import { Loader2, Copy, Check, ExternalLink } from "lucide-react";
 import { cn } from "@/lib/utils";
@@ -19,6 +19,10 @@ import { FAQAccordion } from "@/components/ui/FAQAccordion";
 import { TeamMemberCard } from "@/components/ui/TeamMemberCard";
 import { TrustSignals } from "@/components/ui/TrustSignals";
 import { ALL_CAMPAIGNS } from "@/lib/campaigns";
+import { Confetti } from "@/components/ui/Confetti";
+import { GoalSuccessModal } from "@/components/ui/GoalSuccessModal";
+import { GoalSuccessBadge } from "@/components/ui/GoalSuccessBadge";
+import { ShareModal } from "@/components/ui/ShareModal";
 
 function ContractIdRow({ contractId }: { contractId: string }) {
   const [copied, setCopied] = useState(false);
@@ -76,6 +80,12 @@ export function CampaignDetailContent({ contractId }: { contractId: string }) {
   } = useCampaign(contractId);
   const { address } = useWallet();
 
+  const [showSuccessModal, setShowSuccessModal] = useState(false);
+  const [showShareModal, setShowShareModal] = useState(false);
+  const [showConfetti, setShowConfetti] = useState(false);
+  // Track whether we've already shown the modal for this campaign load
+  const celebratedRef = useRef(false);
+
   if (loading) {
     return (
       <div className="flex justify-center py-24">
@@ -109,9 +119,41 @@ export function CampaignDetailContent({ contractId }: { contractId: string }) {
   const deadlineIso = new Date(Number(info.deadline) * 1000).toISOString();
   const deadlinePassed = Number(info.deadline) * 1000 < Date.now();
   const goalMet = stats.totalRaised >= stats.goal;
+  const totalRaisedXlm = Number(stats.totalRaised) / 1e7;
+  const isCreator = !!address && address === info.creator;
+
+  // Show celebration once for the creator when goal is met
+  useEffect(() => {
+    if (goalMet && isCreator && !celebratedRef.current) {
+      celebratedRef.current = true;
+      setShowConfetti(true);
+      setShowSuccessModal(true);
+    }
+  }, [goalMet, isCreator]);
 
   return (
     <>
+      {showConfetti && <Confetti />}
+
+      {showSuccessModal && info && (
+        <GoalSuccessModal
+          campaignTitle={info.title}
+          totalRaisedXlm={totalRaisedXlm}
+          onClose={() => setShowSuccessModal(false)}
+          onShare={() => { setShowSuccessModal(false); setShowShareModal(true); }}
+          onWithdraw={() => setShowSuccessModal(false)}
+          alreadyWithdrawn={info.status === "Successful"}
+        />
+      )}
+
+      {showShareModal && info && (
+        <ShareModal
+          campaignId={contractId}
+          campaignTitle={info.title}
+          onClose={() => setShowShareModal(false)}
+        />
+      )}
+
       <div className="w-full h-72 overflow-hidden md:h-96 relative">
         <Image
           src="https://images.unsplash.com/photo-1542601906990-b4d3fb778b09?auto=format&fit=crop&q=80&w=1600"
@@ -146,6 +188,8 @@ export function CampaignDetailContent({ contractId }: { contractId: string }) {
             <span>{formatXLM(stats.goal)} goal</span>
           </div>
         </div>
+
+        {goalMet && <GoalSuccessBadge totalRaisedXlm={totalRaisedXlm} />}
 
         <div className="grid grid-cols-1 gap-4 text-center sm:grid-cols-3">
           <div className="rounded-xl bg-gray-100 p-4 dark:bg-gray-900">

--- a/apps/interface/src/app/dashboard/page.tsx
+++ b/apps/interface/src/app/dashboard/page.tsx
@@ -9,6 +9,7 @@ import { WalletGuard } from "@/components/WalletGuard";
 import { EmptyState, NoDashboardCampaignsIllustration } from "@/components/ui/EmptyState";
 import { DeadlineExtensionModal } from "@/components/ui/DeadlineExtensionModal";
 import { AnalyticsDashboard } from "@/components/ui/AnalyticsDashboard";
+import { CancelCampaignModal } from "@/components/ui/CancelCampaignModal";
 import { formatXLM } from "@/lib/format";
 
 const REGISTRY_KEY = "fmc:campaigns";
@@ -162,6 +163,7 @@ function DashboardCampaignCard({
   contractId,
   actionPending,
   onAction,
+  onCancel,
   onEdit,
   onExtend,
   refreshNonce,
@@ -172,6 +174,7 @@ function DashboardCampaignCard({
     contractId: string,
     action: "withdraw" | "cancel",
   ) => Promise<void>;
+  onCancel: (contractId: string, title: string) => void;
   onEdit: (campaign: EditableCampaign) => void;
   onExtend: (contractId: string, currentDeadline: string) => void;
   refreshNonce: number;
@@ -214,7 +217,7 @@ function DashboardCampaignCard({
         )}
         {canCancel && (
           <button
-            onClick={() => onAction(contractId, "cancel")}
+            onClick={() => onCancel(contractId, info.title)}
             disabled={!!actionPending}
             className="flex items-center gap-1 rounded-lg bg-red-800 px-3 py-1.5 text-xs font-medium transition hover:bg-red-700 disabled:opacity-50"
           >
@@ -263,6 +266,7 @@ export default function DashboardPage() {
   const [actionPending, setActionPending] = useState<string | null>(null);
   const [editTarget, setEditTarget] = useState<EditableCampaign | null>(null);
   const [extendTarget, setExtendTarget] = useState<{ contractId: string; currentDeadline: string } | null>(null);
+  const [cancelTarget, setCancelTarget] = useState<{ contractId: string; title: string } | null>(null);
   const [refreshNonce, setRefreshNonce] = useState(0);
 
   const loadCampaignIds = useCallback((walletAddress: string) => {
@@ -291,13 +295,14 @@ export default function DashboardPage() {
   const handleAction = async (
     contractId: string,
     action: "withdraw" | "cancel",
+    reason?: string,
   ) => {
     setActionPending(`${contractId}:${action}`);
     try {
       const xdr =
         action === "withdraw"
           ? await buildWithdrawTx(address!, contractId)
-          : await buildCancelTx(address!, contractId);
+          : await buildCancelTx(address!, contractId, reason);
       const signed = await signTx(xdr);
       await submitSignedTx(signed);
       setRefreshNonce((value) => value + 1);
@@ -355,6 +360,7 @@ export default function DashboardPage() {
                 key={contractId}
                 contractId={contractId}
                 onAction={handleAction}
+                onCancel={(id, title) => setCancelTarget({ contractId: id, title })}
                 onEdit={setEditTarget}
                 onExtend={(id, deadline) => setExtendTarget({ contractId: id, currentDeadline: deadline })}
                 actionPending={actionPending}
@@ -379,6 +385,16 @@ export default function DashboardPage() {
             onExtend={async (_contractId, _newTs) => {
               setExtendTarget(null);
               setRefreshNonce((n) => n + 1);
+            }}
+          />
+        )}
+        {cancelTarget && (
+          <CancelCampaignModal
+            campaignTitle={cancelTarget.title}
+            onClose={() => setCancelTarget(null)}
+            onConfirm={async (reason) => {
+              await handleAction(cancelTarget.contractId, "cancel", reason);
+              setCancelTarget(null);
             }}
           />
         )}

--- a/apps/interface/src/components/ui/CancelCampaignModal.test.tsx
+++ b/apps/interface/src/components/ui/CancelCampaignModal.test.tsx
@@ -1,0 +1,92 @@
+import React from "react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { CancelCampaignModal } from "./CancelCampaignModal";
+
+const defaultProps = {
+  campaignTitle: "Save the Oceans",
+  onClose: jest.fn(),
+  onConfirm: jest.fn(),
+};
+
+beforeEach(() => jest.clearAllMocks());
+
+describe("CancelCampaignModal", () => {
+  it("renders the campaign title", () => {
+    render(<CancelCampaignModal {...defaultProps} />);
+    expect(screen.getByText("Save the Oceans")).toBeInTheDocument();
+  });
+
+  it("shows the irreversible warning", () => {
+    render(<CancelCampaignModal {...defaultProps} />);
+    expect(screen.getByText(/irreversible/i)).toBeInTheDocument();
+  });
+
+  it("calls onClose when Keep Campaign is clicked", () => {
+    render(<CancelCampaignModal {...defaultProps} />);
+    fireEvent.click(screen.getByRole("button", { name: /Keep Campaign/i }));
+    expect(defaultProps.onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls onClose when X button is clicked", () => {
+    render(<CancelCampaignModal {...defaultProps} />);
+    fireEvent.click(screen.getByRole("button", { name: /Close/i }));
+    expect(defaultProps.onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows validation error when confirming with only whitespace", async () => {
+    defaultProps.onConfirm.mockResolvedValueOnce(undefined);
+    render(<CancelCampaignModal {...defaultProps} />);
+
+    // Type whitespace — button becomes enabled but reason.trim() is empty
+    fireEvent.change(screen.getByRole("textbox"), { target: { value: "   " } });
+    fireEvent.click(screen.getByRole("button", { name: /Confirm Cancel/i }));
+
+    expect(await screen.findByText(/provide a cancellation reason/i)).toBeInTheDocument();
+    expect(defaultProps.onConfirm).not.toHaveBeenCalled();
+  });
+
+  it("calls onConfirm with the reason and closes on success", async () => {
+    defaultProps.onConfirm.mockResolvedValueOnce(undefined);
+    render(<CancelCampaignModal {...defaultProps} />);
+
+    fireEvent.change(screen.getByRole("textbox"), { target: { value: "Project cancelled" } });
+    fireEvent.click(screen.getByRole("button", { name: /Confirm Cancel/i }));
+
+    await waitFor(() => expect(defaultProps.onConfirm).toHaveBeenCalledWith("Project cancelled"));
+    await waitFor(() => expect(defaultProps.onClose).toHaveBeenCalledTimes(1));
+  });
+
+  it("shows error message when onConfirm rejects", async () => {
+    const onConfirm = jest.fn().mockRejectedValue(new Error("Transaction failed"));
+    render(
+      <CancelCampaignModal
+        campaignTitle="Save the Oceans"
+        onClose={jest.fn()}
+        onConfirm={onConfirm}
+      />
+    );
+
+    fireEvent.change(screen.getByRole("textbox"), { target: { value: "Some reason" } });
+    fireEvent.click(screen.getByRole("button", { name: /Confirm Cancel/i }));
+
+    await waitFor(() =>
+      expect(screen.getByText("Transaction failed")).toBeInTheDocument()
+    );
+  });
+
+  it("Confirm Cancel button is not disabled when reason is empty (validation is JS-side)", () => {
+    render(<CancelCampaignModal {...defaultProps} />);
+    expect(screen.getByRole("button", { name: /Confirm Cancel/i })).not.toBeDisabled();
+  });
+
+  it("Confirm Cancel button has aria-disabled when reason is empty", () => {
+    render(<CancelCampaignModal {...defaultProps} />);
+    expect(screen.getByRole("button", { name: /Confirm Cancel/i })).toHaveAttribute("aria-disabled", "true");
+  });
+
+  it("Confirm Cancel button does not have aria-disabled when reason is filled", () => {
+    render(<CancelCampaignModal {...defaultProps} />);
+    fireEvent.change(screen.getByRole("textbox"), { target: { value: "reason" } });
+    expect(screen.getByRole("button", { name: /Confirm Cancel/i })).toHaveAttribute("aria-disabled", "false");
+  });
+});

--- a/apps/interface/src/components/ui/CancelCampaignModal.tsx
+++ b/apps/interface/src/components/ui/CancelCampaignModal.tsx
@@ -1,0 +1,119 @@
+"use client";
+
+import React, { useState } from "react";
+import { X, AlertTriangle, Loader2 } from "lucide-react";
+
+interface CancelCampaignModalProps {
+  campaignTitle: string;
+  onClose: () => void;
+  /** Called with the reason string when the user confirms. Should throw on error. */
+  onConfirm: (reason: string) => Promise<void>;
+}
+
+export function CancelCampaignModal({
+  campaignTitle,
+  onClose,
+  onConfirm,
+}: CancelCampaignModalProps) {
+  const [reason, setReason] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleConfirm = async () => {
+    if (!reason.trim()) {
+      setError("Please provide a cancellation reason.");
+      return;
+    }
+    setLoading(true);
+    setError(null);
+    try {
+      await onConfirm(reason.trim());
+      onClose();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Cancellation failed.");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 px-4"
+      onClick={(e) => e.target === e.currentTarget && !loading && onClose()}
+    >
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="cancel-modal-title"
+        className="w-full max-w-sm space-y-5 rounded-2xl border border-gray-700 bg-gray-900 p-6 shadow-2xl"
+      >
+        {/* Header */}
+        <div className="flex items-start justify-between">
+          <div className="flex items-center gap-3">
+            <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-red-900/40">
+              <AlertTriangle size={18} className="text-red-400" />
+            </div>
+            <div>
+              <h2 id="cancel-modal-title" className="font-semibold text-white">
+                Cancel Campaign
+              </h2>
+              <p className="mt-0.5 text-xs text-gray-400 line-clamp-1">{campaignTitle}</p>
+            </div>
+          </div>
+          <button
+            onClick={onClose}
+            disabled={loading}
+            aria-label="Close"
+            className="p-1.5 rounded-lg text-gray-500 hover:bg-gray-800 transition disabled:opacity-50"
+          >
+            <X size={16} />
+          </button>
+        </div>
+
+        {/* Warning */}
+        <p className="text-sm text-gray-300">
+          This action is <span className="font-semibold text-red-400">irreversible</span>. All
+          contributors will be able to claim a full refund.
+        </p>
+
+        {/* Reason input */}
+        <div>
+          <label htmlFor="cancel-reason" className="mb-1.5 block text-sm text-gray-400">
+            Reason for cancellation <span className="text-red-400">*</span>
+          </label>
+          <textarea
+            id="cancel-reason"
+            rows={3}
+            value={reason}
+            onChange={(e) => setReason(e.target.value)}
+            disabled={loading}
+            placeholder="e.g. Project scope changed, unable to deliver…"
+            className="w-full rounded-xl border border-gray-700 bg-gray-800 px-4 py-2 text-sm text-white placeholder-gray-500 focus:border-red-500 focus:outline-none disabled:opacity-50"
+          />
+        </div>
+
+        {error && <p className="text-sm text-red-400">{error}</p>}
+
+        {/* Actions */}
+        <div className="flex gap-2">
+          <button
+            onClick={onClose}
+            disabled={loading}
+            className="flex-1 rounded-xl px-4 py-2 text-sm text-gray-400 hover:text-white transition disabled:opacity-50"
+          >
+            Keep Campaign
+          </button>
+          <button
+            onClick={handleConfirm}
+            disabled={loading}
+            className="flex flex-1 items-center justify-center gap-2 rounded-xl bg-red-700 hover:bg-red-600 px-4 py-2 text-sm font-medium text-white transition disabled:opacity-50 aria-disabled:opacity-50"
+            aria-disabled={!reason.trim() || loading}
+          >
+            {loading && <Loader2 size={14} className="animate-spin" />}
+            Confirm Cancel
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/interface/src/components/ui/Confetti.tsx
+++ b/apps/interface/src/components/ui/Confetti.tsx
@@ -1,0 +1,91 @@
+"use client";
+
+import React, { useEffect, useState } from "react";
+
+interface Piece {
+  id: number;
+  x: number;       // vw
+  delay: number;   // s
+  duration: number; // s
+  color: string;
+  size: number;    // px
+  rotation: number;
+}
+
+const COLORS = [
+  "#6366f1", "#8b5cf6", "#ec4899", "#f59e0b",
+  "#10b981", "#3b82f6", "#f43f5e", "#14b8a6",
+];
+
+function randomBetween(a: number, b: number) {
+  return a + Math.random() * (b - a);
+}
+
+function generatePieces(count: number): Piece[] {
+  return Array.from({ length: count }, (_, i) => ({
+    id: i,
+    x: randomBetween(0, 100),
+    delay: randomBetween(0, 1.5),
+    duration: randomBetween(2.5, 4),
+    color: COLORS[Math.floor(Math.random() * COLORS.length)],
+    size: randomBetween(6, 12),
+    rotation: randomBetween(0, 360),
+  }));
+}
+
+interface ConfettiProps {
+  /** Number of confetti pieces. Default 80. */
+  count?: number;
+  /** Auto-remove after this many ms. Default 4500. */
+  ttl?: number;
+}
+
+export function Confetti({ count = 80, ttl = 4500 }: ConfettiProps) {
+  const [pieces] = useState(() => generatePieces(count));
+  const [visible, setVisible] = useState(true);
+
+  useEffect(() => {
+    const t = setTimeout(() => setVisible(false), ttl);
+    return () => clearTimeout(t);
+  }, [ttl]);
+
+  if (!visible) return null;
+
+  return (
+    <>
+      <style>{`
+        @keyframes confetti-fall {
+          0%   { transform: translateY(-10vh) rotate(var(--rot)); opacity: 1; }
+          80%  { opacity: 1; }
+          100% { transform: translateY(110vh) rotate(calc(var(--rot) + 720deg)); opacity: 0; }
+        }
+      `}</style>
+      <div
+        aria-hidden="true"
+        className="pointer-events-none fixed inset-0 z-[9999] overflow-hidden"
+      >
+        {pieces.map((p) => (
+          <span
+            key={p.id}
+            style={{
+              position: "absolute",
+              left: `${p.x}vw`,
+              top: 0,
+              width: p.size,
+              height: p.size * 0.5,
+              backgroundColor: p.color,
+              borderRadius: 2,
+              animationName: "confetti-fall",
+              animationDuration: `${p.duration}s`,
+              animationDelay: `${p.delay}s`,
+              animationTimingFunction: "linear",
+              animationFillMode: "both",
+              // @ts-expect-error CSS custom property
+              "--rot": `${p.rotation}deg`,
+            }}
+          />
+        ))}
+      </div>
+    </>
+  );
+}

--- a/apps/interface/src/components/ui/GoalSuccess.test.tsx
+++ b/apps/interface/src/components/ui/GoalSuccess.test.tsx
@@ -1,0 +1,97 @@
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { GoalSuccessModal } from "./GoalSuccessModal";
+import { GoalSuccessBadge } from "./GoalSuccessBadge";
+
+// ── GoalSuccessBadge ──────────────────────────────────────────────────────────
+
+describe("GoalSuccessBadge", () => {
+  it("renders the goal reached message", () => {
+    render(<GoalSuccessBadge totalRaisedXlm={5000} />);
+    expect(screen.getByText(/Goal Reached/i)).toBeInTheDocument();
+  });
+
+  it("displays the formatted XLM amount", () => {
+    render(<GoalSuccessBadge totalRaisedXlm={12345} />);
+    expect(screen.getByText(/12,345 XLM/)).toBeInTheDocument();
+  });
+
+  it("has an accessible role=status", () => {
+    render(<GoalSuccessBadge totalRaisedXlm={100} />);
+    expect(screen.getByRole("status")).toBeInTheDocument();
+  });
+});
+
+// ── GoalSuccessModal ──────────────────────────────────────────────────────────
+
+const defaultProps = {
+  campaignTitle: "Save the Rainforest",
+  totalRaisedXlm: 8000,
+  onClose: jest.fn(),
+  onShare: jest.fn(),
+  onWithdraw: jest.fn(),
+};
+
+describe("GoalSuccessModal", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("renders the campaign title", () => {
+    render(<GoalSuccessModal {...defaultProps} />);
+    expect(screen.getByText("Save the Rainforest")).toBeInTheDocument();
+  });
+
+  it("displays the total raised amount", () => {
+    render(<GoalSuccessModal {...defaultProps} />);
+    expect(screen.getByText("8,000 XLM")).toBeInTheDocument();
+  });
+
+  it("shows the withdraw button when not already withdrawn", () => {
+    render(<GoalSuccessModal {...defaultProps} alreadyWithdrawn={false} />);
+    expect(screen.getByRole("button", { name: /Withdraw Funds/i })).toBeInTheDocument();
+  });
+
+  it("hides the withdraw button when already withdrawn", () => {
+    render(<GoalSuccessModal {...defaultProps} alreadyWithdrawn={true} />);
+    expect(screen.queryByRole("button", { name: /Withdraw Funds/i })).not.toBeInTheDocument();
+  });
+
+  it("calls onShare when share button is clicked", () => {
+    render(<GoalSuccessModal {...defaultProps} />);
+    fireEvent.click(screen.getByRole("button", { name: /Share Your Success/i }));
+    expect(defaultProps.onShare).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls onWithdraw when withdraw button is clicked", () => {
+    render(<GoalSuccessModal {...defaultProps} />);
+    fireEvent.click(screen.getByRole("button", { name: /Withdraw Funds/i }));
+    expect(defaultProps.onWithdraw).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls onClose when dismiss button is clicked", () => {
+    render(<GoalSuccessModal {...defaultProps} />);
+    fireEvent.click(screen.getByRole("button", { name: /Dismiss/i }));
+    expect(defaultProps.onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls onClose when close (X) button is clicked", () => {
+    render(<GoalSuccessModal {...defaultProps} />);
+    fireEvent.click(screen.getByRole("button", { name: /Close/i }));
+    expect(defaultProps.onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls onClose when backdrop is clicked", () => {
+    const { container } = render(<GoalSuccessModal {...defaultProps} />);
+    // The backdrop is the outermost fixed div
+    const backdrop = container.firstChild as HTMLElement;
+    fireEvent.click(backdrop);
+    expect(defaultProps.onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows all three next-step items", () => {
+    render(<GoalSuccessModal {...defaultProps} />);
+    // "Share your success" appears in both the list item and the share button — use getAllByText
+    expect(screen.getAllByText(/Share your success/i).length).toBeGreaterThanOrEqual(1);
+    expect(screen.getByText(/Withdraw funds to your wallet/i)).toBeInTheDocument();
+    expect(screen.getByText(/Deliver on your campaign promises/i)).toBeInTheDocument();
+  });
+});

--- a/apps/interface/src/components/ui/GoalSuccessBadge.tsx
+++ b/apps/interface/src/components/ui/GoalSuccessBadge.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import React from "react";
+import { Trophy } from "lucide-react";
+
+interface GoalSuccessBadgeProps {
+  totalRaisedXlm: number;
+}
+
+export function GoalSuccessBadge({ totalRaisedXlm }: GoalSuccessBadgeProps) {
+  return (
+    <div
+      role="status"
+      aria-label="Campaign goal reached"
+      className="flex items-center gap-3 rounded-2xl border border-green-300 bg-green-50 px-5 py-4 dark:border-green-700 dark:bg-green-900/20"
+    >
+      <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-green-100 dark:bg-green-800/50">
+        <Trophy size={18} className="text-green-600 dark:text-green-400" />
+      </div>
+      <div>
+        <p className="font-semibold text-green-800 dark:text-green-300">Goal Reached! 🎉</p>
+        <p className="text-sm text-green-700 dark:text-green-400">
+          {totalRaisedXlm.toLocaleString()} XLM raised — fully funded
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/apps/interface/src/components/ui/GoalSuccessModal.tsx
+++ b/apps/interface/src/components/ui/GoalSuccessModal.tsx
@@ -1,0 +1,105 @@
+"use client";
+
+import React from "react";
+import { X, Trophy, Share2, Wallet, ArrowRight } from "lucide-react";
+
+interface GoalSuccessModalProps {
+  campaignTitle: string;
+  totalRaisedXlm: number;
+  onClose: () => void;
+  onShare: () => void;
+  onWithdraw: () => void;
+  /** Whether the creator has already withdrawn funds */
+  alreadyWithdrawn?: boolean;
+}
+
+export function GoalSuccessModal({
+  campaignTitle,
+  totalRaisedXlm,
+  onClose,
+  onShare,
+  onWithdraw,
+  alreadyWithdrawn = false,
+}: GoalSuccessModalProps) {
+  return (
+    <div
+      className="fixed inset-0 bg-black/70 flex items-center justify-center z-50 px-4"
+      onClick={(e) => e.target === e.currentTarget && onClose()}
+    >
+      <div className="bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-2xl p-6 w-full max-w-sm shadow-2xl space-y-5">
+        {/* Header */}
+        <div className="flex items-start justify-between">
+          <div className="flex items-center gap-3">
+            <div className="flex h-10 w-10 items-center justify-center rounded-full bg-green-100 dark:bg-green-900/40">
+              <Trophy size={20} className="text-green-600 dark:text-green-400" />
+            </div>
+            <div>
+              <h2 className="font-bold text-gray-900 dark:text-white">Goal Reached! 🎉</h2>
+              <p className="text-xs text-gray-500 dark:text-gray-400 mt-0.5 line-clamp-1">{campaignTitle}</p>
+            </div>
+          </div>
+          <button
+            onClick={onClose}
+            aria-label="Close"
+            className="p-1.5 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-800 transition text-gray-500"
+          >
+            <X size={16} />
+          </button>
+        </div>
+
+        {/* Amount raised */}
+        <div className="rounded-xl bg-green-50 dark:bg-green-900/20 border border-green-200 dark:border-green-800 p-4 text-center">
+          <p className="text-3xl font-bold text-green-600 dark:text-green-400">
+            {totalRaisedXlm.toLocaleString()} XLM
+          </p>
+          <p className="text-sm text-green-700 dark:text-green-500 mt-1">raised in total</p>
+        </div>
+
+        {/* Next steps */}
+        <div className="space-y-2">
+          <p className="text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">
+            Next steps
+          </p>
+          <ol className="space-y-2 text-sm text-gray-700 dark:text-gray-300">
+            <li className="flex items-start gap-2">
+              <span className="mt-0.5 flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-indigo-100 dark:bg-indigo-900/40 text-xs font-bold text-indigo-600 dark:text-indigo-400">1</span>
+              Share your success with supporters
+            </li>
+            <li className="flex items-start gap-2">
+              <span className="mt-0.5 flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-indigo-100 dark:bg-indigo-900/40 text-xs font-bold text-indigo-600 dark:text-indigo-400">2</span>
+              Withdraw funds to your wallet
+            </li>
+            <li className="flex items-start gap-2">
+              <span className="mt-0.5 flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-indigo-100 dark:bg-indigo-900/40 text-xs font-bold text-indigo-600 dark:text-indigo-400">3</span>
+              Deliver on your campaign promises
+            </li>
+          </ol>
+        </div>
+
+        {/* Actions */}
+        <div className="flex flex-col gap-2">
+          <button
+            onClick={onShare}
+            className="flex w-full items-center justify-center gap-2 rounded-xl bg-indigo-600 hover:bg-indigo-500 px-4 py-2.5 text-sm font-medium text-white transition"
+          >
+            <Share2 size={15} /> Share Your Success
+          </button>
+          {!alreadyWithdrawn && (
+            <button
+              onClick={onWithdraw}
+              className="flex w-full items-center justify-center gap-2 rounded-xl bg-green-600 hover:bg-green-500 px-4 py-2.5 text-sm font-medium text-white transition"
+            >
+              <Wallet size={15} /> Withdraw Funds <ArrowRight size={14} />
+            </button>
+          )}
+          <button
+            onClick={onClose}
+            className="w-full rounded-xl px-4 py-2 text-sm text-gray-500 hover:text-gray-700 dark:hover:text-gray-300 transition"
+          >
+            Dismiss
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/interface/src/lib/soroban.ts
+++ b/apps/interface/src/lib/soroban.ts
@@ -412,8 +412,13 @@ async function buildSimpleContractTx(
 export const buildWithdrawTx = (caller: string, contractId: string) =>
   buildSimpleContractTx(caller, contractId, "withdraw");
 
-export const buildCancelTx = (caller: string, contractId: string) =>
-  buildSimpleContractTx(caller, contractId, "cancel_campaign");
+export const buildCancelTx = (caller: string, contractId: string, reason?: string) =>
+  buildSimpleContractTx(
+    caller,
+    contractId,
+    "cancel_campaign",
+    reason ? [nativeToScVal(reason, { type: "string" })] : [],
+  );
 
 export async function buildRefundTx(
   caller: string,


### PR DESCRIPTION
closes #275 

- Add Confetti component (CSS keyframe animation, no new deps)
- Add GoalSuccessModal for creator with next steps and share prompt
- Add GoalSuccessBadge displayed to all visitors on goal-met campaigns
- Wire confetti + modal into CampaignDetailContent (creator only)
- Fire goal_reached notification in CampaignActions after pledge tips goal
- 13 tests for GoalSuccessModal and GoalSuccessBadge

## Description

Please include a summary of the changes and related context.

## Related Issue

Closes #(issue number)

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Testing Checklist

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] E2E tests added/updated (if applicable)
- [ ] All tests pass locally
- [ ] Manual testing completed

## Code Quality Checklist

- [ ] Code follows project style guidelines
- [ ] Rust code formatted with `cargo fmt`
- [ ] TypeScript code formatted with `prettier`
- [ ] No new warnings or errors
- [ ] Comments added for complex logic
- [ ] Documentation updated (README, code comments, etc.)

## UI Changes (if applicable)

- [ ] Screenshots attached
- [ ] Snapshots updated (`npm run test -- -u`)
- [ ] Responsive design tested
- [ ] Accessibility checked

## Deployment Notes

Any special deployment instructions or breaking changes?

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests passed locally with my changes
