### PR TITLE
feat: form validation, input masking, auto-save, and undo/redo

### DIFF
--- a/apps/interface/src/components/ui/AutoSaveRecoveryBanner.tsx
+++ b/apps/interface/src/components/ui/AutoSaveRecoveryBanner.tsx
@@ -1,0 +1,92 @@
+"use client";
+
+import React from "react";
+import { FileText, X } from "lucide-react";
+import { AutoSaveStatus } from "@/hooks/useAutoSave";
+
+interface AutoSaveRecoveryBannerProps {
+  /** Whether unsaved recovery data exists. */
+  hasRecovery: boolean;
+  /** Current auto-save status. */
+  status: AutoSaveStatus;
+  /** Last saved timestamp. */
+  lastSaved: Date | null;
+  /** Called when the user clicks "Restore". */
+  onRestore: () => void;
+  /** Called when the user dismisses the banner. */
+  onDismiss: () => void;
+}
+
+function statusLabel(status: AutoSaveStatus, lastSaved: Date | null): string {
+  if (status === "saving") return "Saving…";
+  if (status === "saved" && lastSaved)
+    return `Saved at ${lastSaved.toLocaleTimeString()}`;
+  if (status === "error") return "Auto-save failed";
+  if (lastSaved) return `Last saved ${lastSaved.toLocaleTimeString()}`;
+  return "";
+}
+
+/**
+ * Banner shown when auto-saved recovery data is available.
+ * Also doubles as a subtle status chip when no recovery is pending.
+ */
+export function AutoSaveRecoveryBanner({
+  hasRecovery,
+  status,
+  lastSaved,
+  onRestore,
+  onDismiss,
+}: AutoSaveRecoveryBannerProps) {
+  const label = statusLabel(status, lastSaved);
+
+  if (!hasRecovery && !label) return null;
+
+  return (
+    <div className="flex items-center gap-3 mb-6 px-4 py-3 rounded-xl bg-indigo-50 dark:bg-indigo-950/40 border border-indigo-200 dark:border-indigo-800">
+      <FileText size={16} className="text-indigo-500 dark:text-indigo-400 shrink-0" />
+
+      <div className="flex-1 min-w-0">
+        {hasRecovery ? (
+          <p className="text-sm text-indigo-700 dark:text-indigo-300">
+            Unsaved changes were found. Restore to continue where you left off.
+          </p>
+        ) : (
+          <p className="text-xs text-indigo-500 dark:text-indigo-400">{label}</p>
+        )}
+      </div>
+
+      {hasRecovery && (
+        <button
+          type="button"
+          onClick={onRestore}
+          className="text-sm font-medium text-indigo-600 dark:text-indigo-400 hover:text-indigo-800 dark:hover:text-indigo-200 transition whitespace-nowrap"
+        >
+          Restore
+        </button>
+      )}
+
+      {label && !hasRecovery && (
+        <span
+          className={`text-xs font-medium whitespace-nowrap ${
+            status === "error"
+              ? "text-red-500"
+              : status === "saved"
+              ? "text-green-500"
+              : "text-indigo-400"
+          }`}
+        >
+          {label}
+        </span>
+      )}
+
+      <button
+        type="button"
+        onClick={onDismiss}
+        aria-label="Dismiss"
+        className="text-gray-400 hover:text-gray-600 dark:hover:text-gray-200 transition"
+      >
+        <X size={16} />
+      </button>
+    </div>
+  );
+}

--- a/apps/interface/src/components/ui/MaskedInput.tsx
+++ b/apps/interface/src/components/ui/MaskedInput.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import React, { useState } from "react";
+import { useInputMask, MaskType } from "@/hooks/useInputMask";
+
+interface MaskedInputProps
+  extends Omit<React.InputHTMLAttributes<HTMLInputElement>, "onChange" | "value"> {
+  maskType: MaskType;
+  value: string;
+  onChange: (raw: string) => void;
+  /** Show inline validation feedback below the input. */
+  showValidation?: boolean;
+}
+
+/**
+ * Controlled input with built-in formatting and validation feedback.
+ * Delegates masking logic to useInputMask.
+ */
+export function MaskedInput({
+  maskType,
+  value,
+  onChange,
+  showValidation = true,
+  className,
+  ...rest
+}: MaskedInputProps) {
+  const mask = useInputMask(maskType);
+  const [touched, setTouched] = useState(false);
+  const error = touched ? mask.validate(value) : null;
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const raw = mask.unformat(e.target.value);
+    onChange(raw);
+  };
+
+  return (
+    <div>
+      <input
+        {...rest}
+        value={mask.format(value)}
+        onChange={handleChange}
+        onBlur={() => setTouched(true)}
+        aria-invalid={!!error}
+        className={className}
+      />
+      {showValidation && error && (
+        <p className="text-red-500 dark:text-red-400 text-xs mt-1" role="alert">
+          {error}
+        </p>
+      )}
+      {showValidation && !error && touched && value && (
+        <p className="text-green-500 dark:text-green-400 text-xs mt-1">Looks good</p>
+      )}
+    </div>
+  );
+}

