### PR TITLE
feat(analytics): add real-time predictive analytics dashboard (#597)

### DIFF
--- a/apps/interface/src/components/ui/AnalyticsDashboard.tsx
+++ b/apps/interface/src/components/ui/AnalyticsDashboard.tsx
@@ -6,6 +6,8 @@ import { CampaignData } from "@/types/soroban";
 import { LineChart } from "./LineChart";
 import { PieChart } from "./PieChart";
 import { AnalyticsExport } from "./AnalyticsExport";
+import { PredictiveAnalytics } from "./PredictiveAnalytics";
+import { useRealTimeAnalytics } from "@/hooks/useRealTimeAnalytics";
 
 interface Props {
   campaigns: CampaignData[];
@@ -44,10 +46,10 @@ function ContributionBar({ label, value, max }: { label: string; value: number; 
 export function AnalyticsDashboard({ campaigns, timeRange = "all" }: Props) {
   const filteredCampaigns = useMemo(() => {
     if (timeRange === "all") return campaigns;
-    
+
     const now = Date.now();
     const cutoffDate = new Date();
-    
+
     switch (timeRange) {
       case "7d":
         cutoffDate.setDate(cutoffDate.getDate() - 7);
@@ -61,27 +63,30 @@ export function AnalyticsDashboard({ campaigns, timeRange = "all" }: Props) {
       default:
         return campaigns;
     }
-    
+
     return campaigns.filter((c) => {
       const campaignDate = new Date(c.deadline).getTime();
       return campaignDate >= cutoffDate.getTime() && campaignDate <= now;
     });
   }, [campaigns, timeRange]);
 
+  const { analytics: realtimeCampaigns, connected, error, lastUpdated } = useRealTimeAnalytics(filteredCampaigns);
+  const displayCampaigns = realtimeCampaigns.length > 0 ? realtimeCampaigns : filteredCampaigns;
+
   const stats = useMemo(() => {
-    const totalRaised = filteredCampaigns.reduce((s, c) => s + c.raised, 0);
-    const totalGoal = filteredCampaigns.reduce((s, c) => s + c.goal, 0);
-    const active = filteredCampaigns.filter((c) => c.status === "Active").length;
-    const successful = filteredCampaigns.filter((c) => c.status === "Successful").length;
+    const totalRaised = displayCampaigns.reduce((s, c) => s + c.raised, 0);
+    const totalGoal = displayCampaigns.reduce((s, c) => s + c.goal, 0);
+    const active = displayCampaigns.filter((c) => c.status === "Active").length;
+    const successful = displayCampaigns.filter((c) => c.status === "Successful").length;
     return { totalRaised, totalGoal, active, successful };
-  }, [filteredCampaigns]);
+  }, [displayCampaigns]);
 
   const maxRaised = useMemo(
-    () => Math.max(...filteredCampaigns.map((c) => c.raised), 1),
-    [filteredCampaigns]
+    () => Math.max(...displayCampaigns.map((c) => c.raised), 1),
+    [displayCampaigns]
   );
 
-  if (filteredCampaigns.length === 0) {
+  if (displayCampaigns.length === 0) {
     return (
       <div className="text-center py-16 text-gray-500">
         <TrendingUp size={32} className="mx-auto mb-3 opacity-40" />
@@ -106,15 +111,17 @@ export function AnalyticsDashboard({ campaigns, timeRange = "all" }: Props) {
 
       {/* New chart components */}
       <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-        <LineChart campaigns={filteredCampaigns} />
-        <PieChart campaigns={filteredCampaigns} />
+        <LineChart campaigns={displayCampaigns} />
+        <PieChart campaigns={displayCampaigns} />
       </div>
+
+      <PredictiveAnalytics campaigns={displayCampaigns} connected={connected} lastUpdated={lastUpdated} error={error} />
 
       {/* Contribution timeline (per campaign bar chart) */}
       <div className="bg-gray-900 border border-gray-800 rounded-2xl p-5 space-y-4">
         <h3 className="text-sm font-semibold text-gray-300">Raised per Campaign</h3>
         <div className="space-y-3">
-          {filteredCampaigns.map((c) => (
+          {displayCampaigns.map((c) => (
             <ContributionBar
               key={c.contractId}
               label={c.title}

--- a/apps/interface/src/components/ui/PredictiveAnalytics.tsx
+++ b/apps/interface/src/components/ui/PredictiveAnalytics.tsx
@@ -1,0 +1,100 @@
+"use client";
+
+import { CampaignData } from "@/types/soroban";
+import { buildTrendForecast, compareCampaigns, predictSuccessProbability } from "@/lib/predictiveModeling";
+
+interface Props {
+  campaigns: CampaignData[];
+  connected: boolean;
+  lastUpdated: number;
+  error?: string | null;
+}
+
+export function PredictiveAnalytics({ campaigns, connected, lastUpdated, error }: Props) {
+  if (campaigns.length === 0) {
+    return null;
+  }
+
+  const benchmarks = compareCampaigns(campaigns);
+  const leadCampaign = benchmarks[0];
+  const averageProbability = Math.round(
+    benchmarks.reduce((sum, item) => sum + item.successProbability, 0) / Math.max(benchmarks.length, 1)
+  );
+  const forecast = buildTrendForecast(campaigns);
+
+  return (
+    <div className="bg-gray-900 border border-gray-800 rounded-2xl p-5 space-y-5">
+      <div className="flex flex-col gap-3 md:flex-row md:items-end md:justify-between">
+        <div>
+          <p className="text-sm font-semibold text-gray-300">Predictive Analytics</p>
+          <p className="text-xs text-gray-500">Real-time campaign forecasting and benchmarking.</p>
+        </div>
+        <div className="flex flex-wrap items-center gap-2 text-xs text-gray-400">
+          <span className={`px-2 py-1 rounded-full ${connected ? "bg-emerald-900 text-emerald-300" : "bg-gray-800 text-gray-400"}`}>
+            {connected ? "Real-time connected" : "Live snapshot"}
+          </span>
+          <span>Updated {new Date(lastUpdated).toLocaleTimeString()}</span>
+        </div>
+      </div>
+
+      {error ? (
+        <div className="rounded-2xl bg-red-950 border border-red-900 p-4 text-sm text-red-300">
+          {error}
+        </div>
+      ) : null}
+
+      <div className="grid gap-4 sm:grid-cols-3">
+        <div className="bg-gray-950/60 border border-gray-800 p-4 rounded-2xl">
+          <p className="text-xs text-gray-400 uppercase tracking-[0.2em]">Average success</p>
+          <p className="text-3xl font-semibold text-white mt-3">{averageProbability}%</p>
+        </div>
+        <div className="bg-gray-950/60 border border-gray-800 p-4 rounded-2xl">
+          <p className="text-xs text-gray-400 uppercase tracking-[0.2em]">Top campaign</p>
+          <p className="text-lg font-semibold text-white mt-3 truncate">{leadCampaign?.title || "—"}</p>
+          <p className="text-sm text-gray-400 mt-1">{leadCampaign?.successProbability}% probability</p>
+        </div>
+        <div className="bg-gray-950/60 border border-gray-800 p-4 rounded-2xl">
+          <p className="text-xs text-gray-400 uppercase tracking-[0.2em]">Campaigns benchmarked</p>
+          <p className="text-3xl font-semibold text-white mt-3">{benchmarks.length}</p>
+        </div>
+      </div>
+
+      <div className="grid gap-4 md:grid-cols-2">
+        <div className="bg-gray-950/60 border border-gray-800 p-4 rounded-2xl">
+          <p className="text-sm font-semibold text-gray-300 mb-3">Success probability ranking</p>
+          <div className="space-y-3">
+            {benchmarks.slice(0, 3).map((campaign) => (
+              <div key={campaign.contractId} className="flex items-center justify-between gap-2">
+                <div className="min-w-0">
+                  <p className="truncate text-sm text-white">{campaign.title}</p>
+                  <p className="text-xs text-gray-500">{campaign.status} campaign</p>
+                </div>
+                <span className="text-sm font-semibold text-indigo-300">{campaign.successProbability}%</span>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        <div className="bg-gray-950/60 border border-gray-800 p-4 rounded-2xl">
+          <p className="text-sm font-semibold text-gray-300 mb-3">Forecast scorecard</p>
+          <div className="space-y-3">
+            {forecast.map((point) => (
+              <div key={point.label}>
+                <div className="flex justify-between text-sm text-gray-400">
+                  <span className="truncate">{point.label}</span>
+                  <span>{point.value}%</span>
+                </div>
+                <div className="h-2 mt-2 rounded-full bg-gray-800 overflow-hidden">
+                  <div
+                    className="h-full rounded-full bg-indigo-500"
+                    style={{ width: `${point.value}%` }}
+                  />
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/interface/src/hooks/useRealTimeAnalytics.ts
+++ b/apps/interface/src/hooks/useRealTimeAnalytics.ts
@@ -1,0 +1,72 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { CampaignData } from "@/types/soroban";
+import { createAnalyticsWebSocket, fetchAnalyticsSnapshot, RealtimeAnalyticsPayload } from "@/services/analytics.service";
+
+export function useRealTimeAnalytics(campaigns: CampaignData[]) {
+  const [realtimeCampaigns, setRealtimeCampaigns] = useState<CampaignData[]>(campaigns);
+  const [connected, setConnected] = useState(false);
+  const [lastUpdated, setLastUpdated] = useState<number>(Date.now());
+  const [error, setError] = useState<string | null>(null);
+
+  const campaignIds = useMemo(
+    () => campaigns.map((campaign) => campaign.contractId),
+    [campaigns]
+  );
+
+  useEffect(() => {
+    setRealtimeCampaigns(campaigns);
+  }, [campaigns]);
+
+  useEffect(() => {
+    if (typeof window === "undefined" || campaignIds.length === 0) {
+      return;
+    }
+
+    let disconnected = false;
+    const socket = createAnalyticsWebSocket(
+      campaignIds,
+      (payload: RealtimeAnalyticsPayload) => {
+        if (disconnected) return;
+        setRealtimeCampaigns(payload.campaigns);
+        setLastUpdated(payload.timestamp);
+        setError(null);
+      },
+      () => {
+        if (disconnected) return;
+        setConnected(true);
+      },
+      () => {
+        if (disconnected) return;
+        setConnected(false);
+        setError("Live analytics unavailable. Showing latest cached snapshot.");
+      }
+    );
+
+    void fetchAnalyticsSnapshot(campaignIds)
+      .then((snapshot) => {
+        if (disconnected) return;
+        if (snapshot.campaigns.length > 0) {
+          setRealtimeCampaigns(snapshot.campaigns);
+          setLastUpdated(snapshot.timestamp);
+        }
+      })
+      .catch(() => {
+        if (disconnected) return;
+        setError("Unable to refresh analytics snapshot.");
+      });
+
+    return () => {
+      disconnected = true;
+      socket.disconnect();
+    };
+  }, [campaignIds.join(",")]);
+
+  return {
+    analytics: realtimeCampaigns,
+    connected,
+    error,
+    lastUpdated,
+  };
+}

--- a/apps/interface/src/lib/cacheStrategy.ts
+++ b/apps/interface/src/lib/cacheStrategy.ts
@@ -123,6 +123,20 @@ export class CacheStorage {
   }
 }
 
+const analyticsCache = new CacheStorage("fmc_analytics_");
+
+export function setCachedAnalyticsData<T>(key: string, value: T, ttl = 15_000): void {
+  analyticsCache.set(key, value, ttl);
+}
+
+export function getCachedAnalyticsData<T>(key: string): T | null {
+  return analyticsCache.get(key) as T | null;
+}
+
+export function invalidateAnalyticsCache(pattern: RegExp): void {
+  analyticsCache.invalidate(pattern);
+}
+
 /**
  * Service Worker registration and management
  */

--- a/apps/interface/src/lib/predictiveModeling.ts
+++ b/apps/interface/src/lib/predictiveModeling.ts
@@ -1,0 +1,41 @@
+import { CampaignData } from "@/types/soroban";
+
+export interface ForecastPoint {
+  label: string;
+  value: number;
+}
+
+export function predictSuccessProbability(campaign: CampaignData): number {
+  const progress = campaign.goal > 0 ? campaign.raised / campaign.goal : 0;
+  const deadlineMs = new Date(campaign.deadline).getTime();
+  const remainingDays = Math.max(1, (deadlineMs - Date.now()) / 86_400_000);
+  const momentum = campaign.contributorCount > 0 ? campaign.averageContribution * campaign.contributorCount : 0;
+
+  const baseScore = Math.min(1, progress * 0.75 + Math.min(1, momentum / Math.max(campaign.goal, 1)) * 0.2);
+  const timeAdjustment = Math.max(0, Math.min(1, 1 - remainingDays / 90));
+  const probability = Math.min(1, Math.max(0, baseScore + timeAdjustment * 0.15));
+
+  return Number((probability * 100).toFixed(0));
+}
+
+export function buildTrendForecast(campaigns: CampaignData[]): ForecastPoint[] {
+  const sorted = [...campaigns].sort((a, b) => b.raised - a.raised);
+  return sorted.slice(0, 5).map((campaign) => ({
+    label: campaign.title.substring(0, 20),
+    value: predictSuccessProbability(campaign),
+  }));
+}
+
+export function compareCampaigns(campaigns: CampaignData[]) {
+  return campaigns
+    .map((campaign) => ({
+      contractId: campaign.contractId,
+      title: campaign.title,
+      raised: campaign.raised,
+      goal: campaign.goal,
+      status: campaign.status,
+      progress: campaign.goal > 0 ? campaign.raised / campaign.goal : 0,
+      successProbability: predictSuccessProbability(campaign),
+    }))
+    .sort((a, b) => b.successProbability - a.successProbability);
+}

--- a/apps/interface/src/services/analytics.service.ts
+++ b/apps/interface/src/services/analytics.service.ts
@@ -1,0 +1,102 @@
+import { CampaignData } from "@/types/soroban";
+import { getCachedAnalyticsData, invalidateAnalyticsCache, setCachedAnalyticsData } from "@/lib/cacheStrategy";
+
+export interface RealtimeAnalyticsPayload {
+  campaigns: CampaignData[];
+  timestamp: number;
+}
+
+export type AnalyticsMessageType = "snapshot" | "update";
+
+export interface AnalyticsWebSocketMessage {
+  type: AnalyticsMessageType;
+  payload: RealtimeAnalyticsPayload;
+}
+
+const ANALYTICS_CACHE_KEY = "realtime-analytics-snapshot";
+const SNAPSHOT_TTL = 15_000;
+
+function getAnalyticsEndpoint(campaignIds: string[]): string {
+  if (typeof window === "undefined") return "";
+  const protocol = window.location.protocol === "https:" ? "wss:" : "ws:";
+  const host = window.location.host;
+  const query = campaignIds.map((id) => `campaignId=${encodeURIComponent(id)}`).join("&");
+  return `${protocol}//${host}/ws/analytics${query ? `?${query}` : ""}`;
+}
+
+export function createAnalyticsWebSocket(
+  campaignIds: string[],
+  onMessage: (payload: RealtimeAnalyticsPayload) => void,
+  onOpen?: () => void,
+  onError?: (error: Error | Event) => void
+) {
+  let socket: WebSocket | null = null;
+  if (typeof window === "undefined" || campaignIds.length === 0) {
+    return {
+      disconnect: () => undefined,
+    };
+  }
+
+  try {
+    const url = getAnalyticsEndpoint(campaignIds);
+    socket = new WebSocket(url);
+
+    socket.onopen = () => {
+      onOpen?.();
+    };
+
+    socket.onmessage = (event) => {
+      try {
+        const data = JSON.parse(event.data) as AnalyticsWebSocketMessage;
+        if (data?.payload?.campaigns) {
+          setCachedAnalyticsData<RealtimeAnalyticsPayload>(ANALYTICS_CACHE_KEY, data.payload, SNAPSHOT_TTL);
+          onMessage(data.payload);
+        }
+      } catch (error) {
+        onError?.(error as Error);
+      }
+    };
+
+    socket.onerror = (event) => {
+      onError?.(event);
+    };
+  } catch (error) {
+    onError?.(error as Error);
+  }
+
+  return {
+    disconnect: () => {
+      if (socket && socket.readyState !== WebSocket.CLOSED) {
+        socket.close();
+      }
+      invalidateAnalyticsCache(/^realtime-analytics/);
+    },
+  };
+}
+
+export async function fetchAnalyticsSnapshot(
+  campaignIds: string[]
+): Promise<RealtimeAnalyticsPayload> {
+  const cached = getCachedAnalyticsData<RealtimeAnalyticsPayload>(ANALYTICS_CACHE_KEY);
+  if (cached?.campaigns?.length) {
+    return cached;
+  }
+
+  if (typeof window === "undefined") {
+    return { campaigns: [], timestamp: Date.now() };
+  }
+
+  try {
+    const query = campaignIds.map((id) => `campaignId=${encodeURIComponent(id)}`).join("&");
+    const response = await fetch(`/api/analytics/snapshot${query ? `?${query}` : ""}`);
+    if (!response.ok) {
+      return { campaigns: [], timestamp: Date.now() };
+    }
+
+    const payload = (await response.json()) as RealtimeAnalyticsPayload;
+    setCachedAnalyticsData<RealtimeAnalyticsPayload>(ANALYTICS_CACHE_KEY, payload, SNAPSHOT_TTL);
+    return payload;
+  } catch (error) {
+    return { campaigns: [], timestamp: Date.now() };
+  }
+}


### PR DESCRIPTION
Implements a real-time analytics dashboard, predictive success modeling, campaign benchmarking, WebSocket snapshot caching, and export-ready analytics support. 
closes #597 