### PR TITLE
feat: search suggestions, campaign preview modal, breadcrumb navigation, and back button (#496-499)

### DIFF
--- a/apps/interface/src/app/[locale]/layout.tsx
+++ b/apps/interface/src/app/[locale]/layout.tsx
@@ -10,6 +10,7 @@ import { ErrorBoundary } from "@/components/ErrorBoundary";
 import { ErrorHandlerInitializer } from "@/components/ErrorHandlerInitializer";
 import { ModalProvider } from "@/context/ModalContext";
 import { SkipNav } from "@/components/ui/SkipNav";
+import { BreadcrumbProvider } from "@/context/BreadcrumbContext";
 import { NextIntlClientProvider } from "next-intl";
 import { getMessages } from "next-intl/server";
 import { rtlLocales, type Locale } from "@/i18n/config";
@@ -50,7 +51,9 @@ export default async function LocaleLayout({
                   <NotificationProvider>
                     <ComparisonProvider>
                       <BookmarkProvider>
-                        <WalletProvider>{children}</WalletProvider>
+                        <BreadcrumbProvider>
+                          <WalletProvider>{children}</WalletProvider>
+                        </BreadcrumbProvider>
                       </BookmarkProvider>
                     </ComparisonProvider>
                   </NotificationProvider>

--- a/apps/interface/src/app/campaigns/[id]/page.tsx
+++ b/apps/interface/src/app/campaigns/[id]/page.tsx
@@ -19,6 +19,8 @@ import {
 } from "@/lib/constants";
 import { CampaignActions } from "./CampaignActions";
 import { CampaignDetailContent } from "./CampaignDetailContent";
+import { Breadcrumb } from "@/components/ui/Breadcrumb";
+import { BreadcrumbProvider } from "@/context/BreadcrumbContext";
 
 // ── Static Generation (SSG + ISR) ─────────────────────────────────────────────
 
@@ -99,6 +101,7 @@ export default async function CampaignDetailPage({
   const goalMet = campaign.raised >= campaign.goal;
 
   return (
+    <BreadcrumbProvider>
     <main className="min-h-screen bg-gray-50 dark:bg-gray-950 text-gray-900 dark:text-white">
       <Navbar />
 
@@ -115,6 +118,13 @@ export default async function CampaignDetailPage({
       </div>
 
       <div className="max-w-3xl mx-auto px-6 py-10 space-y-8">
+        <Breadcrumb
+          crumbs={[
+            { label: "Campaigns", href: "/campaigns" },
+            { label: campaign.title },
+          ]}
+          className="text-gray-500"
+        />
         {/* Title + creator */}
         <div>
           <h1 className="text-3xl font-bold mb-2">{campaign.title}</h1>
@@ -206,5 +216,6 @@ export default async function CampaignDetailPage({
       </div>
       <CampaignDetailContent contractId={id} />
     </main>
+    </BreadcrumbProvider>
   );
 }

--- a/apps/interface/src/app/campaigns/page.tsx
+++ b/apps/interface/src/app/campaigns/page.tsx
@@ -20,6 +20,8 @@ import { ShareModal } from "@/components/ui/ShareModal";
 import { SearchSuggestions } from "@/components/ui/SearchSuggestions";
 import { useSearchSuggestions } from "@/hooks/useSearchSuggestions";
 import type { SearchSuggestion } from "@/hooks/useSearchSuggestions";
+import { Breadcrumb } from "@/components/ui/Breadcrumb";
+import { BreadcrumbProvider } from "@/context/BreadcrumbContext";
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 
@@ -591,17 +593,23 @@ export function CampaignsInner() {
 
 export default function DiscoveryPage() {
   return (
-    <main className="min-h-screen bg-gray-50 dark:bg-gray-950 text-gray-900 dark:text-white">
-      <Navbar />
-      <div className="max-w-6xl mx-auto px-6 py-12">
-        <h1 className="text-3xl font-bold mb-2">Discover Campaigns</h1>
-        <p className="text-gray-500 mb-8">
-          Find and support causes that matter to you
-        </p>
-        <Suspense fallback={<LoadingSkeletonGrid count={6} />}>
-          <CampaignsInner />
-        </Suspense>
-      </div>
-    </main>
+    <BreadcrumbProvider>
+      <main className="min-h-screen bg-gray-50 dark:bg-gray-950 text-gray-900 dark:text-white">
+        <Navbar />
+        <div className="max-w-6xl mx-auto px-6 py-12">
+          <Breadcrumb
+            crumbs={[{ label: "Campaigns" }]}
+            className="mb-4 text-gray-500"
+          />
+          <h1 className="text-3xl font-bold mb-2">Discover Campaigns</h1>
+          <p className="text-gray-500 mb-8">
+            Find and support causes that matter to you
+          </p>
+          <Suspense fallback={<LoadingSkeletonGrid count={6} />}>
+            <CampaignsInner />
+          </Suspense>
+        </div>
+      </main>
+    </BreadcrumbProvider>
   );
 }

--- a/apps/interface/src/app/campaigns/page.tsx
+++ b/apps/interface/src/app/campaigns/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { Suspense, useState } from "react";
+import React, { Suspense, useState, useCallback } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import Link from "next/link";
 import { Navbar } from "@/components/layout/Navbar";
@@ -17,6 +17,9 @@ import { Search, GitCompare, SlidersHorizontal, X } from "lucide-react";
 import { useComparison } from "@/context/ComparisonContext";
 import { Pagination } from "@/components/ui/Pagination";
 import { ShareModal } from "@/components/ui/ShareModal";
+import { SearchSuggestions } from "@/components/ui/SearchSuggestions";
+import { useSearchSuggestions } from "@/hooks/useSearchSuggestions";
+import type { SearchSuggestion } from "@/hooks/useSearchSuggestions";
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 
@@ -91,9 +94,33 @@ export function CampaignsInner() {
     title: string;
   } | null>(null);
   const [inputValue, setInputValue] = useState(query);
+  const [suggestionActiveIndex, setSuggestionActiveIndex] = useState(-1);
   const searchQuery = inputValue.trim();
   const hasSearch = searchQuery.length > 0;
   const [showAdvanced, setShowAdvanced] = useState(false);
+
+  const fetchSuggestions = useCallback((q: string) => {
+    const lower = q.toLowerCase();
+    return ALL_CAMPAIGNS
+      .filter(
+        (c) =>
+          c.title.toLowerCase().includes(lower) ||
+          c.description.toLowerCase().includes(lower),
+      )
+      .map((c) => ({ id: c.id, title: c.title, category: c.category }));
+  }, []);
+
+  const { suggestions, isOpen: suggestionsOpen, close: closeSuggestions } =
+    useSearchSuggestions(inputValue, fetchSuggestions);
+
+  const handleSuggestionSelect = useCallback(
+    (suggestion: SearchSuggestion) => {
+      setInputValue(suggestion.title);
+      closeSuggestions();
+      setSuggestionActiveIndex(-1);
+    },
+    [closeSuggestions],
+  );
   const [showMobileFilters, setShowMobileFilters] = useState(false);
   const [goalMin, setGoalMin] = useState(searchParams.get("goalMin") ?? "");
   const [goalMax, setGoalMax] = useState(searchParams.get("goalMax") ?? "");
@@ -231,9 +258,42 @@ export function CampaignsInner() {
             type="text"
             placeholder="Search campaigns..."
             value={inputValue}
-            onChange={(e) => setInputValue(e.target.value)}
+            onChange={(e) => {
+              setInputValue(e.target.value);
+              setSuggestionActiveIndex(-1);
+            }}
+            onKeyDown={(e) => {
+              if (e.key === "ArrowDown") {
+                e.preventDefault();
+                setSuggestionActiveIndex((i) =>
+                  Math.min(i + 1, suggestions.length - 1),
+                );
+              } else if (e.key === "ArrowUp") {
+                e.preventDefault();
+                setSuggestionActiveIndex((i) => Math.max(i - 1, -1));
+              } else if (e.key === "Enter" && suggestionActiveIndex >= 0) {
+                e.preventDefault();
+                handleSuggestionSelect(suggestions[suggestionActiveIndex]);
+              } else if (e.key === "Escape") {
+                closeSuggestions();
+              }
+            }}
+            onFocus={() => {
+              if (suggestions.length > 0) setSuggestionActiveIndex(-1);
+            }}
             aria-label="Search campaigns"
+            aria-autocomplete="list"
+            aria-expanded={suggestionsOpen}
+            aria-haspopup="listbox"
             className="w-full bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-700 rounded-xl pl-9 pr-4 py-2 text-sm text-gray-900 dark:text-white placeholder-gray-400 dark:placeholder-gray-500 focus:outline-none focus:border-indigo-500"
+          />
+          <SearchSuggestions
+            suggestions={suggestions}
+            isOpen={suggestionsOpen}
+            onSelect={handleSuggestionSelect}
+            onClose={closeSuggestions}
+            activeIndex={suggestionActiveIndex}
+            onActiveIndexChange={setSuggestionActiveIndex}
           />
         </div>
 

--- a/apps/interface/src/components/create/CreateCampaignWizard.tsx
+++ b/apps/interface/src/components/create/CreateCampaignWizard.tsx
@@ -25,6 +25,7 @@ import { CampaignPreview } from "@/components/ui/CampaignPreview";
 import type { FAQ, TeamMember } from "@/types/campaign";
 import { CheckCircle2, XCircle, FileText, X, Eye, Trash2, PlusCircle } from "lucide-react";
 import { CampaignPreviewModal } from "@/components/ui/CampaignPreviewModal";
+import { BackButton } from "@/components/ui/BackButton";
 
 interface FormData {
   contractId: string;
@@ -642,6 +643,11 @@ export function CreateCampaignWizard() {
           </div>
         ) : (
           <div className={showPreview ? "max-w-4xl mx-auto px-6 py-12" : "max-w-xl mx-auto px-6 py-12"}>
+            <BackButton
+              fallbackPath="/"
+              confirmMessage="You have unsaved changes. Are you sure you want to leave?"
+              className="mb-6"
+            />
             <h1 className="text-3xl font-bold mb-4">Create Campaign</h1>
 
             {hasDraft && showResumeBanner && !showPreview && (

--- a/apps/interface/src/components/create/CreateCampaignWizard.tsx
+++ b/apps/interface/src/components/create/CreateCampaignWizard.tsx
@@ -24,6 +24,7 @@ import { DraftIndicator } from "@/components/ui/DraftIndicator";
 import { CampaignPreview } from "@/components/ui/CampaignPreview";
 import type { FAQ, TeamMember } from "@/types/campaign";
 import { CheckCircle2, XCircle, FileText, X, Eye, Trash2, PlusCircle } from "lucide-react";
+import { CampaignPreviewModal } from "@/components/ui/CampaignPreviewModal";
 
 interface FormData {
   contractId: string;
@@ -512,6 +513,7 @@ export function CreateCampaignWizard() {
   const [txError, setTxError] = useState<string | null>(null);
   const [showResumeBanner, setShowResumeBanner] = useState(true);
   const [showPreview, setShowPreview] = useState(false);
+  const [previewModalOpen, setPreviewModalOpen] = useState(false);
 
   const { hasDraft, loadDraft, saveDraft, clearDraft, saveStatus, lastSaved } =
     useCampaignDraft({ ...data, step });
@@ -737,28 +739,50 @@ export function CreateCampaignWizard() {
                     Back
                   </button>
 
-                  {step < STEPS.length - 2 ? (
-                    <button
-                      onClick={next}
-                      className="bg-indigo-600 hover:bg-indigo-500 px-6 py-2 rounded-xl text-sm font-medium transition text-white"
-                    >
-                      Next
-                    </button>
-                  ) : (
-                    <button
-                      onClick={next}
-                      className="flex items-center gap-2 bg-indigo-600 hover:bg-indigo-500 px-6 py-2 rounded-xl text-sm font-medium transition text-white"
-                    >
-                      <Eye size={15} />
-                      Preview
-                    </button>
-                  )}
+                  <div className="flex items-center gap-2">
+                    {step === STEPS.length - 2 && (
+                      <button
+                        type="button"
+                        onClick={() => setPreviewModalOpen(true)}
+                        className="flex items-center gap-2 border border-indigo-500 text-indigo-600 dark:text-indigo-400 hover:bg-indigo-50 dark:hover:bg-indigo-950/40 px-4 py-2 rounded-xl text-sm font-medium transition"
+                      >
+                        <Eye size={15} />
+                        Preview
+                      </button>
+                    )}
+
+                    {step < STEPS.length - 2 ? (
+                      <button
+                        onClick={next}
+                        className="bg-indigo-600 hover:bg-indigo-500 px-6 py-2 rounded-xl text-sm font-medium transition text-white"
+                      >
+                        Next
+                      </button>
+                    ) : (
+                      <button
+                        onClick={next}
+                        className="flex items-center gap-2 bg-indigo-600 hover:bg-indigo-500 px-6 py-2 rounded-xl text-sm font-medium transition text-white"
+                      >
+                        Review & Deploy
+                      </button>
+                    )}
+                  </div>
                 </div>
               </div>
             )}
           </div>
         )}
       </WalletGuard>
+
+      <CampaignPreviewModal
+        data={{ ...data, creatorAddress: address ?? "" }}
+        isOpen={previewModalOpen}
+        onClose={() => setPreviewModalOpen(false)}
+        onEdit={() => setPreviewModalOpen(false)}
+        onPublish={deploy}
+        publishDisabled={txStatus === "pending" || networkMismatch}
+        publishPending={txStatus === "pending"}
+      />
     </main>
   );
 }

--- a/apps/interface/src/components/ui/BackButton.tsx
+++ b/apps/interface/src/components/ui/BackButton.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+import React from "react";
+import { ArrowLeft } from "lucide-react";
+import { useBackButton } from "@/hooks/useBackButton";
+import type { UseBackButtonOptions } from "@/hooks/useBackButton";
+
+interface BackButtonProps extends UseBackButtonOptions {
+  label?: string;
+  className?: string;
+}
+
+export function BackButton({
+  label = "Back",
+  fallbackPath = "/",
+  confirmMessage,
+  className = "",
+}: BackButtonProps) {
+  const { goBack, canGoBack, confirmOpen, confirmBack, cancelBack } =
+    useBackButton({ fallbackPath, confirmMessage });
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={goBack}
+        aria-label={canGoBack ? `Go back` : `Go to home`}
+        className={`inline-flex items-center gap-2 text-sm text-gray-500 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white transition ${className}`}
+      >
+        <ArrowLeft size={15} aria-hidden />
+        {label}
+      </button>
+
+      {/* Confirmation dialog */}
+      {confirmOpen && (
+        <div
+          className="fixed inset-0 z-[60] flex items-center justify-center bg-black/60 backdrop-blur-sm"
+          role="alertdialog"
+          aria-modal="true"
+          aria-labelledby="back-confirm-title"
+          aria-describedby="back-confirm-desc"
+        >
+          <div className="bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-2xl shadow-2xl p-6 max-w-sm w-full mx-4 space-y-4">
+            <h2
+              id="back-confirm-title"
+              className="text-base font-semibold text-gray-900 dark:text-white"
+            >
+              Leave this page?
+            </h2>
+            <p
+              id="back-confirm-desc"
+              className="text-sm text-gray-600 dark:text-gray-400"
+            >
+              {confirmMessage}
+            </p>
+            <div className="flex justify-end gap-3">
+              <button
+                type="button"
+                onClick={cancelBack}
+                className="px-4 py-2 rounded-xl text-sm text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white hover:bg-gray-100 dark:hover:bg-gray-800 transition"
+              >
+                Stay
+              </button>
+              <button
+                type="button"
+                onClick={confirmBack}
+                className="px-4 py-2 rounded-xl text-sm font-medium bg-indigo-600 hover:bg-indigo-500 text-white transition"
+              >
+                Leave
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </>
+  );
+}

--- a/apps/interface/src/components/ui/Breadcrumb.tsx
+++ b/apps/interface/src/components/ui/Breadcrumb.tsx
@@ -1,0 +1,91 @@
+"use client";
+
+import React from "react";
+import Link from "next/link";
+import { ChevronRight, Home } from "lucide-react";
+import { useBreadcrumb } from "@/context/BreadcrumbContext";
+import type { BreadcrumbItem } from "@/context/BreadcrumbContext";
+
+interface BreadcrumbProps {
+  /** Override crumbs from context with static ones */
+  crumbs?: BreadcrumbItem[];
+  /** Show a home icon as the first crumb */
+  showHome?: boolean;
+  className?: string;
+}
+
+export function Breadcrumb({
+  crumbs: staticCrumbs,
+  showHome = true,
+  className = "",
+}: BreadcrumbProps) {
+  const { crumbs: contextCrumbs } = useBreadcrumb();
+  const crumbs = staticCrumbs ?? contextCrumbs;
+
+  const allCrumbs: BreadcrumbItem[] = showHome
+    ? [{ label: "Home", href: "/" }, ...crumbs]
+    : crumbs;
+
+  if (allCrumbs.length <= 1) return null;
+
+  return (
+    <nav
+      aria-label="Breadcrumb"
+      className={`flex items-center gap-1 text-sm ${className}`}
+    >
+      <ol className="flex items-center gap-1 flex-wrap">
+        {allCrumbs.map((crumb, index) => {
+          const isLast = index === allCrumbs.length - 1;
+          return (
+            <li key={index} className="flex items-center gap-1">
+              {index > 0 && (
+                <ChevronRight
+                  size={14}
+                  className="text-gray-400 dark:text-gray-600 shrink-0"
+                  aria-hidden
+                />
+              )}
+              {isLast || !crumb.href ? (
+                <span
+                  className={`${
+                    isLast
+                      ? "text-gray-900 dark:text-white font-medium"
+                      : "text-gray-500 dark:text-gray-400"
+                  } truncate max-w-[180px]`}
+                  aria-current={isLast ? "page" : undefined}
+                >
+                  {index === 0 && showHome ? (
+                    <span className="flex items-center gap-1">
+                      <Home size={13} aria-hidden />
+                      <span className="sr-only">Home</span>
+                    </span>
+                  ) : (
+                    crumb.label
+                  )}
+                </span>
+              ) : (
+                <Link
+                  href={crumb.href}
+                  className={`transition hover:text-indigo-600 dark:hover:text-indigo-400 truncate max-w-[180px] ${
+                    index === 0 && showHome
+                      ? "text-gray-500 dark:text-gray-400"
+                      : "text-gray-500 dark:text-gray-400"
+                  }`}
+                >
+                  {index === 0 && showHome ? (
+                    <span className="flex items-center gap-1">
+                      <Home size={13} aria-hidden />
+                      <span className="sr-only">Home</span>
+                    </span>
+                  ) : (
+                    crumb.label
+                  )}
+                </Link>
+              )}
+            </li>
+          );
+        })}
+      </ol>
+    </nav>
+  );
+}

--- a/apps/interface/src/components/ui/CampaignPreviewModal.tsx
+++ b/apps/interface/src/components/ui/CampaignPreviewModal.tsx
@@ -1,0 +1,90 @@
+"use client";
+
+import React, { useEffect, useCallback } from "react";
+import { X } from "lucide-react";
+import { CampaignPreview } from "@/components/ui/CampaignPreview";
+import type { PreviewData } from "@/components/ui/CampaignPreview";
+
+interface CampaignPreviewModalProps {
+  data: PreviewData;
+  isOpen: boolean;
+  onClose: () => void;
+  onEdit: () => void;
+  onPublish: () => void;
+  publishDisabled?: boolean;
+  publishPending?: boolean;
+}
+
+export function CampaignPreviewModal({
+  data,
+  isOpen,
+  onClose,
+  onEdit,
+  onPublish,
+  publishDisabled = false,
+  publishPending = false,
+}: CampaignPreviewModalProps) {
+  const handleBackdropClick = useCallback(
+    (e: React.MouseEvent<HTMLDivElement>) => {
+      if (e.target === e.currentTarget) onClose();
+    },
+    [onClose],
+  );
+
+  useEffect(() => {
+    if (!isOpen) return;
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    document.addEventListener("keydown", handleKey);
+    const prev = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.removeEventListener("keydown", handleKey);
+      document.body.style.overflow = prev;
+    };
+  }, [isOpen, onClose]);
+
+  if (!isOpen) return null;
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-start justify-center bg-black/70 backdrop-blur-sm overflow-y-auto py-8 px-4"
+      onClick={handleBackdropClick}
+      aria-modal="true"
+      role="dialog"
+      aria-label="Campaign preview"
+    >
+      <div className="relative w-full max-w-4xl bg-white dark:bg-gray-900 rounded-2xl shadow-2xl border border-gray-200 dark:border-gray-700">
+        {/* Header */}
+        <div className="flex items-center justify-between px-6 py-4 border-b border-gray-200 dark:border-gray-700">
+          <h2 className="text-lg font-semibold text-gray-900 dark:text-white">
+            Campaign Preview
+          </h2>
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="Close preview"
+            className="p-1.5 rounded-lg text-gray-500 hover:text-gray-900 dark:hover:text-white hover:bg-gray-100 dark:hover:bg-gray-800 transition"
+          >
+            <X size={18} aria-hidden />
+          </button>
+        </div>
+
+        {/* Body */}
+        <div className="p-6">
+          <CampaignPreview
+            data={data}
+            onEdit={() => {
+              onEdit();
+              onClose();
+            }}
+            onDeploy={onPublish}
+            deployDisabled={publishDisabled}
+            deployPending={publishPending}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/interface/src/components/ui/SearchSuggestions.tsx
+++ b/apps/interface/src/components/ui/SearchSuggestions.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+import React, { useRef, useEffect, KeyboardEvent } from "react";
+import { Search, Tag } from "lucide-react";
+import type { SearchSuggestion } from "@/hooks/useSearchSuggestions";
+
+interface SearchSuggestionsProps {
+  suggestions: SearchSuggestion[];
+  isOpen: boolean;
+  onSelect: (suggestion: SearchSuggestion) => void;
+  onClose: () => void;
+  activeIndex?: number;
+  onActiveIndexChange?: (index: number) => void;
+}
+
+export function SearchSuggestions({
+  suggestions,
+  isOpen,
+  onSelect,
+  onClose,
+  activeIndex = -1,
+  onActiveIndexChange,
+}: SearchSuggestionsProps) {
+  const listRef = useRef<HTMLUListElement>(null);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    function handleClickOutside(e: MouseEvent) {
+      if (listRef.current && !listRef.current.contains(e.target as Node)) {
+        onClose();
+      }
+    }
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, [isOpen, onClose]);
+
+  if (!isOpen || suggestions.length === 0) return null;
+
+  return (
+    <ul
+      ref={listRef}
+      role="listbox"
+      aria-label="Search suggestions"
+      className="absolute top-full left-0 right-0 z-50 mt-1 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-xl shadow-lg overflow-hidden"
+    >
+      {suggestions.map((suggestion, index) => (
+        <li
+          key={suggestion.id}
+          role="option"
+          aria-selected={index === activeIndex}
+          onMouseDown={(e) => {
+            e.preventDefault();
+            onSelect(suggestion);
+          }}
+          onMouseEnter={() => onActiveIndexChange?.(index)}
+          className={`flex items-center gap-3 px-4 py-2.5 cursor-pointer text-sm transition ${
+            index === activeIndex
+              ? "bg-indigo-50 dark:bg-indigo-900/30 text-indigo-700 dark:text-indigo-300"
+              : "text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700/50"
+          }`}
+        >
+          <Search size={13} className="shrink-0 text-gray-400" aria-hidden />
+          <span className="flex-1 truncate">{suggestion.title}</span>
+          {suggestion.category && (
+            <span className="flex items-center gap-1 text-xs text-gray-400 dark:text-gray-500">
+              <Tag size={10} aria-hidden />
+              {suggestion.category}
+            </span>
+          )}
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/apps/interface/src/context/BreadcrumbContext.tsx
+++ b/apps/interface/src/context/BreadcrumbContext.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useState,
+} from "react";
+
+export interface BreadcrumbItem {
+  label: string;
+  href?: string;
+}
+
+interface BreadcrumbContextType {
+  crumbs: BreadcrumbItem[];
+  setCrumbs: (crumbs: BreadcrumbItem[]) => void;
+  pushCrumb: (crumb: BreadcrumbItem) => void;
+  popCrumb: () => void;
+  clearCrumbs: () => void;
+}
+
+const BreadcrumbContext = createContext<BreadcrumbContextType | undefined>(
+  undefined,
+);
+
+export function BreadcrumbProvider({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const [crumbs, setCrumbs] = useState<BreadcrumbItem[]>([]);
+
+  const pushCrumb = useCallback((crumb: BreadcrumbItem) => {
+    setCrumbs((prev) => [...prev, crumb]);
+  }, []);
+
+  const popCrumb = useCallback(() => {
+    setCrumbs((prev) => prev.slice(0, -1));
+  }, []);
+
+  const clearCrumbs = useCallback(() => setCrumbs([]), []);
+
+  return (
+    <BreadcrumbContext.Provider
+      value={{ crumbs, setCrumbs, pushCrumb, popCrumb, clearCrumbs }}
+    >
+      {children}
+    </BreadcrumbContext.Provider>
+  );
+}
+
+export function useBreadcrumb() {
+  const ctx = useContext(BreadcrumbContext);
+  if (!ctx)
+    throw new Error("useBreadcrumb must be used within a BreadcrumbProvider");
+  return ctx;
+}

--- a/apps/interface/src/hooks/index.ts
+++ b/apps/interface/src/hooks/index.ts
@@ -24,3 +24,5 @@ export { useBreakpoint } from "./useBreakpoint";
 export { useFocusTrap } from "./useFocusTrap";
 export { useSearchSuggestions } from "./useSearchSuggestions";
 export type { SearchSuggestion } from "./useSearchSuggestions";
+export { useBackButton } from "./useBackButton";
+export type { UseBackButtonOptions, UseBackButtonReturn } from "./useBackButton";

--- a/apps/interface/src/hooks/index.ts
+++ b/apps/interface/src/hooks/index.ts
@@ -22,3 +22,5 @@ export { useRecommendations } from "./useRecommendations";
 export { useComments } from "./useComments";
 export { useBreakpoint } from "./useBreakpoint";
 export { useFocusTrap } from "./useFocusTrap";
+export { useSearchSuggestions } from "./useSearchSuggestions";
+export type { SearchSuggestion } from "./useSearchSuggestions";

--- a/apps/interface/src/hooks/useBackButton.ts
+++ b/apps/interface/src/hooks/useBackButton.ts
@@ -1,0 +1,83 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { useRouter, usePathname } from "next/navigation";
+
+export interface UseBackButtonOptions {
+  /** Route to navigate to when no history is available */
+  fallbackPath?: string;
+  /** Show a confirmation dialog before navigating back */
+  confirmMessage?: string;
+  /** Max number of history entries to track */
+  maxHistory?: number;
+}
+
+export interface UseBackButtonReturn {
+  /** Navigate back — shows confirmation if configured */
+  goBack: () => void;
+  /** Whether there is at least one previous page in the tracked history */
+  canGoBack: boolean;
+  /** The list of visited paths tracked during this session */
+  history: string[];
+  /** Whether the confirmation dialog is currently showing */
+  confirmOpen: boolean;
+  /** Call this to confirm the navigation */
+  confirmBack: () => void;
+  /** Call this to cancel the navigation */
+  cancelBack: () => void;
+}
+
+export function useBackButton({
+  fallbackPath = "/",
+  confirmMessage,
+  maxHistory = 50,
+}: UseBackButtonOptions = {}): UseBackButtonReturn {
+  const router = useRouter();
+  const pathname = usePathname();
+  const historyRef = useRef<string[]>([]);
+  const [history, setHistory] = useState<string[]>([]);
+  const [confirmOpen, setConfirmOpen] = useState(false);
+
+  // Track pathname changes
+  useEffect(() => {
+    const prev = historyRef.current;
+    // Avoid duplicate consecutive entries
+    if (prev[prev.length - 1] === pathname) return;
+    const next = [...prev, pathname].slice(-maxHistory);
+    historyRef.current = next;
+    setHistory(next);
+  }, [pathname, maxHistory]);
+
+  const canGoBack = history.length > 1;
+
+  const performBack = useCallback(() => {
+    const prev = historyRef.current;
+    if (prev.length > 1) {
+      // Remove current entry
+      historyRef.current = prev.slice(0, -1);
+      setHistory(historyRef.current);
+      router.back();
+    } else {
+      router.push(fallbackPath);
+    }
+  }, [router, fallbackPath]);
+
+  const goBack = useCallback(() => {
+    if (confirmMessage) {
+      setConfirmOpen(true);
+    } else {
+      performBack();
+    }
+  }, [confirmMessage, performBack]);
+
+  const confirmBack = useCallback(() => {
+    setConfirmOpen(false);
+    performBack();
+  }, [performBack]);
+
+  const cancelBack = useCallback(() => {
+    setConfirmOpen(false);
+  }, []);
+
+  return { goBack, canGoBack, history, confirmOpen, confirmBack, cancelBack };
+}

--- a/apps/interface/src/hooks/useSearchSuggestions.ts
+++ b/apps/interface/src/hooks/useSearchSuggestions.ts
@@ -1,0 +1,56 @@
+"use client";
+
+import { useState, useEffect, useRef, useCallback } from "react";
+import { useDebounce } from "./useDebounce";
+
+export interface SearchSuggestion {
+  id: string;
+  title: string;
+  category?: string;
+}
+
+type SuggestionFetcher = (query: string) => SearchSuggestion[];
+
+const cache = new Map<string, SearchSuggestion[]>();
+
+export function useSearchSuggestions(
+  query: string,
+  fetchSuggestions: SuggestionFetcher,
+  options: { delay?: number; minLength?: number; maxResults?: number } = {},
+) {
+  const { delay = 250, minLength = 2, maxResults = 6 } = options;
+  const debouncedQuery = useDebounce(query, delay);
+  const [suggestions, setSuggestions] = useState<SearchSuggestion[]>([]);
+  const [isOpen, setIsOpen] = useState(false);
+  const fetchRef = useRef(fetchSuggestions);
+  fetchRef.current = fetchSuggestions;
+
+  useEffect(() => {
+    const trimmed = debouncedQuery.trim();
+    if (trimmed.length < minLength) {
+      setSuggestions([]);
+      setIsOpen(false);
+      return;
+    }
+
+    const key = trimmed.toLowerCase();
+    if (cache.has(key)) {
+      const cached = cache.get(key)!;
+      setSuggestions(cached.slice(0, maxResults));
+      setIsOpen(cached.length > 0);
+      return;
+    }
+
+    const results = fetchRef.current(trimmed).slice(0, maxResults);
+    cache.set(key, results);
+    setSuggestions(results);
+    setIsOpen(results.length > 0);
+  }, [debouncedQuery, minLength, maxResults]);
+
+  const close = useCallback(() => setIsOpen(false), []);
+  const open = useCallback(() => {
+    if (suggestions.length > 0) setIsOpen(true);
+  }, [suggestions.length]);
+
+  return { suggestions, isOpen, close, open };
+}


### PR DESCRIPTION
## Summary

- **#496** — Search suggestions & autocomplete: `useSearchSuggestions` hook with debouncing + in-memory caching; `SearchSuggestions` dropdown with keyboard navigation (arrows, Enter, Escape) wired into the campaigns search input.
- **#497** — Campaign preview modal: `CampaignPreviewModal` wraps the existing `CampaignPreview` component in a full overlay with Escape/backdrop dismiss, scroll lock, and a "Preview" button added to the create wizard review step.
- **#498** — Breadcrumb navigation: `BreadcrumbContext` (setCrumbs/pushCrumb/popCrumb/clearCrumbs) + `Breadcrumb` component with Home icon, ChevronRight separators, and `aria-current="page"`; wired into the locale layout and shown on campaigns list and detail pages.
- **#499** — Back button: `useBackButton` hook tracking pathname history, fallback navigation, and confirmation dialog state; `BackButton` component with Leave/Stay confirmation overlay; integrated into the create campaign wizard with an unsaved-changes warning.

## Closes

Closes #496
Closes #497
Closes #498
Closes #499

## Test plan

- [ ] Visit `/campaigns` — breadcrumb "Home / Campaigns" appears
- [ ] Visit a campaign detail — breadcrumb "Home / Campaigns / <title>" appears
- [ ] Type in campaigns search — suggestions dropdown appears with keyboard nav
- [ ] Open create wizard, reach review step — "Preview" button opens modal; "Edit Campaign" closes it
- [ ] On create wizard, click back — confirmation dialog appears before leaving

🤖 Generated with [Claude Code](https://claude.com/claude-code)