--- a/apps/interface/src/components/ui/UndoRedoControls.tsx
+++ b/apps/interface/src/components/ui/UndoRedoControls.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import React from "react";
+import { Undo2, Redo2 } from "lucide-react";
+
+interface UndoRedoControlsProps {
+  canUndo: boolean;
+  canRedo: boolean;
+  onUndo: () => void;
+  onRedo: () => void;
+  className?: string;
+}
+
+/**
+ * Undo / Redo button pair.
+ * Keyboard shortcuts (Ctrl+Z / Ctrl+Y) are handled by useUndoRedo directly.
+ */
+export function UndoRedoControls({
+  canUndo,
+  canRedo,
+  onUndo,
+  onRedo,
+  className = "",
+}: UndoRedoControlsProps) {
+  return (
+    <div className={`flex items-center gap-1 ${className}`}>
+      <button
+        type="button"
+        onClick={onUndo}
+        disabled={!canUndo}
+        aria-label="Undo (Ctrl+Z)"
+        title="Undo (Ctrl+Z)"
+        className="p-1.5 rounded-lg text-gray-500 hover:text-gray-900 dark:hover:text-white hover:bg-gray-200 dark:hover:bg-gray-700 disabled:opacity-30 disabled:pointer-events-none transition"
+      >
+        <Undo2 size={15} />
+      </button>
+      <button
+        type="button"
+        onClick={onRedo}
+        disabled={!canRedo}
+        aria-label="Redo (Ctrl+Y)"
+        title="Redo (Ctrl+Y)"
+        className="p-1.5 rounded-lg text-gray-500 hover:text-gray-900 dark:hover:text-white hover:bg-gray-200 dark:hover:bg-gray-700 disabled:opacity-30 disabled:pointer-events-none transition"
+      >
+        <Redo2 size={15} />
+      </button>
+    </div>
+  );
+}

--- a/apps/interface/src/hooks/index.ts
+++ b/apps/interface/src/hooks/index.ts
@@ -25,3 +25,5 @@ export { useFocusTrap } from "./useFocusTrap";
 export { useFormValidation } from "./useFormValidation";
 export { useInputMask } from "./useInputMask";
 export type { MaskType, UseMaskResult } from "./useInputMask";
+export { useAutoSave } from "./useAutoSave";
+export type { AutoSaveStatus, UseAutoSaveOptions, UseAutoSaveReturn } from "./useAutoSave";

--- a/apps/interface/src/hooks/index.ts
+++ b/apps/interface/src/hooks/index.ts
@@ -27,3 +27,5 @@ export { useInputMask } from "./useInputMask";
 export type { MaskType, UseMaskResult } from "./useInputMask";
 export { useAutoSave } from "./useAutoSave";
 export type { AutoSaveStatus, UseAutoSaveOptions, UseAutoSaveReturn } from "./useAutoSave";
+export { useUndoRedo } from "./useUndoRedo";
+export type { UseUndoRedoReturn } from "./useUndoRedo";

--- a/apps/interface/src/hooks/index.ts
+++ b/apps/interface/src/hooks/index.ts
@@ -23,3 +23,5 @@ export { useComments } from "./useComments";
 export { useBreakpoint } from "./useBreakpoint";
 export { useFocusTrap } from "./useFocusTrap";
 export { useFormValidation } from "./useFormValidation";
+export { useInputMask } from "./useInputMask";
+export type { MaskType, UseMaskResult } from "./useInputMask";

--- a/apps/interface/src/hooks/index.ts
+++ b/apps/interface/src/hooks/index.ts
@@ -22,3 +22,4 @@ export { useRecommendations } from "./useRecommendations";
 export { useComments } from "./useComments";
 export { useBreakpoint } from "./useBreakpoint";
 export { useFocusTrap } from "./useFocusTrap";
