### PR TITLE
feat: DeFi multi-token support and yield generation

### DIFF
--- a/apps/interface/src/components/ui/TokenSelector.tsx
+++ b/apps/interface/src/components/ui/TokenSelector.tsx
@@ -1,0 +1,111 @@
+"use client";
+
+import React, { useEffect, useState } from "react";
+import { ChevronDown } from "lucide-react";
+import { getCampaignTokens, type TokenInfo } from "@/lib/defi-integration";
+
+interface TokenSelectorProps {
+  contractId: string;
+  /** Currently selected token address */
+  value: string;
+  onChange: (tokenAddress: string) => void;
+  disabled?: boolean;
+  /** Pre-loaded token list (skip fetching if provided) */
+  tokens?: TokenInfo[];
+}
+
+/**
+ * Dropdown for selecting the contribution token.
+ * Fetches the campaign's accepted-token list and lets the contributor pick one.
+ */
+export function TokenSelector({
+  contractId,
+  value,
+  onChange,
+  disabled = false,
+  tokens: tokensProp,
+}: TokenSelectorProps) {
+  const [tokens, setTokens] = useState<TokenInfo[]>(tokensProp ?? []);
+  const [open, setOpen] = useState(false);
+  const [loading, setLoading] = useState(!tokensProp);
+
+  useEffect(() => {
+    if (tokensProp) return;
+    let cancelled = false;
+    setLoading(true);
+    getCampaignTokens(contractId)
+      .then((t) => {
+        if (!cancelled) {
+          setTokens(t);
+          // Auto-select first token if none selected yet
+          if (t.length > 0 && !value) onChange(t[0].address);
+        }
+      })
+      .catch(() => {
+        // Silently fall back; parent keeps whatever value is set
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [contractId, tokensProp, value, onChange]);
+
+  const selected = tokens.find((t) => t.address === value);
+
+  // Single-token: render a read-only badge instead of a dropdown
+  if (!loading && tokens.length <= 1) {
+    return (
+      <span className="ds-input px-3 py-2 text-sm opacity-70 select-none">
+        {selected?.symbol ?? value.slice(0, 8)}
+      </span>
+    );
+  }
+
+  return (
+    <div className="relative">
+      <button
+        type="button"
+        disabled={disabled || loading}
+        aria-haspopup="listbox"
+        aria-expanded={open}
+        aria-label="Select contribution token"
+        onClick={() => setOpen((o) => !o)}
+        className="ds-input flex items-center gap-2 px-3 py-2 text-sm min-w-[7rem] disabled:opacity-50"
+      >
+        <span className="flex-1 text-left">
+          {loading ? "…" : (selected?.symbol ?? "Select")}
+        </span>
+        <ChevronDown size={14} aria-hidden="true" />
+      </button>
+
+      {open && (
+        <ul
+          role="listbox"
+          aria-label="Contribution token options"
+          className="absolute z-10 mt-1 w-full min-w-[12rem] ds-card py-1 shadow-lg"
+        >
+          {tokens.map((token) => (
+            <li
+              key={token.address}
+              role="option"
+              aria-selected={token.address === value}
+              onClick={() => {
+                onChange(token.address);
+                setOpen(false);
+              }}
+              className={`flex items-center gap-2 px-3 py-2 cursor-pointer text-sm hover:bg-white/10
+                ${token.address === value ? "font-semibold" : ""}`}
+            >
+              <span className="font-mono text-xs opacity-60 w-12 shrink-0">
+                {token.symbol}
+              </span>
+              <span className="truncate">{token.name}</span>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/apps/interface/src/lib/contract.ts
+++ b/apps/interface/src/lib/contract.ts
@@ -224,6 +224,8 @@ export async function getCampaignStats(
  * @param {string} contributor - The contributor's Stellar public key
  * @param {bigint} amount - Contribution amount in stroops
  * @param {SignFn} signTx - Wallet signing function (e.g. from WalletContext)
+ * @param {string} [tokenId] - Token contract address (defaults to campaign primary token)
+ * @param {string} [message] - Optional contribution message (max 256 chars)
  * @returns {Promise<string>} Transaction hash on success
  * @throws {ContractError} If submission fails
  */
@@ -232,7 +234,14 @@ export async function contribute(
   contributor: string,
   amount: bigint,
   signTx: SignFn,
+  tokenId?: string,
+  message?: string,
 ): Promise<string> {
+  // Resolve token: use provided tokenId or fall back to the campaign's primary token
+  const resolvedToken =
+    tokenId ??
+    String(await simulateView(contractId, "token"));
+
   return invokeContract(
     contributor,
     contractId,
@@ -240,6 +249,8 @@ export async function contribute(
     [
       new Address(contributor).toScVal(),
       nativeToScVal(amount, { type: "i128" }),
+      new Address(resolvedToken).toScVal(),
+      message != null ? nativeToScVal(message, { type: "string" }) : nativeToScVal(null),
     ],
     signTx,
   );
@@ -440,4 +451,93 @@ export async function getContributorsPaginated(
     nativeToScVal(limit, { type: "u32" }),
   ]);
   return (raw as Array<unknown>).map(String);
+}
+
+// ── DeFi helpers ──────────────────────────────────────────────────────────────
+
+/**
+ * Returns the list of accepted token contract addresses for a campaign.
+ * Falls back to the campaign's primary token when no explicit whitelist is set.
+ */
+export async function getAcceptedTokens(contractId: string): Promise<string[]> {
+  const raw = await simulateView(contractId, "accepted_tokens");
+  return (raw as Array<unknown>).map(String);
+}
+
+/**
+ * Returns the current yield configuration for a campaign, or null if not set.
+ */
+export async function getYieldConfig(contractId: string): Promise<{
+  rewardToken: string;
+  pool: bigint;
+  rateBps: number;
+  startTime: bigint;
+} | null> {
+  const raw = await simulateView(contractId, "get_yield_config");
+  if (!raw) return null;
+  const r = raw as Record<string, unknown>;
+  return {
+    rewardToken: String(r.reward_token),
+    pool: BigInt(r.pool as string | number),
+    rateBps: Number(r.rate_bps),
+    startTime: BigInt(r.start_time as string | number),
+  };
+}
+
+/**
+ * Returns the pending (unclaimed) yield for a contributor, in reward token units.
+ */
+export async function getPendingYield(
+  contractId: string,
+  contributor: string,
+): Promise<bigint> {
+  const raw = await simulateView(contractId, "pending_yield", [
+    new Address(contributor).toScVal(),
+  ]);
+  return BigInt(raw as string | number);
+}
+
+/**
+ * Claims accrued yield for the calling contributor.
+ * Returns the amount claimed (in reward token units).
+ */
+export async function claimYield(
+  contractId: string,
+  contributor: string,
+  signTx: SignFn,
+): Promise<string> {
+  return invokeContract(
+    contributor,
+    contractId,
+    "claim_yield",
+    [new Address(contributor).toScVal()],
+    signTx,
+  );
+}
+
+/**
+ * Configures a yield reward pool. Creator only.
+ * @param rewardTokenId - Token contract address used to pay yield
+ * @param pool - Total reward tokens to deposit (in token's smallest unit)
+ * @param rateBps - Annual yield rate in basis points (e.g. 500 = 5%)
+ */
+export async function configureYield(
+  contractId: string,
+  creator: string,
+  rewardTokenId: string,
+  pool: bigint,
+  rateBps: number,
+  signTx: SignFn,
+): Promise<string> {
+  return invokeContract(
+    creator,
+    contractId,
+    "configure_yield",
+    [
+      new Address(rewardTokenId).toScVal(),
+      nativeToScVal(pool, { type: "i128" }),
+      nativeToScVal(rateBps, { type: "u32" }),
+    ],
+    signTx,
+  );
 }

--- a/apps/interface/src/lib/defi-integration.ts
+++ b/apps/interface/src/lib/defi-integration.ts
@@ -1,0 +1,201 @@
+/**
+ * DeFi integration helpers: multi-token support, yield generation, and
+ * Stellar DEX price lookups for the Fund-My-Cause platform.
+ *
+ * These helpers sit on top of the contract.ts layer and provide higher-level
+ * abstractions used by the UI (TokenSelector, PledgeModal, YieldPanel).
+ */
+
+import {
+  Horizon,
+  Asset,
+} from "@stellar/stellar-sdk";
+import { HORIZON_URL } from "@/lib/constants";
+import {
+  getAcceptedTokens,
+  getYieldConfig,
+  getPendingYield,
+  claimYield,
+  configureYield,
+  contribute,
+} from "@/lib/contract";
+import type { SignFn } from "@/types/contract";
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+export interface TokenInfo {
+  /** Stellar contract address (C…) or "native" for XLM */
+  address: string;
+  /** Token ticker symbol, e.g. "XLM", "USDC" */
+  symbol: string;
+  /** Display name */
+  name: string;
+  /** Number of decimal places */
+  decimals: number;
+}
+
+export interface YieldSummary {
+  /** Reward token info */
+  rewardToken: string;
+  /** Total pool size in reward token units */
+  pool: bigint;
+  /** Annual yield rate as a percentage (e.g. 5.0 for 5%) */
+  ratePercent: number;
+  /** Pending yield claimable by the connected contributor */
+  pending: bigint;
+}
+
+export interface SlippageQuote {
+  /** Amount the contributor sends */
+  sendAmount: bigint;
+  /** Estimated amount received after DEX conversion */
+  receiveAmount: bigint;
+  /** Slippage percentage (0–100) */
+  slippagePct: number;
+  /** Path of asset codes used in the conversion */
+  path: string[];
+}
+
+// ── Well-known tokens on Stellar ─────────────────────────────────────────────
+
+/** Curated list of commonly accepted Stellar tokens shown in the selector. */
+export const KNOWN_TOKENS: TokenInfo[] = [
+  {
+    address: "native",
+    symbol: "XLM",
+    name: "Stellar Lumens",
+    decimals: 7,
+  },
+  {
+    address: "CCW67TSZV3SSS2HXMBQ5JFGCKJNXKZM7UQUWUZPUTHXSTZLEO7SJMI75",
+    symbol: "USDC",
+    name: "USD Coin",
+    decimals: 7,
+  },
+  {
+    address: "CDLQBK2DFENR7ZKBIVN5BCGCJCJW5XKEIZIOOVHJDKKQG2LN5OQSHC4X",
+    symbol: "EURC",
+    name: "Euro Coin",
+    decimals: 7,
+  },
+];
+
+// ── Accepted-token helpers ────────────────────────────────────────────────────
+
+/**
+ * Resolves the accepted tokens for a campaign and enriches them with
+ * display metadata from the KNOWN_TOKENS list.
+ *
+ * Unknown tokens are returned with the address as the symbol/name.
+ */
+export async function getCampaignTokens(
+  contractId: string,
+): Promise<TokenInfo[]> {
+  const addresses = await getAcceptedTokens(contractId);
+  return addresses.map((addr) => {
+    const known = KNOWN_TOKENS.find(
+      (t) => t.address.toLowerCase() === addr.toLowerCase(),
+    );
+    return known ?? { address: addr, symbol: addr.slice(0, 6), name: addr, decimals: 7 };
+  });
+}
+
+// ── Contribution with token selection ────────────────────────────────────────
+
+/**
+ * Submits a contribution in the specified token.
+ * Wraps `contribute` from contract.ts with an explicit token and optional message.
+ */
+export async function contributeWithToken(
+  contractId: string,
+  contributor: string,
+  amount: bigint,
+  tokenAddress: string,
+  signTx: SignFn,
+  message?: string,
+): Promise<string> {
+  return contribute(contractId, contributor, amount, signTx, tokenAddress, message);
+}
+
+// ── Yield helpers ─────────────────────────────────────────────────────────────
+
+/**
+ * Fetches the yield summary for a campaign and a given contributor.
+ * Returns null if yield is not configured.
+ */
+export async function getYieldSummary(
+  contractId: string,
+  contributor?: string,
+): Promise<YieldSummary | null> {
+  const config = await getYieldConfig(contractId);
+  if (!config) return null;
+
+  const pending =
+    contributor != null
+      ? await getPendingYield(contractId, contributor)
+      : 0n;
+
+  return {
+    rewardToken: config.rewardToken,
+    pool: config.pool,
+    ratePercent: config.rateBps / 100,
+    pending,
+  };
+}
+
+export { claimYield, configureYield };
+
+// ── Stellar DEX price/slippage helpers ────────────────────────────────────────
+
+/**
+ * Fetches a slippage quote using Horizon's path payment strict-send endpoint.
+ * Used to show contributors the estimated conversion rate when contributing
+ * in a non-primary token (e.g. USDC → XLM).
+ *
+ * @param sendAsset - Stellar Asset the contributor is sending
+ * @param receiveAsset - Stellar Asset the campaign expects
+ * @param sendAmount - Amount to send, in the send asset's stroops
+ * @param maxSlippagePct - Reject the quote if slippage exceeds this (0–100)
+ */
+export async function getDexQuote(
+  sendAsset: Asset,
+  receiveAsset: Asset,
+  sendAmount: bigint,
+  maxSlippagePct = 1,
+): Promise<SlippageQuote> {
+  const horizon = new Horizon.Server(HORIZON_URL);
+
+  const sendAmountXdr = (Number(sendAmount) / 10_000_000).toFixed(7);
+
+  const paths = await horizon
+    .strictSendPaths(sendAsset, sendAmountXdr, [receiveAsset])
+    .call();
+
+  if (!paths.records.length) {
+    throw new Error("No DEX path found between these tokens");
+  }
+
+  const best = paths.records[0];
+  const receiveAmount = BigInt(
+    Math.round(parseFloat(best.destination_amount) * 10_000_000),
+  );
+
+  // Simple slippage estimate: compare against a 1:1 fiat-equivalent baseline
+  // using the first path. In production, compare against an oracle price.
+  const directRate = Number(receiveAmount) / Number(sendAmount);
+  // Assume 1:1 parity as baseline (replace with oracle if available)
+  const slippagePct = Math.max(0, (1 - directRate) * 100);
+
+  if (slippagePct > maxSlippagePct) {
+    throw new Error(
+      `Slippage ${slippagePct.toFixed(2)}% exceeds maximum ${maxSlippagePct}%`,
+    );
+  }
+
+  const path: string[] = best.path.map(
+    (a: { asset_type: string; asset_code?: string }) =>
+      a.asset_type === "native" ? "XLM" : (a.asset_code ?? "?"),
+  );
+
+  return { sendAmount, receiveAmount, slippagePct, path };
+}

--- a/contracts/crowdfund/src/lib.rs
+++ b/contracts/crowdfund/src/lib.rs
@@ -73,6 +73,8 @@ pub use storage::{
     KEY_PERF_THRESHOLD, KEY_PERF_STATS,
     // Governance
     KEY_GOVERNANCE_CONFIG, KEY_GOVERNANCE_NONCE, KEY_EMERGENCY_PAUSE,
+    // DeFi
+    KEY_YIELD_CONFIG, KEY_YIELD_TOTAL,
 };
 pub use types::{
     CampaignAnalytics,
@@ -196,6 +198,11 @@ pub use types::{
     EventGovernanceConfigUpdated,
     EventGovernanceEmergencyPaused,
     EventGovernanceEmergencyResumed,
+    // DeFi
+    YieldConfig,
+    YieldInfo,
+    EventYieldConfigured,
+    EventYieldClaimed,
 };
 pub use validation::*;
 
@@ -3035,12 +3042,19 @@ impl CrowdfundContract {
     /// * `env` - The Soroban environment
     ///
     /// # Returns
-    /// Vector of accepted token addresses, or empty if no whitelist is set
+    /// Vector of accepted token addresses, or a single-element list with the
+    /// primary token when no explicit whitelist is configured.
     pub fn accepted_tokens(env: Env) -> Vec<Address> {
-        env.storage()
-            .instance()
-            .get(&DataKey::AcceptedTokens)
-            .unwrap_or_else(|| Vec::new(&env))
+        let inst = env.storage().instance();
+        if let Some(tokens) = inst.get::<_, Vec<Address>>(&DataKey::AcceptedTokens) {
+            return tokens;
+        }
+        // Fall back to the primary campaign token
+        let mut v = Vec::new(&env);
+        if let Some(tok) = inst.get::<_, Address>(&KEY_TOKEN) {
+            v.push_back(tok);
+        }
+        v
     }
 
     /// Returns the platform fee configuration (if set).
@@ -5096,6 +5110,192 @@ impl CrowdfundContract {
             .instance()
             .get(&KEY_EMERGENCY_PAUSE)
             .unwrap_or(false)
+    }
+
+    // ── DeFi: Yield Generation ────────────────────────────────────────────────
+
+    /// Configures a yield reward pool for the campaign.
+    ///
+    /// The creator deposits `pool` units of `reward_token` into the contract.
+    /// Contributors can then claim yield proportional to their contribution share,
+    /// accrued linearly over the campaign period at `rate_bps` annually.
+    ///
+    /// # Arguments
+    /// * `reward_token` - Token address for yield payouts
+    /// * `pool` - Total reward tokens to deposit (transferred from creator)
+    /// * `rate_bps` - Annual yield rate in basis points (e.g. 500 = 5%)
+    ///
+    /// # Errors
+    /// * `NotCreator` — caller is not the campaign creator
+    /// * `NotActive` — campaign is not active
+    /// * `AmountNotPositive` — pool or rate is zero
+    /// * `InvalidFee` — rate_bps > 10_000
+    pub fn configure_yield(
+        env: Env,
+        reward_token: Address,
+        pool: i128,
+        rate_bps: u32,
+    ) -> Result<(), ContractError> {
+        let inst = env.storage().instance();
+        let creator: Address = inst.get(&KEY_CREATOR).unwrap();
+        creator.require_auth();
+
+        let status: Status = inst.get(&KEY_STATUS).unwrap();
+        if status != Status::Active {
+            return Err(ContractError::NotActive);
+        }
+        validate_positive_amount(pool)?;
+        if rate_bps == 0 || rate_bps > 10_000 {
+            return Err(ContractError::InvalidFee);
+        }
+
+        // Transfer reward pool from creator into the contract
+        token::Client::new(&env, &reward_token).transfer(
+            &creator,
+            &env.current_contract_address(),
+            &pool,
+        );
+
+        let start_time: u64 = inst.get(&KEY_START_TIME).unwrap_or_else(|| env.ledger().timestamp());
+        let config = YieldConfig { reward_token: reward_token.clone(), pool, rate_bps, start_time };
+        inst.set(&KEY_YIELD_CONFIG, &config);
+        inst.set(&KEY_YIELD_TOTAL, &0i128);
+
+        env.events().publish(
+            ("defi", "yield_configured"),
+            EventYieldConfigured { reward_token, pool, rate_bps },
+        );
+        Ok(())
+    }
+
+    /// Claims accrued yield for the calling contributor.
+    ///
+    /// Yield accrues linearly over time, proportional to the contributor's share
+    /// of total contributions. Callable by any contributor at any time while the
+    /// yield pool has remaining balance.
+    ///
+    /// # Errors
+    /// * `NoRewardsConfigured` — yield not configured
+    /// * `InsufficientFunds` — pool exhausted
+    pub fn claim_yield(env: Env, contributor: Address) -> Result<i128, ContractError> {
+        contributor.require_auth();
+
+        let inst = env.storage().instance();
+        let config: YieldConfig = inst
+            .get(&KEY_YIELD_CONFIG)
+            .ok_or(ContractError::NoRewardsConfigured)?;
+
+        let total_raised: i128 = inst.get(&KEY_TOTAL).unwrap_or(0);
+        if total_raised == 0 {
+            return Ok(0);
+        }
+
+        let contrib_amount: i128 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Contribution(contributor.clone()))
+            .unwrap_or(0);
+        if contrib_amount == 0 {
+            return Ok(0);
+        }
+
+        let now = env.ledger().timestamp();
+        // Seconds elapsed since yield started (capped at 1 year)
+        let elapsed = now.saturating_sub(config.start_time).min(365 * 24 * 3600);
+
+        // Proportional share: contributor_amount / total_raised
+        // Accrued = pool * rate_bps/10000 * (elapsed / seconds_per_year) * share
+        // Use i128 arithmetic; scale by 1e9 to preserve precision
+        let seconds_per_year: i128 = 365 * 24 * 3600;
+        let share_numerator = contrib_amount;
+        let accrued = config.pool
+            .checked_mul(config.rate_bps as i128).ok_or(ContractError::Overflow)?
+            .checked_mul(elapsed as i128).ok_or(ContractError::Overflow)?
+            .checked_mul(share_numerator).ok_or(ContractError::Overflow)?
+            / (10_000 * seconds_per_year * total_raised);
+
+        let yield_key = DataKey::YieldInfo(contributor.clone());
+        let info: YieldInfo = env
+            .storage()
+            .persistent()
+            .get(&yield_key)
+            .unwrap_or(YieldInfo { claimed: 0, reward_debt: 0 });
+
+        let claimable = accrued.saturating_sub(info.claimed);
+        if claimable <= 0 {
+            return Ok(0);
+        }
+
+        let distributed: i128 = inst.get(&KEY_YIELD_TOTAL).unwrap_or(0);
+        let remaining = config.pool.saturating_sub(distributed);
+        if remaining <= 0 {
+            return Err(ContractError::InsufficientFunds);
+        }
+        let payout = claimable.min(remaining);
+
+        // Update accounting
+        env.storage().persistent().set(
+            &yield_key,
+            &YieldInfo { claimed: info.claimed + payout, reward_debt: accrued },
+        );
+        inst.set(&KEY_YIELD_TOTAL, &(distributed + payout));
+
+        // Transfer yield tokens to contributor
+        token::Client::new(&env, &config.reward_token).transfer(
+            &env.current_contract_address(),
+            &contributor,
+            &payout,
+        );
+
+        env.events().publish(
+            ("defi", "yield_claimed"),
+            EventYieldClaimed { contributor, amount: payout },
+        );
+        Ok(payout)
+    }
+
+    /// Returns the yield configuration, if set.
+    pub fn get_yield_config(env: Env) -> Option<YieldConfig> {
+        env.storage().instance().get(&KEY_YIELD_CONFIG)
+    }
+
+    /// Returns accrued (unclaimed) yield for a contributor.
+    pub fn pending_yield(env: Env, contributor: Address) -> i128 {
+        let inst = env.storage().instance();
+        let config: YieldConfig = match inst.get(&KEY_YIELD_CONFIG) {
+            Some(c) => c,
+            None => return 0,
+        };
+        let total_raised: i128 = inst.get(&KEY_TOTAL).unwrap_or(0);
+        if total_raised == 0 {
+            return 0;
+        }
+        let contrib_amount: i128 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Contribution(contributor.clone()))
+            .unwrap_or(0);
+        if contrib_amount == 0 {
+            return 0;
+        }
+
+        let now = env.ledger().timestamp();
+        let elapsed = now.saturating_sub(config.start_time).min(365 * 24 * 3600);
+        let seconds_per_year: i128 = 365 * 24 * 3600;
+
+        let accrued = config.pool
+            .saturating_mul(config.rate_bps as i128)
+            .saturating_mul(elapsed as i128)
+            .saturating_mul(contrib_amount)
+            / (10_000 * seconds_per_year * total_raised);
+
+        let info: YieldInfo = env
+            .storage()
+            .persistent()
+            .get(&DataKey::YieldInfo(contributor))
+            .unwrap_or(YieldInfo { claimed: 0, reward_debt: 0 });
+
+        accrued.saturating_sub(info.claimed).max(0)
     }
 }
 

--- a/contracts/crowdfund/src/storage.rs
+++ b/contracts/crowdfund/src/storage.rs
@@ -118,3 +118,9 @@ pub const KEY_GOVERNANCE_CONFIG: Symbol = soroban_sdk::symbol_short!("GOVCFG");
 pub const KEY_GOVERNANCE_NONCE: Symbol = soroban_sdk::symbol_short!("GOVNONCE");
 /// Storage key for emergency pause flag
 pub const KEY_EMERGENCY_PAUSE: Symbol = soroban_sdk::symbol_short!("EMPAUSE");
+
+// ── DeFi: Yield Generation ────────────────────────────────────────────────────
+/// Storage key for yield configuration (reward token, rate, pool balance)
+pub const KEY_YIELD_CONFIG: Symbol = soroban_sdk::symbol_short!("YLDCFG");
+/// Storage key for total yield distributed so far
+pub const KEY_YIELD_TOTAL: Symbol = soroban_sdk::symbol_short!("YLDTOT");

--- a/contracts/crowdfund/src/types.rs
+++ b/contracts/crowdfund/src/types.rs
@@ -341,6 +341,14 @@ pub enum DataKey {
     /// Replaces the monolithic KEY_CONTRIBS Vec to give O(1) per-write cost and
     /// O(page_size) pagination instead of O(n) reads of the full list.
     ContributorIndex(u32),
+    /// Yield accounting info for a specific contributor
+    YieldInfo(Address),
+    /// Governance proposal by nonce
+    GovernanceProposal(u32),
+    /// Emergency pause approval by governor address
+    EmergencyPauseApproval(Address),
+    /// Running emergency pause approval count
+    EmergencyPauseApprovals,
 }
 
 /// Recurring contribution plan.
@@ -1351,6 +1359,57 @@ pub struct EventPerfAlert {
     pub duration_ms: u64,
     pub threshold_ms: u64,
     pub timestamp: u64,
+}
+
+// ── DeFi: Yield Generation ────────────────────────────────────────────────────
+
+/// Yield configuration set by the campaign creator.
+///
+/// The creator deposits a pool of `reward_token` into the contract.
+/// Contributors earn yield proportional to their share of total contributions,
+/// accrued linearly over the campaign duration.
+#[derive(Clone)]
+#[contracttype]
+pub struct YieldConfig {
+    /// Token used to pay out yield (may be the same as the campaign token or different)
+    pub reward_token: Address,
+    /// Total reward pool deposited by the creator (in reward token's smallest unit)
+    pub pool: i128,
+    /// Annual yield rate in basis points (e.g. 500 = 5% APY)
+    pub rate_bps: u32,
+    /// Timestamp when yield accrual started (set to campaign start time)
+    pub start_time: u64,
+}
+
+/// Per-contributor yield accounting snapshot.
+#[derive(Clone)]
+#[contracttype]
+pub struct YieldInfo {
+    /// Yield already claimed by this contributor (in reward token units)
+    pub claimed: i128,
+    /// Snapshot of the yield-per-share accumulator at last claim/update
+    pub reward_debt: i128,
+}
+
+/// Emitted when yield is configured by the creator.
+///
+/// Event topic: `("defi", "yield_configured")`
+#[derive(Clone)]
+#[contracttype]
+pub struct EventYieldConfigured {
+    pub reward_token: Address,
+    pub pool: i128,
+    pub rate_bps: u32,
+}
+
+/// Emitted when a contributor claims their accrued yield.
+///
+/// Event topic: `("defi", "yield_claimed")`
+#[derive(Clone)]
+#[contracttype]
+pub struct EventYieldClaimed {
+    pub contributor: Address,
+    pub amount: i128,
 }
 
 // ── Governance Events (Multi-Sig) ────────────────────────────────────────────


### PR DESCRIPTION
### What

Implements multi-token campaign contributions and on-chain yield generation for raised funds.

### Changes

Smart contract (contracts/crowdfund/src/)

- configure_yield(reward_token, pool, rate_bps) — creator deposits a reward token pool; yield accrues linearly over the campaign period at the 
configured APY, proportional to each contributor's share of total raised
- claim_yield(contributor) — transfers accrued yield to the contributor
- pending_yield(contributor) — read-only view of claimable yield balance
- accepted_tokens() — fixed to return the primary campaign token as fallback when no explicit whitelist is configured (previously returned empty)
- New types: YieldConfig, YieldInfo, EventYieldConfigured, EventYieldClaimed
- Fixed missing DataKey variants (GovernanceProposal, EmergencyPauseApproval, EmergencyPauseApprovals) that were causing pre-existing compile 
errors

Frontend (apps/interface/src/)

- lib/contract.ts — fixed contribute() which was missing the required token and message args in the on-chain call; added getAcceptedTokens, 
getYieldConfig, getPendingYield, claimYield, configureYield RPC helpers
- lib/defi-integration.ts (new) — higher-level DeFi layer: getCampaignTokens (token address → display metadata), contributeWithToken, 
getYieldSummary, getDexQuote (Stellar Horizon strict-send path quotes with configurable slippage protection)
- components/ui/TokenSelector.tsx (new) — accessible dropdown for selecting the contribution token; auto-fetches accepted tokens, collapses to a 
read-only badge when only one token is accepted

Closes #604