### PR TITLE
feat(contract): add rate limit struct, visibility controls, and tests

### DIFF
--- a/contracts/crowdfund/src/errors.rs
+++ b/contracts/crowdfund/src/errors.rs
@@ -76,4 +76,6 @@ pub enum ContractError {
     InsufficientFunds = 32,
     /// Caller is not authorized for this operation
     Unauthorized = 33,
+    /// Rate limit configuration is invalid (negative amount or zero window)
+    InvalidRateLimit = 34,
 }

--- a/contracts/crowdfund/src/lib.rs
+++ b/contracts/crowdfund/src/lib.rs
@@ -59,6 +59,7 @@ pub use storage::{
     CONTRACT_VERSION, KEY_ADMIN, KEY_CATEGORY, KEY_CONTRIBS, KEY_CREATOR, KEY_DEADLINE, KEY_DESC,
     KEY_GOAL, KEY_GOAL_HISTORY, KEY_INSURANCE, KEY_INSURANCE_POOL, KEY_MAX, KEY_MIN, KEY_PLATFORM,
     KEY_RATE_LIMIT, KEY_SOCIAL, KEY_STATUS, KEY_TITLE, KEY_TOKEN, KEY_TOTAL, KEY_VESTING,
+    KEY_VISIBILITY,
 };
 pub use types::{
     CampaignInfo,
@@ -85,12 +86,14 @@ pub use types::{
     EventInsurancePayout,
     EventMetadataUpdated,
     EventPartialRefund,
+    EventRateLimitHit,
     EventRateLimitUpdated,
     EventRecurringCancelled,
     EventRecurringExecuted,
     EventRecurringSetup,
     EventRefunded,
     EventStatusChanged,
+    EventVisibilityChanged,
     EventWhitelistOnlySet,
     EventWhitelistRemoved,
     EventWhitelisted,
@@ -100,10 +103,12 @@ pub use types::{
     InsuranceConfig,
     MatchingConfig,
     PlatformConfig,
+    RateLimit,
     RecurringPlan,
     Status,
     TemplateType,
     VestingSchedule,
+    Visibility,
 };
 pub use validation::*;
 
@@ -215,6 +220,7 @@ impl CrowdfundContract {
         storage.set(&KEY_TOTAL, &0i128);
         storage.set(&KEY_STATUS, &Status::Active);
         storage.set(&KEY_CATEGORY, &category);
+        storage.set(&KEY_VISIBILITY, &Visibility::Public);
         storage.set(&DataKey::ContributorCount, &0u32);
         storage.set(&DataKey::LargestContribution, &0i128);
 
@@ -309,7 +315,8 @@ impl CrowdfundContract {
         let max: i128 = inst.get(&KEY_MAX).unwrap_or(0);
         let deadline: u64 = inst.get(&KEY_DEADLINE).unwrap();
         let default_token: Address = inst.get(&KEY_TOKEN).unwrap();
-        let rate_limit: Option<i128> = inst.get(&KEY_RATE_LIMIT);
+        let rate_limit: Option<RateLimit> = inst.get(&KEY_RATE_LIMIT);
+        let visibility: Visibility = inst.get(&KEY_VISIBILITY).unwrap_or(Visibility::Public);
         let accepted_tokens: Option<Vec<Address>> = inst.get(&DataKey::AcceptedTokens);
         let total: i128 = inst.get(&KEY_TOTAL).unwrap();
         let count: u32 = inst.get(&DataKey::ContributorCount).unwrap();
@@ -339,7 +346,8 @@ impl CrowdfundContract {
             return Err(ContractError::Blacklisted);
         }
         let whitelist_only: bool = inst.get(&DataKey::WhitelistOnly).unwrap_or(false);
-        if whitelist_only
+        let needs_whitelist = whitelist_only || visibility == Visibility::Private;
+        if needs_whitelist
             && !env
                 .storage()
                 .persistent()
@@ -368,22 +376,39 @@ impl CrowdfundContract {
         }
 
         // ── Rate limit check (reuse cached `now`) ─────────────────────────────
-        if let Some(rate_limit) = rate_limit {
-            let ts_key = DataKey::RateLimitTimestamp(contributor.clone());
-            let amt_key = DataKey::RateLimitAmount(contributor.clone());
-            let last_ts: u64 = env.storage().persistent().get(&ts_key).unwrap_or(0);
+        if let Some(rl) = rate_limit {
+            if rl.max_amount > 0 && rl.window_seconds > 0 {
+                let ts_key = DataKey::RateLimitTimestamp(contributor.clone());
+                let amt_key = DataKey::RateLimitAmount(contributor.clone());
+                let last_ts: u64 = env.storage().persistent().get(&ts_key).unwrap_or(0);
 
-            if now - last_ts < 3600 {
-                let period_amount: i128 = env.storage().persistent().get(&amt_key).unwrap_or(0);
-                if period_amount + amount > rate_limit {
+                let in_window = last_ts > 0 && now.saturating_sub(last_ts) < rl.window_seconds;
+                let period_amount: i128 = if in_window {
+                    env.storage().persistent().get(&amt_key).unwrap_or(0)
+                } else {
+                    0
+                };
+                let new_period = period_amount
+                    .checked_add(amount)
+                    .ok_or(ContractError::Overflow)?;
+                if new_period > rl.max_amount {
+                    env.events().publish(
+                        ("campaign", "rate_limit_hit"),
+                        EventRateLimitHit {
+                            contributor: contributor.clone(),
+                            attempted: amount,
+                            period_amount,
+                            max_amount: rl.max_amount,
+                        },
+                    );
                     return Err(ContractError::RateLimitExceeded);
                 }
-                env.storage()
-                    .persistent()
-                    .set(&amt_key, &(period_amount + amount));
-            } else {
-                env.storage().persistent().set(&ts_key, &now);
-                env.storage().persistent().set(&amt_key, &amount);
+                if in_window {
+                    env.storage().persistent().set(&amt_key, &new_period);
+                } else {
+                    env.storage().persistent().set(&ts_key, &now);
+                    env.storage().persistent().set(&amt_key, &amount);
+                }
             }
         }
 
@@ -845,33 +870,71 @@ impl CrowdfundContract {
         Ok(refunded)
     }
 
-    /// Sets the rate limit for contributions per hour (admin only).
+    /// Sets the per-address contribution rate limit (admin only).
     ///
-    /// Configures the maximum amount a single address can contribute within a 1-hour window.
-    /// Set to 0 to disable rate limiting.
+    /// Configures the maximum amount a single address can contribute within a
+    /// rolling window of `window_seconds`. Passing `max_amount = 0` clears the
+    /// rate limit (and the window value is then ignored).
     ///
     /// # Arguments
     /// * `env` - The Soroban environment
-    /// * `max_amount_per_hour` - Maximum contribution amount per hour in stroops (0 = disabled)
+    /// * `max_amount` - Maximum contribution amount per address per window (0 = disabled)
+    /// * `window_seconds` - Length of the per-address window in seconds (must be > 0 when enabling)
     ///
     /// # Returns
     /// * `Ok(())` on success
+    /// * `Err(ContractError::InvalidRateLimit)` if `max_amount < 0`, or if enabling
+    ///   the limit with `window_seconds == 0`
     ///
     /// # Side Effects
-    /// - Updates rate limit configuration
-    /// - Publishes "RateLimitUpdated" event
-    pub fn set_rate_limit(env: Env, max_amount_per_hour: i128) -> Result<(), ContractError> {
+    /// - Updates or clears the stored rate limit configuration
+    /// - Publishes a "rate_limit_updated" event
+    pub fn set_rate_limit(
+        env: Env,
+        max_amount: i128,
+        window_seconds: u64,
+    ) -> Result<(), ContractError> {
         let inst = env.storage().instance();
         let admin: Address = inst.get(&KEY_ADMIN).unwrap();
         admin.require_auth();
-        inst.set(&KEY_RATE_LIMIT, &max_amount_per_hour.max(0));
+
+        if max_amount < 0 {
+            return Err(ContractError::InvalidRateLimit);
+        }
+        if max_amount == 0 {
+            inst.remove(&KEY_RATE_LIMIT);
+            env.events().publish(
+                ("campaign", "rate_limit_updated"),
+                EventRateLimitUpdated {
+                    max_amount: 0,
+                    window_seconds: 0,
+                },
+            );
+            return Ok(());
+        }
+        if window_seconds == 0 {
+            return Err(ContractError::InvalidRateLimit);
+        }
+        inst.set(
+            &KEY_RATE_LIMIT,
+            &RateLimit {
+                max_amount,
+                window_seconds,
+            },
+        );
         env.events().publish(
             ("campaign", "rate_limit_updated"),
             EventRateLimitUpdated {
-                max_amount_per_hour,
+                max_amount,
+                window_seconds,
             },
         );
         Ok(())
+    }
+
+    /// Returns the current per-address rate limit configuration, if any.
+    pub fn get_rate_limit(env: Env) -> Option<RateLimit> {
+        env.storage().instance().get(&KEY_RATE_LIMIT)
     }
 
     /// Initiates an emergency withdrawal (admin only).
@@ -1519,6 +1582,44 @@ impl CrowdfundContract {
             .unwrap_or(false)
     }
 
+    // ── Visibility Controls ───────────────────────────────────────────────────
+
+    /// Sets the campaign visibility level (creator only).
+    ///
+    /// `Public` and `Unlisted` allow anyone to contribute; `Private` restricts
+    /// contributions to whitelisted addresses (orthogonal to the legacy
+    /// `whitelist_only` flag — either being on requires the contributor to be
+    /// whitelisted). The `Unlisted` variant signals that the campaign should
+    /// not appear in public discovery feeds but does not restrict contributions.
+    ///
+    /// # Arguments
+    /// * `env` - The Soroban environment
+    /// * `visibility` - New visibility level
+    pub fn set_visibility(env: Env, visibility: Visibility) -> Result<(), ContractError> {
+        let inst = env.storage().instance();
+        let creator: Address = inst.get(&KEY_CREATOR).unwrap();
+        creator.require_auth();
+
+        let old: Visibility = inst.get(&KEY_VISIBILITY).unwrap_or(Visibility::Public);
+        inst.set(&KEY_VISIBILITY, &visibility);
+        env.events().publish(
+            ("campaign", "visibility_changed"),
+            EventVisibilityChanged {
+                old_visibility: old,
+                new_visibility: visibility,
+            },
+        );
+        Ok(())
+    }
+
+    /// Returns the campaign's current visibility level.
+    pub fn get_visibility(env: Env) -> Visibility {
+        env.storage()
+            .instance()
+            .get(&KEY_VISIBILITY)
+            .unwrap_or(Visibility::Public)
+    }
+
     // ── Delegation Functions ──────────────────────────────────────────────────
 
     /// Delegates contribution authority to another address (delegator must authorize).
@@ -1631,7 +1732,12 @@ impl CrowdfundContract {
             .instance()
             .get(&DataKey::WhitelistOnly)
             .unwrap_or(false);
-        if whitelist_only
+        let visibility: Visibility = env
+            .storage()
+            .instance()
+            .get(&KEY_VISIBILITY)
+            .unwrap_or(Visibility::Public);
+        if (whitelist_only || visibility == Visibility::Private)
             && !env
                 .storage()
                 .persistent()

--- a/contracts/crowdfund/src/storage.rs
+++ b/contracts/crowdfund/src/storage.rs
@@ -53,3 +53,5 @@ pub const KEY_CATEGORY: Symbol = soroban_sdk::symbol_short!("CATEGORY");
 pub const KEY_VESTING: Symbol = soroban_sdk::symbol_short!("VESTING");
 /// Storage key for goal adjustment history
 pub const KEY_GOAL_HISTORY: Symbol = soroban_sdk::symbol_short!("GHIST");
+/// Storage key for campaign visibility level
+pub const KEY_VISIBILITY: Symbol = soroban_sdk::symbol_short!("VIS");

--- a/contracts/crowdfund/src/test.rs
+++ b/contracts/crowdfund/src/test.rs
@@ -599,3 +599,372 @@ fn update_metadata_with_valid_title_succeeds() {
     client.update_metadata(&Some(String::from_str(&env, "New Title")), &None, &None);
     assert_eq!(client.title(), String::from_str(&env, "New Title"));
 }
+
+// ── Rate limit tests (#428) ───────────────────────────────────────────────────
+
+#[test]
+fn set_rate_limit_stores_struct_and_get_returns_it() {
+    let env = Env::default();
+    let (_creator, _token_id, client, _) = setup_contract(&env, 1_000, 10_000, 0);
+
+    client.set_rate_limit(&500, &3_600);
+    let rl = client.get_rate_limit().expect("rate limit set");
+    assert_eq!(rl.max_amount, 500);
+    assert_eq!(rl.window_seconds, 3_600);
+}
+
+#[test]
+fn set_rate_limit_zero_clears_existing_limit() {
+    let env = Env::default();
+    let (_creator, _token_id, client, _) = setup_contract(&env, 1_000, 10_000, 0);
+
+    client.set_rate_limit(&500, &3_600);
+    assert!(client.get_rate_limit().is_some());
+
+    client.set_rate_limit(&0, &0);
+    assert!(client.get_rate_limit().is_none());
+}
+
+#[test]
+fn set_rate_limit_rejects_negative_amount() {
+    let env = Env::default();
+    let (_creator, _token_id, client, _) = setup_contract(&env, 1_000, 10_000, 0);
+
+    let result = client.try_set_rate_limit(&-1, &3_600);
+    assert_eq!(result.err(), Some(Ok(ContractError::InvalidRateLimit)));
+}
+
+#[test]
+fn set_rate_limit_rejects_zero_window_when_enabling() {
+    let env = Env::default();
+    let (_creator, _token_id, client, _) = setup_contract(&env, 1_000, 10_000, 0);
+
+    let result = client.try_set_rate_limit(&500, &0);
+    assert_eq!(result.err(), Some(Ok(ContractError::InvalidRateLimit)));
+}
+
+#[test]
+fn contribute_exceeding_rate_limit_in_window_is_rejected() {
+    let env = Env::default();
+    let (_creator, token_id, client, token_admin_client) =
+        setup_contract(&env, 10_000, 100_000, 100);
+
+    client.set_rate_limit(&500, &3_600);
+
+    let contributor = Address::generate(&env);
+    token_admin_client.mint(&contributor, &1_000);
+
+    env.ledger().set_timestamp(100);
+    client.contribute(&contributor, &400, &token_id, &None);
+
+    // Second contribution in same window would exceed 500
+    let result = client.try_contribute(&contributor, &200, &token_id, &None);
+    assert_eq!(result.err(), Some(Ok(ContractError::RateLimitExceeded)));
+    // First contribution still counted; second rolled back
+    assert_eq!(client.contribution(&contributor), 400);
+}
+
+#[test]
+fn contribute_within_rate_limit_succeeds() {
+    let env = Env::default();
+    let (_creator, token_id, client, token_admin_client) =
+        setup_contract(&env, 10_000, 100_000, 100);
+
+    client.set_rate_limit(&500, &3_600);
+
+    let contributor = Address::generate(&env);
+    token_admin_client.mint(&contributor, &1_000);
+
+    env.ledger().set_timestamp(100);
+    client.contribute(&contributor, &300, &token_id, &None);
+    client.contribute(&contributor, &200, &token_id, &None);
+
+    assert_eq!(client.contribution(&contributor), 500);
+}
+
+#[test]
+fn rate_limit_resets_after_window_elapses() {
+    let env = Env::default();
+    let (_creator, token_id, client, token_admin_client) =
+        setup_contract(&env, 100_000, 1_000_000, 100);
+
+    client.set_rate_limit(&500, &3_600);
+
+    let contributor = Address::generate(&env);
+    token_admin_client.mint(&contributor, &2_000);
+
+    env.ledger().set_timestamp(1_000);
+    client.contribute(&contributor, &500, &token_id, &None);
+
+    // Advance past the window — the per-address counter should reset
+    env.ledger().set_timestamp(1_000 + 3_601);
+    client.contribute(&contributor, &500, &token_id, &None);
+
+    assert_eq!(client.contribution(&contributor), 1_000);
+}
+
+#[test]
+fn disabled_rate_limit_allows_large_contributions() {
+    let env = Env::default();
+    let (_creator, token_id, client, token_admin_client) =
+        setup_contract(&env, 100_000, 1_000_000, 100);
+
+    // No rate limit configured by default
+    assert!(client.get_rate_limit().is_none());
+
+    let contributor = Address::generate(&env);
+    token_admin_client.mint(&contributor, &50_000);
+    client.contribute(&contributor, &50_000, &token_id, &None);
+    assert_eq!(client.contribution(&contributor), 50_000);
+}
+
+// ── Visibility control tests (#429) ───────────────────────────────────────────
+
+#[test]
+fn default_visibility_is_public() {
+    let env = Env::default();
+    let (_creator, _token_id, client, _) = setup_contract(&env, 1_000, 10_000, 100);
+    assert_eq!(client.get_visibility(), Visibility::Public);
+}
+
+#[test]
+fn set_visibility_updates_storage() {
+    let env = Env::default();
+    let (_creator, _token_id, client, _) = setup_contract(&env, 1_000, 10_000, 100);
+
+    client.set_visibility(&Visibility::Unlisted);
+    assert_eq!(client.get_visibility(), Visibility::Unlisted);
+
+    client.set_visibility(&Visibility::Private);
+    assert_eq!(client.get_visibility(), Visibility::Private);
+}
+
+#[test]
+fn private_visibility_blocks_non_whitelisted_contributors() {
+    let env = Env::default();
+    let (_creator, token_id, client, token_admin_client) =
+        setup_contract(&env, 10_000, 100_000, 100);
+
+    client.set_visibility(&Visibility::Private);
+
+    let contributor = Address::generate(&env);
+    token_admin_client.mint(&contributor, &500);
+
+    let result = client.try_contribute(&contributor, &500, &token_id, &None);
+    assert_eq!(result.err(), Some(Ok(ContractError::NotWhitelisted)));
+}
+
+#[test]
+fn private_visibility_allows_whitelisted_contributors() {
+    let env = Env::default();
+    let (_creator, token_id, client, token_admin_client) =
+        setup_contract(&env, 10_000, 100_000, 100);
+
+    let contributor = Address::generate(&env);
+    client.set_visibility(&Visibility::Private);
+    client.add_to_whitelist(&contributor);
+
+    token_admin_client.mint(&contributor, &500);
+    client.contribute(&contributor, &500, &token_id, &None);
+    assert_eq!(client.contribution(&contributor), 500);
+}
+
+#[test]
+fn unlisted_visibility_allows_any_contributor() {
+    let env = Env::default();
+    let (_creator, token_id, client, token_admin_client) =
+        setup_contract(&env, 10_000, 100_000, 100);
+
+    client.set_visibility(&Visibility::Unlisted);
+
+    let contributor = Address::generate(&env);
+    token_admin_client.mint(&contributor, &500);
+    client.contribute(&contributor, &500, &token_id, &None);
+    assert_eq!(client.contribution(&contributor), 500);
+}
+
+// ── Delegation tests (#430) ───────────────────────────────────────────────────
+
+#[test]
+fn delegate_contribution_then_contribute_on_behalf() {
+    let env = Env::default();
+    let (_creator, token_id, client, token_admin_client) =
+        setup_contract(&env, 10_000, 100_000, 100);
+
+    let delegator = Address::generate(&env);
+    let delegate = Address::generate(&env);
+    token_admin_client.mint(&delegate, &500);
+
+    client.delegate_contribution(&delegator, &delegate, &500);
+
+    let info = client.get_delegation(&delegator).expect("delegation stored");
+    assert_eq!(info.amount, 500);
+    assert_eq!(info.delegate, delegate);
+    assert!(info.active);
+
+    client.contribute_on_behalf(&delegator, &delegate, &300, &token_id);
+
+    // Contribution is credited to the delegator, not the delegate
+    assert_eq!(client.contribution(&delegator), 300);
+    assert_eq!(client.contribution(&delegate), 0);
+    assert_eq!(client.total_raised(), 300);
+}
+
+#[test]
+fn contribute_on_behalf_rejects_exceeding_delegated_amount() {
+    let env = Env::default();
+    let (_creator, token_id, client, token_admin_client) =
+        setup_contract(&env, 10_000, 100_000, 100);
+
+    let delegator = Address::generate(&env);
+    let delegate = Address::generate(&env);
+    token_admin_client.mint(&delegate, &1_000);
+
+    client.delegate_contribution(&delegator, &delegate, &500);
+    client.contribute_on_behalf(&delegator, &delegate, &400, &token_id);
+
+    let result = client.try_contribute_on_behalf(&delegator, &delegate, &200, &token_id);
+    assert_eq!(result.err(), Some(Ok(ContractError::ExceedsMaximum)));
+}
+
+#[test]
+fn revoke_delegation_blocks_further_contributions() {
+    let env = Env::default();
+    let (_creator, token_id, client, token_admin_client) =
+        setup_contract(&env, 10_000, 100_000, 100);
+
+    let delegator = Address::generate(&env);
+    let delegate = Address::generate(&env);
+    token_admin_client.mint(&delegate, &500);
+
+    client.delegate_contribution(&delegator, &delegate, &500);
+    client.revoke_delegation(&delegator);
+
+    let info = client.get_delegation(&delegator).expect("still stored");
+    assert!(!info.active);
+
+    let result = client.try_contribute_on_behalf(&delegator, &delegate, &200, &token_id);
+    assert_eq!(result.err(), Some(Ok(ContractError::InvalidDelegation)));
+}
+
+#[test]
+fn contribute_on_behalf_without_delegation_is_rejected() {
+    let env = Env::default();
+    let (_creator, token_id, client, token_admin_client) =
+        setup_contract(&env, 10_000, 100_000, 100);
+
+    let delegator = Address::generate(&env);
+    let delegate = Address::generate(&env);
+    token_admin_client.mint(&delegate, &500);
+
+    let result = client.try_contribute_on_behalf(&delegator, &delegate, &200, &token_id);
+    assert_eq!(result.err(), Some(Ok(ContractError::DelegationNotFound)));
+}
+
+#[test]
+fn delegate_contribution_rejects_non_positive_amount() {
+    let env = Env::default();
+    let (_creator, _token_id, client, _) = setup_contract(&env, 10_000, 100_000, 100);
+
+    let delegator = Address::generate(&env);
+    let delegate = Address::generate(&env);
+
+    let result = client.try_delegate_contribution(&delegator, &delegate, &0);
+    assert_eq!(result.err(), Some(Ok(ContractError::InvalidDelegation)));
+}
+
+// ── Recurring contribution tests (#431) ───────────────────────────────────────
+
+#[test]
+fn setup_and_execute_recurring_contribution() {
+    let env = Env::default();
+    let deadline = 1_000_000u64;
+    let (_creator, token_id, client, token_admin_client) =
+        setup_contract(&env, deadline, 1_000_000, 100);
+
+    let contributor = Address::generate(&env);
+    token_admin_client.mint(&contributor, &10_000);
+
+    env.ledger().set_timestamp(1_000);
+    let interval = 3_600u64;
+    let end_date = 100_000u64;
+    client.setup_recurring(&contributor, &500, &interval, &end_date);
+
+    let plan = client.get_recurring_plan(&contributor).expect("plan stored");
+    assert_eq!(plan.amount, 500);
+    assert_eq!(plan.interval, interval);
+    assert_eq!(plan.end_date, end_date);
+
+    // Not enough time has passed yet
+    let too_early = client.try_execute_recurring(&contributor);
+    assert_eq!(too_early.err(), Some(Ok(ContractError::InvalidRecurringPlan)));
+
+    env.ledger().set_timestamp(1_000 + interval + 1);
+    client.execute_recurring(&contributor);
+    assert_eq!(client.contribution(&contributor), 500);
+
+    // Cannot execute again immediately
+    let again = client.try_execute_recurring(&contributor);
+    assert_eq!(again.err(), Some(Ok(ContractError::InvalidRecurringPlan)));
+
+    // After another interval passes, a second execution succeeds
+    env.ledger().set_timestamp(1_000 + 2 * interval + 2);
+    client.execute_recurring(&contributor);
+    assert_eq!(client.contribution(&contributor), 1_000);
+}
+
+#[test]
+fn setup_recurring_rejects_invalid_parameters() {
+    let env = Env::default();
+    let (_creator, _token_id, client, _) = setup_contract(&env, 1_000_000, 1_000_000, 100);
+
+    let contributor = Address::generate(&env);
+    env.ledger().set_timestamp(1_000);
+
+    // amount must be > 0
+    let r = client.try_setup_recurring(&contributor, &0, &3_600, &100_000);
+    assert_eq!(r.err(), Some(Ok(ContractError::InvalidRecurringPlan)));
+
+    // interval must be > 0
+    let r = client.try_setup_recurring(&contributor, &500, &0, &100_000);
+    assert_eq!(r.err(), Some(Ok(ContractError::InvalidRecurringPlan)));
+
+    // end_date must be in the future
+    let r = client.try_setup_recurring(&contributor, &500, &3_600, &500);
+    assert_eq!(r.err(), Some(Ok(ContractError::InvalidRecurringPlan)));
+}
+
+#[test]
+fn execute_recurring_after_end_date_is_rejected() {
+    let env = Env::default();
+    let deadline = 1_000_000u64;
+    let (_creator, _token_id, client, token_admin_client) =
+        setup_contract(&env, deadline, 1_000_000, 100);
+
+    let contributor = Address::generate(&env);
+    token_admin_client.mint(&contributor, &1_000);
+
+    env.ledger().set_timestamp(1_000);
+    client.setup_recurring(&contributor, &500, &3_600, &10_000);
+
+    env.ledger().set_timestamp(20_000);
+    let r = client.try_execute_recurring(&contributor);
+    assert_eq!(r.err(), Some(Ok(ContractError::InvalidRecurringPlan)));
+}
+
+#[test]
+fn cancel_recurring_removes_plan() {
+    let env = Env::default();
+    let (_creator, _token_id, client, _) = setup_contract(&env, 1_000_000, 1_000_000, 100);
+
+    let contributor = Address::generate(&env);
+    env.ledger().set_timestamp(1_000);
+    client.setup_recurring(&contributor, &500, &3_600, &100_000);
+    assert!(client.get_recurring_plan(&contributor).is_some());
+
+    client.cancel_recurring(&contributor);
+    assert!(client.get_recurring_plan(&contributor).is_none());
+
+    let r = client.try_execute_recurring(&contributor);
+    assert_eq!(r.err(), Some(Ok(ContractError::InvalidRecurringPlan)));
+}

--- a/contracts/crowdfund/src/types.rs
+++ b/contracts/crowdfund/src/types.rs
@@ -172,6 +172,38 @@ pub struct CampaignTemplate {
     pub goal_multiplier: u32,
 }
 
+/// Per-address rate limit configuration for contributions.
+///
+/// Limits the total amount a single address can contribute within a configurable
+/// time window. The window is tracked per-address from the moment of the first
+/// contribution in the window; once `window_seconds` have elapsed without a new
+/// contribution, the period resets.
+#[derive(Clone, Debug, PartialEq)]
+#[contracttype]
+pub struct RateLimit {
+    /// Maximum total contribution amount per address within `window_seconds`.
+    pub max_amount: i128,
+    /// Length of the per-address window in seconds.
+    pub window_seconds: u64,
+}
+
+/// Campaign visibility level.
+///
+/// Controls who can contribute and whether the campaign is publicly discoverable.
+/// `Private` campaigns restrict contributions to whitelisted addresses; `Public`
+/// and `Unlisted` campaigns place no extra access restriction here, but `Unlisted`
+/// signals to frontends that the campaign should not appear in discovery feeds.
+#[derive(Clone, Copy, Debug, PartialEq)]
+#[contracttype]
+pub enum Visibility {
+    /// Listed publicly; anyone may contribute.
+    Public,
+    /// Whitelist-only contributions; not listed in discovery.
+    Private,
+    /// Anyone may contribute; not listed in discovery.
+    Unlisted,
+}
+
 /// Delegation configuration.
 #[derive(Clone)]
 #[contracttype]
@@ -560,7 +592,35 @@ pub struct EventWhitelistOnlySet {
 #[derive(Clone)]
 #[contracttype]
 pub struct EventRateLimitUpdated {
-    pub max_amount_per_hour: i128,
+    /// Maximum total contribution amount per address within `window_seconds`.
+    pub max_amount: i128,
+    /// Window length in seconds (0 when the rate limit is cleared).
+    pub window_seconds: u64,
+}
+
+/// Emitted when a contribution is rejected because it would exceed the rate limit.
+///
+/// Event topic: `("campaign", "rate_limit_hit")`
+#[derive(Clone)]
+#[contracttype]
+pub struct EventRateLimitHit {
+    pub contributor: Address,
+    /// Amount the contributor attempted to add.
+    pub attempted: i128,
+    /// Amount already counted toward the contributor's current window.
+    pub period_amount: i128,
+    /// Configured maximum for the window.
+    pub max_amount: i128,
+}
+
+/// Emitted when a campaign's visibility level is changed.
+///
+/// Event topic: `("campaign", "visibility_changed")`
+#[derive(Clone)]
+#[contracttype]
+pub struct EventVisibilityChanged {
+    pub old_visibility: Visibility,
+    pub new_visibility: Visibility,
 }
 
 /// Emitted when an emergency withdrawal is initiated.


### PR DESCRIPTION
Implements issues #428-#431:
- #428: refactor rate limit to RateLimit struct with configurable window; emit EventRateLimitHit when contributions are rejected; add get_rate_limit
- #429: add Visibility enum (Public/Private/Unlisted), set_visibility/ get_visibility, EventVisibilityChanged; Private requires whitelist on contribute and contribute_on_behalf
- #430/#431: add comprehensive test coverage for delegation and recurring contribution flows (already-implemented features)

Closes #428 
Closes #429 
Closes #430 
Closes #431 