+export { useFormValidation } from "./useFormValidation";

--- a/apps/interface/src/hooks/useAutoSave.ts
+++ b/apps/interface/src/hooks/useAutoSave.ts
@@ -1,0 +1,133 @@
+"use client";
+
+import { useEffect, useRef, useCallback, useState } from "react";
+import { useDebounce } from "./useDebounce";
+
+export type AutoSaveStatus = "idle" | "saving" | "saved" | "error";
+
+export interface UseAutoSaveOptions<T> {
+  /** Debounce delay in ms before triggering a save (default: 1000). */
+  debounceMs?: number;
+  /** localStorage key to persist data under. */
+  storageKey: string;
+  /** Whether auto-save is enabled. */
+  enabled?: boolean;
+  /** Called after every successful save. */
+  onSave?: (data: T) => void;
+  /** Called on save error. */
+  onError?: (err: unknown) => void;
+}
+
+export interface UseAutoSaveReturn<T> {
+  /** Current save status. */
+  status: AutoSaveStatus;
+  /** Timestamp of the last successful save, or null. */
+  lastSaved: Date | null;
+  /** Whether saved data exists in localStorage. */
+  hasRecovery: boolean;
+  /** Load and return the last saved data, or null if none. */
+  recover: () => T | null;
+  /** Delete the saved data from localStorage. */
+  clearRecovery: () => void;
+  /** Trigger a save immediately (bypasses debounce). */
+  saveNow: () => void;
+}
+
+/**
+ * Automatically saves `data` to localStorage after the debounce delay.
+ * Provides recovery detection and manual save trigger.
+ *
+ * @example
+ * const { status, hasRecovery, recover, clearRecovery } = useAutoSave(formData, {
+ *   storageKey: "fmc:form_draft",
+ *   debounceMs: 800,
+ * });
+ */
+export function useAutoSave<T>(
+  data: T,
+  {
+    debounceMs = 1000,
+    storageKey,
+    enabled = true,
+    onSave,
+    onError,
+  }: UseAutoSaveOptions<T>,
+): UseAutoSaveReturn<T> {
+  const debouncedData = useDebounce(data, debounceMs);
+  const [status, setStatus] = useState<AutoSaveStatus>("idle");
+  const [lastSaved, setLastSaved] = useState<Date | null>(null);
+  const [hasRecovery, setHasRecovery] = useState(false);
+  const isFirstRender = useRef(true);
+  const dataRef = useRef(data);
+
+  // Keep ref fresh for the imperative saveNow path.
+  useEffect(() => {
+    dataRef.current = data;
+  }, [data]);
+
+  // Detect existing recovery on mount.
+  useEffect(() => {
+    try {
+      setHasRecovery(localStorage.getItem(storageKey) !== null);
+    } catch {
+      setHasRecovery(false);
+    }
+  }, [storageKey]);
+
+  const persist = useCallback(
+    (payload: T) => {
+      setStatus("saving");
+      try {
+        localStorage.setItem(storageKey, JSON.stringify(payload));
+        setLastSaved(new Date());
+        setHasRecovery(true);
+        setStatus("saved");
+        onSave?.(payload);
+      } catch (err) {
+        setStatus("error");
+        onError?.(err);
+      }
+    },
+    [storageKey, onSave, onError],
+  );
+
+  // Reset "saved" back to "idle" after 3 s.
+  useEffect(() => {
+    if (status === "saved") {
+      const id = setTimeout(() => setStatus("idle"), 3000);
+      return () => clearTimeout(id);
+    }
+  }, [status]);
+
+  // Auto-save whenever debounced data changes (skip the initial mount).
+  useEffect(() => {
+    if (isFirstRender.current) {
+      isFirstRender.current = false;
+      return;
+    }
+    if (!enabled) return;
+    persist(debouncedData);
+  }, [debouncedData, enabled, persist]);
+
+  const recover = useCallback((): T | null => {
+    try {
+      const raw = localStorage.getItem(storageKey);
+      return raw ? (JSON.parse(raw) as T) : null;
+    } catch {
+      return null;
+    }
+  }, [storageKey]);
+
+  const clearRecovery = useCallback(() => {
+    try {
+      localStorage.removeItem(storageKey);
+      setHasRecovery(false);
+    } catch {}
+  }, [storageKey]);
+
+  const saveNow = useCallback(() => {
+    persist(dataRef.current);
+  }, [persist]);
+
+  return { status, lastSaved, hasRecovery, recover, clearRecovery, saveNow };
+}

--- a/apps/interface/src/hooks/useFormValidation.ts
+++ b/apps/interface/src/hooks/useFormValidation.ts
@@ -1,0 +1,101 @@
+"use client";
+
+import { useState, useCallback } from "react";
+import {
+  FieldValidator,
+  FormValidationResult,
+  validateForm,
+} from "@/lib/formValidation";
+
+type Schema<T extends Record<string, unknown>> = Partial<Record<keyof T, FieldValidator[]>>;
+
+interface UseFormValidationReturn<T extends Record<string, unknown>> {
+  /** Per-field error messages. */
+  errors: Partial<Record<keyof T, string>>;
+  /** True when all validated fields pass. */
+  isValid: boolean;
+  /** First error message across all fields (useful for a summary banner). */
+  firstError: string | null;
+  /** Validate all fields and update error state. Returns true if valid. */
+  validate: (values: T) => boolean;
+  /** Validate a single field and update its error. Returns the error or null. */
+  validateOne: (field: keyof T, value: unknown) => string | null;
+  /** Clear error for a specific field. */
+  clearError: (field: keyof T) => void;
+  /** Clear all errors. */
+  clearAll: () => void;
+}
+
+/**
+ * Manages form validation state.
+ * Supports field-level and form-level validation with per-field error messages.
+ *
+ * @example
+ * const schema = { title: [required(), maxLength(100)], goal: [required(), isNumber()] };
+ * const { errors, validate, validateOne } = useFormValidation(schema);
+ */
+export function useFormValidation<T extends Record<string, unknown>>(
+  schema: Schema<T>,
+): UseFormValidationReturn<T> {
+  const [result, setResult] = useState<FormValidationResult<T>>({
+    valid: true,
+    errors: {},
+    firstError: null,
+  });
+
+  const validate = useCallback(
+    (values: T): boolean => {
+      const r = validateForm(values, schema);
+      setResult(r);
+      return r.valid;
+    },
+    [schema],
+  );
+
+  const validateOne = useCallback(
+    (field: keyof T, value: unknown): string | null => {
+      const fieldValidators = schema[field];
+      if (!fieldValidators) return null;
+      let error: string | null = null;
+      for (const v of fieldValidators) {
+        error = v(value as string);
+        if (error) break;
+      }
+      setResult((prev) => {
+        const errors = { ...prev.errors };
+        if (error) {
+          errors[field] = error;
+        } else {
+          delete errors[field];
+        }
+        const firstError = Object.values(errors).find(Boolean) as string | null ?? null;
+        return { valid: Object.keys(errors).length === 0, errors, firstError };
+      });
+      return error;
+    },
+    [schema],
+  );
+
+  const clearError = useCallback((field: keyof T) => {
+    setResult((prev) => {
+      const errors = { ...prev.errors };
+      delete errors[field];
+      const firstError = Object.values(errors).find(Boolean) as string | null ?? null;
+      return { valid: Object.keys(errors).length === 0, errors, firstError };
+    });
+  }, []);
+
+  const clearAll = useCallback(() => {
+    setResult({ valid: true, errors: {}, firstError: null });
+  }, []);
+
+  return {
+    errors: result.errors,
+    isValid: result.valid,
+    firstError: result.firstError,
+    validate,
+    validateOne,
+    clearError,
+    clearAll,
+  };
+}

--- a/apps/interface/src/hooks/useInputMask.ts
+++ b/apps/interface/src/hooks/useInputMask.ts
@@ -1,0 +1,100 @@
+"use client";
+
+import { useCallback } from "react";
+
+export type MaskType = "amount" | "stellarAddress" | "date";
+
+export interface UseMaskResult {
+  /** Format the raw value into the display string. */
+  format: (raw: string) => string;
+  /** Strip mask characters to get the raw value. */
+  unformat: (display: string) => string;
+  /** Return a validation error for the masked value, or null. */
+  validate: (raw: string) => string | null;
+}
+
+/** Mask helpers for XLM amount fields (positive decimals, max 7 decimal places). */
+function amountMask(): UseMaskResult {
+  const format = (raw: string) => {
+    if (!raw) return "";
+    const cleaned = raw.replace(/[^0-9.]/g, "");
+    const parts = cleaned.split(".");
+    const integer = parts[0].replace(/\B(?=(\d{3})+(?!\d))/g, ",");
+    if (parts.length === 1) return integer;
+    const decimals = parts[1].slice(0, 7);
+    return `${integer}.${decimals}`;
+  };
+
+  const unformat = (display: string) => display.replace(/,/g, "");
+
+  const validate = (raw: string): string | null => {
+    if (!raw) return null;
+    const num = Number(raw.replace(/,/g, ""));
+    if (isNaN(num)) return "Enter a valid number.";
+    if (num <= 0) return "Amount must be greater than 0.";
+    return null;
+  };
+
+  return { format, unformat, validate };
+}
+
+/** Mask helpers for Stellar addresses (G…/C…/M…, 56 chars, uppercase). */
+function stellarAddressMask(): UseMaskResult {
+  const format = (raw: string) => raw.toUpperCase().replace(/[^A-Z2-7]/g, "").slice(0, 56);
+
+  const unformat = (display: string) => display;
+
+  const validate = (raw: string): string | null => {
+    if (!raw) return null;
+    const v = raw.trim();
+    if (!/^[GCM][A-Z2-7]{55}$/.test(v)) return "Invalid Stellar address.";
+    return null;
+  };
+
+  return { format, unformat, validate };
+}
+
+/** Mask helpers for date fields (YYYY-MM-DD). */
+function dateMask(): UseMaskResult {
+  const format = (raw: string) => {
+    const digits = raw.replace(/\D/g, "").slice(0, 8);
+    if (digits.length <= 4) return digits;
+    if (digits.length <= 6) return `${digits.slice(0, 4)}-${digits.slice(4)}`;
+    return `${digits.slice(0, 4)}-${digits.slice(4, 6)}-${digits.slice(6)}`;
+  };
+
+  const unformat = (display: string) => display;
+
+  const validate = (raw: string): string | null => {
+    if (!raw) return null;
+    if (!/^\d{4}-\d{2}-\d{2}$/.test(raw)) return "Enter a date in YYYY-MM-DD format.";
+    const date = new Date(raw);
+    if (isNaN(date.getTime())) return "Enter a valid date.";
+    return null;
+  };
+
+  return { format, unformat, validate };
+}
+
+/**
+ * Returns format/unformat/validate helpers for a given mask type.
+ * Use in controlled inputs to enforce formatting as the user types.
+ *
+ * @example
+ * const mask = useInputMask("amount");
+ * <input value={mask.format(value)} onChange={e => setValue(mask.unformat(e.target.value))} />
+ */
+export function useInputMask(type: MaskType): UseMaskResult {
+  const getMask = useCallback((): UseMaskResult => {
+    switch (type) {
+      case "amount":
+        return amountMask();
+      case "stellarAddress":
+        return stellarAddressMask();
+      case "date":
+        return dateMask();
+    }
+  }, [type]);
+
+  return getMask();
+}

--- a/apps/interface/src/hooks/useUndoRedo.ts
+++ b/apps/interface/src/hooks/useUndoRedo.ts
@@ -1,0 +1,122 @@
+"use client";
+
+import { useState, useCallback, useEffect, useRef } from "react";
+
+export interface UseUndoRedoReturn<T> {
+  /** Current state value. */
+  state: T;
+  /** Push a new state onto the history stack. */
+  set: (next: T | ((prev: T) => T)) => void;
+  /** Step back one entry in history. */
+  undo: () => void;
+  /** Step forward one entry in history. */
+  redo: () => void;
+  /** Whether undo is available. */
+  canUndo: boolean;
+  /** Whether redo is available. */
+  canRedo: boolean;
+  /** Clear history and reset to the given state (or the initial value). */
+  reset: (next?: T) => void;
+}
+
+/**
+ * Tracks a bounded history of state snapshots and exposes undo/redo.
+ * Also registers Ctrl+Z (undo) and Ctrl+Y / Ctrl+Shift+Z (redo) keyboard shortcuts.
+ *
+ * @param initialState - initial value
+ * @param maxHistory   - maximum snapshots to retain (default: 50)
+ *
+ * @example
+ * const { state, set, undo, redo, canUndo, canRedo } = useUndoRedo(initialFormData);
+ */
+export function useUndoRedo<T>(
+  initialState: T,
+  maxHistory = 50,
+): UseUndoRedoReturn<T> {
+  const [history, setHistory] = useState<T[]>([initialState]);
+  const [cursor, setCursor] = useState(0);
+
+  // Keep a ref so keyboard handlers always see the latest cursor without
+  // being re-registered every render.
+  const cursorRef = useRef(cursor);
+  const historyRef = useRef(history);
+  cursorRef.current = cursor;
+  historyRef.current = history;
+
+  const set = useCallback((next: T | ((prev: T) => T)) => {
+    setHistory((prev) => {
+      const current = prev[cursorRef.current];
+      const nextValue = typeof next === "function" ? (next as (p: T) => T)(current) : next;
+
+      // Truncate any redo-future and append new state.
+      const truncated = prev.slice(0, cursorRef.current + 1);
+      const updated = [...truncated, nextValue];
+
+      // Enforce cap.
+      const capped = updated.length > maxHistory ? updated.slice(updated.length - maxHistory) : updated;
+      const newCursor = capped.length - 1;
+      setCursor(newCursor);
+      cursorRef.current = newCursor;
+      historyRef.current = capped;
+      return capped;
+    });
+  }, [maxHistory]);
+
+  const undo = useCallback(() => {
+    setCursor((c) => {
+      const next = Math.max(0, c - 1);
+      cursorRef.current = next;
+      return next;
+    });
+  }, []);
+
+  const redo = useCallback(() => {
+    setCursor((c) => {
+      const next = Math.min(historyRef.current.length - 1, c + 1);
+      cursorRef.current = next;
+      return next;
+    });
+  }, []);
+
+  const reset = useCallback(
+    (next?: T) => {
+      const value = next !== undefined ? next : initialState;
+      setHistory([value]);
+      setCursor(0);
+      cursorRef.current = 0;
+      historyRef.current = [value];
+    },
+    [initialState],
+  );
+
+  // Global keyboard shortcuts.
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      const ctrl = e.ctrlKey || e.metaKey;
+      if (!ctrl) return;
+      if (e.key === "z" && !e.shiftKey) {
+        e.preventDefault();
+        const next = Math.max(0, cursorRef.current - 1);
+        cursorRef.current = next;
+        setCursor(next);
+      } else if (e.key === "y" || (e.key === "z" && e.shiftKey)) {
+        e.preventDefault();
+        const next = Math.min(historyRef.current.length - 1, cursorRef.current + 1);
+        cursorRef.current = next;
+        setCursor(next);
+      }
+    };
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, []);
+
+  return {
+    state: history[cursor],
+    set,
+    undo,
+    redo,
+    canUndo: cursor > 0,
+    canRedo: cursor < history.length - 1,
+    reset,
+  };
+}

--- a/apps/interface/src/lib/formValidation.ts
+++ b/apps/interface/src/lib/formValidation.ts
@@ -1,0 +1,143 @@
+/**
+ * Comprehensive form validation utilities.
+ * Provides field-level validators, form-level validation, and error message helpers.
+ */
+
+export type FieldValidator<T = string> = (value: T, context?: Record<string, unknown>) => string | null;
+
+export interface FieldValidationResult {
+  valid: boolean;
+  error: string | null;
+}
+
+export interface FormValidationResult<T extends Record<string, unknown>> {
+  valid: boolean;
+  errors: Partial<Record<keyof T, string>>;
+  firstError: string | null;
+}
+
+/** Run a single validator and return a structured result. */
+export function validateField<T = string>(
+  value: T,
+  validators: FieldValidator<T>[],
+  context?: Record<string, unknown>,
+): FieldValidationResult {
+  for (const validator of validators) {
+    const error = validator(value, context);
+    if (error) return { valid: false, error };
+  }
+  return { valid: true, error: null };
+}
+
+/** Run a map of field validators over a form values object. */
+export function validateForm<T extends Record<string, unknown>>(
+  values: T,
+  schema: Partial<Record<keyof T, FieldValidator[]>>,
+): FormValidationResult<T> {
+  const errors: Partial<Record<keyof T, string>> = {};
+  let firstError: string | null = null;
+
+  for (const key in schema) {
+    const fieldValidators = schema[key];
+    if (!fieldValidators) continue;
+    const value = values[key] as unknown;
+    for (const validator of fieldValidators) {
+      const error = validator(value as string);
+      if (error) {
+        errors[key] = error;
+        if (!firstError) firstError = error;
+        break;
+      }
+    }
+  }
+
+  return { valid: Object.keys(errors).length === 0, errors, firstError };
+}
+
+// ── Built-in field validators ───────────────────────────────────────────────
+
+export const required =
+  (message = "This field is required."): FieldValidator =>
+  (value) =>
+    !value || !String(value).trim() ? message : null;
+
+export const minLength =
+  (min: number, message?: string): FieldValidator =>
+  (value) =>
+    String(value).trim().length < min
+      ? (message ?? `Must be at least ${min} characters.`)
+      : null;
+
+export const maxLength =
+  (max: number, message?: string): FieldValidator =>
+  (value) =>
+    String(value).trim().length > max
+      ? (message ?? `Must be ${max} characters or less.`)
+      : null;
+
+export const isNumber =
+  (message = "Must be a valid number."): FieldValidator =>
+  (value) =>
+    isNaN(Number(value)) ? message : null;
+
+export const minValue =
+  (min: number, message?: string): FieldValidator =>
+  (value) =>
+    Number(value) < min ? (message ?? `Must be at least ${min}.`) : null;
+
+export const maxValue =
+  (max: number, message?: string): FieldValidator =>
+  (value) =>
+    Number(value) > max ? (message ?? `Must be at most ${max}.`) : null;
+
+export const pattern =
+  (regex: RegExp, message: string): FieldValidator =>
+  (value) =>
+    !regex.test(String(value)) ? message : null;
+
+export const httpsUrl =
+  (message = "Must be a valid https:// URL."): FieldValidator =>
+  (value) => {
+    if (!value || !String(value).trim()) return null;
+    try {
+      const url = new URL(String(value));
+      return url.protocol === "https:" ? null : message;
+    } catch {
+      return message;
+    }
+  };
+
+export const stellarAddress =
+  (message = "Must be a valid Stellar address (G…, C…, or M…)."): FieldValidator =>
+  (value) => {
+    if (!value || !String(value).trim()) return null;
+    const v = String(value).trim();
+    return /^[GCM][A-Z2-7]{54,55}$/.test(v) ? null : message;
+  };
+
+export const futureDate =
+  (minHours = 1, message?: string): FieldValidator =>
+  (value) => {
+    if (!value) return "Date is required.";
+    const date = new Date(String(value));
+    const diffHours = (date.getTime() - Date.now()) / 3_600_000;
+    return diffHours < minHours
+      ? (message ?? `Date must be at least ${minHours} hour(s) in the future.`)
+      : null;
+  };
+
+export const pastDate =
+  (message = "Date must be in the past."): FieldValidator =>
+  (value) => {
+    if (!value) return "Date is required.";
+    return new Date(String(value)).getTime() > Date.now() ? message : null;
+  };
+
+/** Cross-field validator: ensures fieldA <= fieldB numerically. */
+export function lessThanOrEqual(
+  a: string,
+  b: string,
+  message: string,
+): string | null {
+  return Number(a) > Number(b) ? message : null;
+}


### PR DESCRIPTION
## Summary

This PR implements four frontend features for the campaign creation form.

---

### #479 — [Frontend] Implement form validation

- Added `apps/interface/src/lib/formValidation.ts` with composable, reusable field validators:
  - `required`, `minLength`, `maxLength`, `isNumber`, `minValue`, `maxValue`
  - `pattern`, `httpsUrl`, `stellarAddress`, `futureDate`, `pastDate`, `lessThanOrEqual`
  - `validateField` — runs a list of validators against a single value and returns the first error
  - `validateForm` — runs a schema of validators over a full form values object, returning per-field errors and a `firstError` summary
- Added `apps/interface/src/hooks/useFormValidation.ts`:
  - Manages per-field error state (`errors`, `isValid`, `firstError`)
  - Exposes `validate(values)` for whole-form validation
  - Exposes `validateOne(field, value)` for inline field-level validation on change/blur
  - Exposes `clearError(field)` and `clearAll()` for resetting state

---

### #480 — [Frontend] Add input masking

- Added `apps/interface/src/hooks/useInputMask.ts`:
  - `amount` mask — comma-separated thousands, up to 7 decimal places; strips commas on unformat; validates positive number
  - `stellarAddress` mask — forces uppercase base32 characters, caps at 56 chars; validates G/C/M prefix + length
  - `date` mask — formats raw digits as `YYYY-MM-DD`; validates format and real date
  - Each mask type exposes `format(raw)`, `unformat(display)`, and `validate(raw)`
- Added `apps/interface/src/components/ui/MaskedInput.tsx`:
  - Controlled input component wrapping `useInputMask`
  - Tracks `touched` state — shows error in red on blur, green confirmation on valid input
  - Fully accessible (`aria-invalid`, `role="alert"`)

---

### #494 — [Frontend] Implement auto-save

- Added `apps/interface/src/hooks/useAutoSave.ts`:
  - Debounces data writes to localStorage using the existing `useDebounce` hook (default 1000 ms, configurable)
  - Status machine: `idle → saving → saved → idle` (resets after 3 s) or `error`
  - Exposes `hasRecovery` (detected on mount), `recover()`, `clearRecovery()`, and `saveNow()` for imperative saves
  - Skips the initial mount to avoid overwriting existing recovery data on first render
  - `onSave` / `onError` callbacks for side-effects
- Added `apps/interface/src/components/ui/AutoSaveRecoveryBanner.tsx`:
  - Shows a **Restore** prompt banner when `hasRecovery` is true
  - Doubles as a subtle save-status chip (`Saving…` / `Saved at HH:MM:SS` / `Auto-save failed`) when no recovery is pending
  - Dismissable via ✕ button

---

### #495 — [Frontend] Add undo/redo functionality

- Added `apps/interface/src/hooks/useUndoRedo.ts`:
  - Maintains a bounded snapshot array (default max 50 entries, configurable)
  - `set(next | updater)` — pushes a new snapshot, truncating any redo-future
  - `undo()` / `redo()` — move the cursor back/forward through history
  - `reset(next?)` — clears history and restores to initial or given state
  - `canUndo` / `canRedo` — boolean flags for button disabled state
  - Registers **Ctrl+Z** (undo) and **Ctrl+Y** / **Ctrl+Shift+Z** (redo) as global `keydown` listeners, cleaned up on unmount
- Added `apps/interface/src/components/ui/UndoRedoControls.tsx`:
  - `Undo2` / `Redo2` icon buttons (lucide-react)
  - Disabled styling when `canUndo`/`canRedo` is false
  - `aria-label` and `title` attributes include the keyboard shortcut hint

---

## Files changed

| File | Change |
|------|--------|
| `src/lib/formValidation.ts` | New — validator primitives + `validateField` / `validateForm` |
| `src/hooks/useFormValidation.ts` | New — React hook for form error state |
| `src/hooks/useInputMask.ts` | New — amount / stellarAddress / date mask logic |
| `src/components/ui/MaskedInput.tsx` | New — controlled masked input with validation feedback |
| `src/hooks/useAutoSave.ts` | New — debounced localStorage auto-save hook |
| `src/components/ui/AutoSaveRecoveryBanner.tsx` | New — recovery + status UI banner |
| `src/hooks/useUndoRedo.ts` | New — bounded history + keyboard shortcuts |
| `src/components/ui/UndoRedoControls.tsx` | New — undo/redo icon button pair |
| `src/hooks/index.ts` | Updated — re-exports all new hooks |

## Test plan

- [ ] `useFormValidation` — call `validate(values)` and verify `errors` map populates; call `validateOne` on a single field and confirm only that field's error updates
- [ ] `MaskedInput` (amount) — type `1234567.1234567`, confirm display shows `1,234,567.1234567`; blur on empty and confirm no error; blur on `-5` and confirm error
- [ ] `MaskedInput` (stellarAddress) — type lowercase and confirm auto-uppercase; type >56 chars and confirm truncation; blur on invalid address and confirm error
- [ ] `MaskedInput` (date) — type `20260101`, confirm display becomes `2026-01-01`
- [ ] `useAutoSave` — mount with data, wait for debounce, open DevTools → Application → localStorage and confirm key exists; reload page and confirm `hasRecovery` is true and `recover()` returns saved data
- [ ] `AutoSaveRecoveryBanner` — confirm Restore button calls `onRestore`; confirm status chip shows `Saving…` then `Saved at …` then disappears after 3 s
- [ ] `useUndoRedo` — call `set` three times, confirm `canUndo` true; call `undo` twice, confirm state reverts; call `redo`, confirm it advances; press Ctrl+Z / Ctrl+Y in browser and confirm same behavior
- [ ] `UndoRedoControls` — confirm buttons are visually disabled when `canUndo`/`canRedo` is false

Closes #479
Closes #480
Closes #494
Closes #495

🤖 Generated with [Claude Code](https://claude.com/claude-code)