### PR TITLE
feat: QF hooks, recommendation service, fraud detection, backend blue-green

### DIFF
--- a/backend/fraud_detection/pipeline.py
+++ b/backend/fraud_detection/pipeline.py
@@ -1,0 +1,301 @@
+"""
+Fraud / Anomaly Detection Pipeline (#636)
+
+Detects suspicious patterns over indexed contribution and campaign data:
+
+ - Wash contributions  : same wallet contributing and immediately requesting
+                         a refund in a short window, repeatedly.
+ - Sudden spike        : campaign receives an unusually large number of
+                         contributions in a short window.
+ - Duplicate content   : campaign title/description appears nearly identical
+                         to an existing campaign (Jaccard similarity).
+
+Each check produces a ``Flag`` that is appended to a moderation queue and
+surfaced via the ``/moderation-queue`` endpoint.
+
+Heuristics and their thresholds are documented in
+``docs/fraud-detection-heuristics.md``.
+"""
+
+from __future__ import annotations
+
+import math
+import time
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Optional
+
+from fastapi import FastAPI, BackgroundTasks
+from fastapi.responses import JSONResponse
+
+# ---------------------------------------------------------------------------
+# Tuneable thresholds (see docs/fraud-detection-heuristics.md for rationale)
+# ---------------------------------------------------------------------------
+WASH_WINDOW_SECONDS = 3600          # contributions that refund within 1 h
+WASH_MIN_OCCURRENCES = 3            # flag after 3 wash cycles
+SPIKE_WINDOW_SECONDS = 600          # 10-minute rolling window
+SPIKE_MAX_CONTRIBUTIONS = 50        # > 50 contributions in 10 min → spike
+DUPLICATE_JACCARD_THRESHOLD = 0.8   # titles ≥ 80 % token overlap → duplicate
+
+
+# ---------------------------------------------------------------------------
+# Domain types
+# ---------------------------------------------------------------------------
+class FlagReason(str, Enum):
+    WASH_CONTRIBUTION = "wash_contribution"
+    CONTRIBUTION_SPIKE = "contribution_spike"
+    DUPLICATE_CONTENT = "duplicate_content"
+
+
+class FlagSeverity(str, Enum):
+    LOW = "low"
+    MEDIUM = "medium"
+    HIGH = "high"
+
+
+@dataclass
+class Flag:
+    id: str
+    reason: FlagReason
+    severity: FlagSeverity
+    campaign_id: str
+    wallet: Optional[str]
+    detail: str
+    flagged_at: float = field(default_factory=time.time)
+    reviewed: bool = False
+
+
+# ---------------------------------------------------------------------------
+# Moderation queue (in-memory; replace with DB in production)
+# ---------------------------------------------------------------------------
+_QUEUE: list[Flag] = []
+_FLAG_COUNTER = 0
+
+
+def _next_flag_id() -> str:
+    global _FLAG_COUNTER
+    _FLAG_COUNTER += 1
+    return f"FLAG-{_FLAG_COUNTER:05d}"
+
+
+def _enqueue(flag: Flag) -> None:
+    _QUEUE.append(flag)
+
+
+# ---------------------------------------------------------------------------
+# Indexed event store (populated by indexer; stubbed here)
+# ---------------------------------------------------------------------------
+@dataclass
+class ContributionEvent:
+    campaign_id: str
+    wallet: str
+    amount: int
+    timestamp: float
+
+
+@dataclass
+class RefundEvent:
+    campaign_id: str
+    wallet: str
+    timestamp: float
+
+
+@dataclass
+class CampaignRecord:
+    id: str
+    title: str
+    description: str
+
+
+_CONTRIBUTIONS: list[ContributionEvent] = []
+_REFUNDS: list[RefundEvent] = []
+_CAMPAIGN_RECORDS: list[CampaignRecord] = []
+
+
+# ---------------------------------------------------------------------------
+# Heuristic implementations
+# ---------------------------------------------------------------------------
+
+def _jaccard(a: str, b: str) -> float:
+    """Token-level Jaccard similarity between two strings."""
+    sa = set(a.lower().split())
+    sb = set(b.lower().split())
+    if not sa and not sb:
+        return 1.0
+    return len(sa & sb) / len(sa | sb)
+
+
+def scan_wash_contributions() -> list[Flag]:
+    """
+    Wash contribution heuristic.
+
+    A wallet that contributes then refunds the *same campaign* within
+    WASH_WINDOW_SECONDS, and does so WASH_MIN_OCCURRENCES or more times,
+    is flagged as a potential wash contributor.
+    """
+    flags: list[Flag] = []
+    # Group refunds by (campaign, wallet)
+    refund_lookup: dict[tuple[str, str], list[float]] = {}
+    for r in _REFUNDS:
+        key = (r.campaign_id, r.wallet)
+        refund_lookup.setdefault(key, []).append(r.timestamp)
+
+    # For each contribution, check if a refund followed within the window
+    wash_count: dict[tuple[str, str], int] = {}
+    for c in _CONTRIBUTIONS:
+        key = (c.campaign_id, c.wallet)
+        for rt in refund_lookup.get(key, []):
+            if 0 < rt - c.timestamp <= WASH_WINDOW_SECONDS:
+                wash_count[key] = wash_count.get(key, 0) + 1
+
+    for (campaign_id, wallet), count in wash_count.items():
+        if count >= WASH_MIN_OCCURRENCES:
+            flags.append(Flag(
+                id=_next_flag_id(),
+                reason=FlagReason.WASH_CONTRIBUTION,
+                severity=FlagSeverity.HIGH,
+                campaign_id=campaign_id,
+                wallet=wallet,
+                detail=f"Wallet performed {count} wash cycles within {WASH_WINDOW_SECONDS}s",
+            ))
+    return flags
+
+
+def scan_contribution_spikes() -> list[Flag]:
+    """
+    Sudden-spike heuristic.
+
+    If a campaign receives more than SPIKE_MAX_CONTRIBUTIONS in any
+    SPIKE_WINDOW_SECONDS rolling window, flag it as a potential sybil attack.
+    """
+    flags: list[Flag] = []
+    by_campaign: dict[str, list[float]] = {}
+    for c in _CONTRIBUTIONS:
+        by_campaign.setdefault(c.campaign_id, []).append(c.timestamp)
+
+    for campaign_id, timestamps in by_campaign.items():
+        ts = sorted(timestamps)
+        for i, t_start in enumerate(ts):
+            window = [t for t in ts[i:] if t - t_start <= SPIKE_WINDOW_SECONDS]
+            if len(window) > SPIKE_MAX_CONTRIBUTIONS:
+                flags.append(Flag(
+                    id=_next_flag_id(),
+                    reason=FlagReason.CONTRIBUTION_SPIKE,
+                    severity=FlagSeverity.MEDIUM,
+                    campaign_id=campaign_id,
+                    wallet=None,
+                    detail=(
+                        f"{len(window)} contributions in "
+                        f"{SPIKE_WINDOW_SECONDS}s window "
+                        f"(threshold: {SPIKE_MAX_CONTRIBUTIONS})"
+                    ),
+                ))
+                break  # one flag per campaign per scan
+    return flags
+
+
+def scan_duplicate_content() -> list[Flag]:
+    """
+    Duplicate-content heuristic.
+
+    Compares every pair of campaigns by title Jaccard similarity.
+    Pairs above DUPLICATE_JACCARD_THRESHOLD are flagged.
+    """
+    flags: list[Flag] = []
+    records = _CAMPAIGN_RECORDS
+    for i in range(len(records)):
+        for j in range(i + 1, len(records)):
+            a, b = records[i], records[j]
+            sim = _jaccard(a.title, b.title)
+            if sim >= DUPLICATE_JACCARD_THRESHOLD:
+                flags.append(Flag(
+                    id=_next_flag_id(),
+                    reason=FlagReason.DUPLICATE_CONTENT,
+                    severity=FlagSeverity.LOW,
+                    campaign_id=b.id,
+                    wallet=None,
+                    detail=(
+                        f"Title Jaccard similarity {sim:.2f} with campaign {a.id} "
+                        f"(threshold: {DUPLICATE_JACCARD_THRESHOLD})"
+                    ),
+                ))
+    return flags
+
+
+def run_full_scan() -> list[Flag]:
+    """Execute all heuristics and append new flags to the moderation queue."""
+    new_flags: list[Flag] = []
+    new_flags.extend(scan_wash_contributions())
+    new_flags.extend(scan_contribution_spikes())
+    new_flags.extend(scan_duplicate_content())
+    for f in new_flags:
+        _enqueue(f)
+    return new_flags
+
+
+# ---------------------------------------------------------------------------
+# FastAPI app
+# ---------------------------------------------------------------------------
+app = FastAPI(title="Fund-My-Cause Fraud Detection", version="1.0.0")
+
+
+@app.get("/health")
+def health() -> dict:
+    return {"status": "ok"}
+
+
+@app.post("/scan")
+def trigger_scan(background_tasks: BackgroundTasks) -> dict:
+    """Trigger a full fraud scan asynchronously."""
+    background_tasks.add_task(run_full_scan)
+    return {"status": "scan_scheduled"}
+
+
+@app.get("/moderation-queue")
+def moderation_queue(
+    reviewed: Optional[bool] = None,
+    reason: Optional[FlagReason] = None,
+    limit: int = 50,
+) -> JSONResponse:
+    """
+    Return flags from the moderation queue.
+
+    Query params:
+    - `reviewed`: filter by reviewed status (omit for all)
+    - `reason`: filter by flag reason
+    - `limit`: max flags returned (default 50)
+    """
+    items = _QUEUE
+    if reviewed is not None:
+        items = [f for f in items if f.reviewed == reviewed]
+    if reason is not None:
+        items = [f for f in items if f.reason == reason]
+    items = items[-limit:]
+
+    return JSONResponse(content={
+        "total": len(_QUEUE),
+        "returned": len(items),
+        "flags": [
+            {
+                "id": f.id,
+                "reason": f.reason,
+                "severity": f.severity,
+                "campaign_id": f.campaign_id,
+                "wallet": f.wallet,
+                "detail": f.detail,
+                "flagged_at": f.flagged_at,
+                "reviewed": f.reviewed,
+            }
+            for f in items
+        ],
+    })
+
+
+@app.patch("/moderation-queue/{flag_id}/reviewed")
+def mark_reviewed(flag_id: str) -> dict:
+    """Mark a flag as reviewed by a moderator."""
+    for f in _QUEUE:
+        if f.id == flag_id:
+            f.reviewed = True
+            return {"status": "updated", "id": flag_id}
+    return JSONResponse(status_code=404, content={"error": "flag not found"})

--- a/backend/fraud_detection/requirements.txt
+++ b/backend/fraud_detection/requirements.txt
@@ -1,0 +1,2 @@
+fastapi==0.111.0
+uvicorn[standard]==0.29.0

--- a/backend/fraud_detection/tests_pipeline.py
+++ b/backend/fraud_detection/tests_pipeline.py
@@ -1,0 +1,139 @@
+"""Tests for the fraud/anomaly detection pipeline (#636)."""
+
+import time
+import pytest
+from fastapi.testclient import TestClient
+
+from pipeline import (
+    CampaignRecord,
+    ContributionEvent,
+    FlagReason,
+    RefundEvent,
+    _CAMPAIGN_RECORDS,
+    _CONTRIBUTIONS,
+    _QUEUE,
+    _REFUNDS,
+    app,
+    scan_contribution_spikes,
+    scan_duplicate_content,
+    scan_wash_contributions,
+    WASH_MIN_OCCURRENCES,
+    WASH_WINDOW_SECONDS,
+    SPIKE_MAX_CONTRIBUTIONS,
+    SPIKE_WINDOW_SECONDS,
+)
+
+client = TestClient(app)
+
+
+def _clear():
+    _CONTRIBUTIONS.clear()
+    _REFUNDS.clear()
+    _CAMPAIGN_RECORDS.clear()
+    _QUEUE.clear()
+
+
+def test_health():
+    r = client.get("/health")
+    assert r.status_code == 200
+
+
+# ── Wash contribution ─────────────────────────────────────────────────────────
+
+def test_wash_contribution_flagged():
+    _clear()
+    now = time.time()
+    for i in range(WASH_MIN_OCCURRENCES):
+        _CONTRIBUTIONS.append(ContributionEvent("camp1", "GWASH", 1000, now + i * 10))
+        _REFUNDS.append(RefundEvent("camp1", "GWASH", now + i * 10 + 60))
+
+    flags = scan_wash_contributions()
+    assert len(flags) == 1
+    assert flags[0].reason == FlagReason.WASH_CONTRIBUTION
+    assert flags[0].wallet == "GWASH"
+
+
+def test_wash_below_threshold_not_flagged():
+    _clear()
+    now = time.time()
+    for i in range(WASH_MIN_OCCURRENCES - 1):
+        _CONTRIBUTIONS.append(ContributionEvent("camp2", "GCLEAN", 1000, now + i * 10))
+        _REFUNDS.append(RefundEvent("camp2", "GCLEAN", now + i * 10 + 60))
+
+    flags = scan_wash_contributions()
+    assert flags == []
+
+
+def test_wash_refund_outside_window_not_flagged():
+    _clear()
+    now = time.time()
+    for i in range(WASH_MIN_OCCURRENCES):
+        _CONTRIBUTIONS.append(ContributionEvent("camp3", "GSLOW", 1000, now + i * 10))
+        # Refund after window expires
+        _REFUNDS.append(RefundEvent("camp3", "GSLOW", now + WASH_WINDOW_SECONDS + 3600))
+
+    flags = scan_wash_contributions()
+    assert flags == []
+
+
+# ── Contribution spike ────────────────────────────────────────────────────────
+
+def test_spike_flagged():
+    _clear()
+    now = time.time()
+    for i in range(SPIKE_MAX_CONTRIBUTIONS + 1):
+        _CONTRIBUTIONS.append(ContributionEvent("campSpike", f"G{i}", 100, now + i))
+
+    flags = scan_contribution_spikes()
+    assert len(flags) == 1
+    assert flags[0].reason == FlagReason.CONTRIBUTION_SPIKE
+
+
+def test_spike_below_threshold_not_flagged():
+    _clear()
+    now = time.time()
+    for i in range(SPIKE_MAX_CONTRIBUTIONS - 1):
+        _CONTRIBUTIONS.append(ContributionEvent("campOk", f"G{i}", 100, now + i))
+
+    flags = scan_contribution_spikes()
+    assert flags == []
+
+
+# ── Duplicate content ─────────────────────────────────────────────────────────
+
+def test_duplicate_title_flagged():
+    _clear()
+    _CAMPAIGN_RECORDS.append(CampaignRecord("x1", "Fund a Solar Farm Project", "desc"))
+    _CAMPAIGN_RECORDS.append(CampaignRecord("x2", "Fund a Solar Farm Project", "desc2"))
+
+    flags = scan_duplicate_content()
+    assert len(flags) == 1
+    assert flags[0].reason == FlagReason.DUPLICATE_CONTENT
+
+
+def test_different_titles_not_flagged():
+    _clear()
+    _CAMPAIGN_RECORDS.append(CampaignRecord("y1", "Community Garden Initiative", ""))
+    _CAMPAIGN_RECORDS.append(CampaignRecord("y2", "Open Source Wallet Development", ""))
+
+    flags = scan_duplicate_content()
+    assert flags == []
+
+
+# ── Moderation queue endpoint ─────────────────────────────────────────────────
+
+def test_moderation_queue_returns_flags():
+    _clear()
+    now = time.time()
+    for i in range(WASH_MIN_OCCURRENCES):
+        _CONTRIBUTIONS.append(ContributionEvent("cq", "GQ", 1000, now + i * 5))
+        _REFUNDS.append(RefundEvent("cq", "GQ", now + i * 5 + 30))
+
+    from pipeline import run_full_scan
+    run_full_scan()
+
+    r = client.get("/moderation-queue")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["total"] >= 1
+    assert any(f["reason"] == FlagReason.WASH_CONTRIBUTION for f in body["flags"])

--- a/backend/recommendations/requirements.txt
+++ b/backend/recommendations/requirements.txt
@@ -1,0 +1,2 @@
+fastapi==0.111.0
+uvicorn[standard]==0.29.0

--- a/backend/recommendations/service.py
+++ b/backend/recommendations/service.py
@@ -1,0 +1,156 @@
+"""
+Campaign Recommendation Service (#635)
+
+Exposes GET /recommendations with per-wallet personalisation.
+Falls back to trending/popular campaigns for cold-start users.
+Results are cached with a configurable TTL.
+"""
+
+from __future__ import annotations
+
+import math
+import time
+from dataclasses import dataclass, field
+from typing import Optional
+
+from fastapi import FastAPI, Query
+from fastapi.responses import JSONResponse
+
+# ---------------------------------------------------------------------------
+# In-process cache (TTL-based)
+# ---------------------------------------------------------------------------
+_CACHE: dict[str, tuple[float, object]] = {}
+CACHE_TTL_SECONDS = 300  # 5 minutes
+
+
+def _cache_get(key: str) -> object | None:
+    entry = _CACHE.get(key)
+    if entry and time.time() - entry[0] < CACHE_TTL_SECONDS:
+        return entry[1]
+    return None
+
+
+def _cache_set(key: str, value: object) -> None:
+    _CACHE[key] = (time.time(), value)
+
+
+# ---------------------------------------------------------------------------
+# Domain types
+# ---------------------------------------------------------------------------
+@dataclass
+class Campaign:
+    id: str
+    title: str
+    category: str
+    total_raised: int
+    contributor_count: int
+    created_at: float
+
+
+@dataclass
+class IndexedActivity:
+    """Indexed on-chain activity for a contributor wallet."""
+
+    wallet: str
+    contributed_campaign_ids: list[str] = field(default_factory=list)
+    preferred_categories: list[str] = field(default_factory=list)
+
+
+# ---------------------------------------------------------------------------
+# Stub data store (replace with real DB / Horizon indexer in production)
+# ---------------------------------------------------------------------------
+_CAMPAIGNS: list[Campaign] = [
+    Campaign("c1", "Open-Source Wallet", "tech", 50_000, 120, time.time() - 86400),
+    Campaign("c2", "Community Garden", "environment", 20_000, 45, time.time() - 3600),
+    Campaign("c3", "Stellar SDK Docs", "tech", 80_000, 200, time.time() - 172800),
+    Campaign("c4", "Local Music Festival", "arts", 15_000, 30, time.time() - 7200),
+    Campaign("c5", "Solar Panels for Schools", "environment", 120_000, 300, time.time() - 43200),
+]
+
+_ACTIVITY: dict[str, IndexedActivity] = {}
+
+
+# ---------------------------------------------------------------------------
+# Scoring helpers
+# ---------------------------------------------------------------------------
+def _trending_score(c: Campaign) -> float:
+    """Recency-weighted activity: more weight to recent, active campaigns."""
+    age_hours = max((time.time() - c.created_at) / 3600, 1)
+    return (c.contributor_count * math.log1p(c.total_raised)) / age_hours
+
+
+def _personalised_score(c: Campaign, activity: IndexedActivity) -> float:
+    base = _trending_score(c)
+    # Boost campaigns in categories the user has previously contributed to
+    category_boost = 2.0 if c.category in activity.preferred_categories else 1.0
+    # Exclude campaigns the user already contributed to
+    already_contributed = c.id in activity.contributed_campaign_ids
+    return 0.0 if already_contributed else base * category_boost
+
+
+def _recommend(wallet: Optional[str], limit: int) -> list[dict]:
+    activity = _ACTIVITY.get(wallet) if wallet else None
+
+    if activity:
+        scored = sorted(
+            _CAMPAIGNS,
+            key=lambda c: _personalised_score(c, activity),
+            reverse=True,
+        )
+    else:
+        # Cold-start: return trending
+        scored = sorted(_CAMPAIGNS, key=_trending_score, reverse=True)
+
+    return [
+        {
+            "campaign_id": c.id,
+            "title": c.title,
+            "category": c.category,
+            "total_raised": c.total_raised,
+            "contributor_count": c.contributor_count,
+            "score": round(
+                _personalised_score(c, activity) if activity else _trending_score(c), 4
+            ),
+        }
+        for c in scored[:limit]
+    ]
+
+
+# ---------------------------------------------------------------------------
+# FastAPI app
+# ---------------------------------------------------------------------------
+app = FastAPI(title="Fund-My-Cause Recommendation Service", version="1.0.0")
+
+
+@app.get("/health")
+def health() -> dict:
+    return {"status": "ok"}
+
+
+@app.get("/recommendations")
+def get_recommendations(
+    wallet: Optional[str] = Query(None, description="Stellar wallet address for personalisation"),
+    limit: int = Query(5, ge=1, le=20, description="Maximum number of recommendations"),
+) -> JSONResponse:
+    """
+    Return ranked campaign recommendations.
+
+    - If `wallet` is provided and has indexed activity, results are personalised
+      by category affinity and exclude campaigns already contributed to.
+    - Cold-start (unknown wallet or no wallet) returns the top trending campaigns.
+    - Results are cached per (wallet, limit) key for CACHE_TTL_SECONDS.
+    """
+    cache_key = f"{wallet}:{limit}"
+    cached = _cache_get(cache_key)
+    if cached is not None:
+        return JSONResponse(content=cached, headers={"X-Cache": "HIT"})
+
+    recommendations = _recommend(wallet, limit)
+    payload = {
+        "wallet": wallet,
+        "personalised": wallet is not None and wallet in _ACTIVITY,
+        "recommendations": recommendations,
+        "cached_at": time.time(),
+    }
+    _cache_set(cache_key, payload)
+    return JSONResponse(content=payload, headers={"X-Cache": "MISS"})

--- a/backend/recommendations/tests_service.py
+++ b/backend/recommendations/tests_service.py
@@ -1,0 +1,101 @@
+"""Tests for the campaign recommendation service (#635)."""
+
+import pytest
+from fastapi.testclient import TestClient
+
+from service import (
+    IndexedActivity,
+    _ACTIVITY,
+    _CAMPAIGNS,
+    _recommend,
+    app,
+)
+
+client = TestClient(app)
+
+
+def test_health():
+    r = client.get("/health")
+    assert r.status_code == 200
+    assert r.json()["status"] == "ok"
+
+
+# ── Cold-start fallback ───────────────────────────────────────────────────────
+
+def test_cold_start_returns_trending():
+    """Unknown wallet → still gets sensible (trending) suggestions."""
+    r = client.get("/recommendations?wallet=GUNKNOWN&limit=3")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["personalised"] is False
+    assert len(body["recommendations"]) == 3
+    # All returned campaigns must be from our known set
+    known_ids = {c.id for c in _CAMPAIGNS}
+    for rec in body["recommendations"]:
+        assert rec["campaign_id"] in known_ids
+
+
+def test_no_wallet_returns_trending():
+    r = client.get("/recommendations?limit=2")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["personalised"] is False
+    assert len(body["recommendations"]) == 2
+
+
+# ── Personalised recommendations ─────────────────────────────────────────────
+
+def test_personalised_excludes_already_contributed():
+    """Campaigns already contributed to must not appear in recommendations."""
+    wallet = "GTESTPERSONALISED"
+    _ACTIVITY[wallet] = IndexedActivity(
+        wallet=wallet,
+        contributed_campaign_ids=["c1", "c3"],
+        preferred_categories=["tech"],
+    )
+    try:
+        result = _recommend(wallet, 10)
+        ids = [r["campaign_id"] for r in result]
+        assert "c1" not in ids
+        assert "c3" not in ids
+    finally:
+        del _ACTIVITY[wallet]
+
+
+def test_personalised_boosts_preferred_category():
+    """Campaigns in a preferred category must rank above unrelated ones."""
+    wallet = "GTESTBOOST"
+    _ACTIVITY[wallet] = IndexedActivity(
+        wallet=wallet,
+        contributed_campaign_ids=[],
+        preferred_categories=["environment"],
+    )
+    try:
+        result = _recommend(wallet, len(_CAMPAIGNS))
+        env_ids = {"c2", "c5"}  # environment campaigns
+        top_ids = {r["campaign_id"] for r in result[:2]}
+        # At least one environment campaign should be in the top 2
+        assert top_ids & env_ids
+    finally:
+        del _ACTIVITY[wallet]
+
+
+# ── Caching ───────────────────────────────────────────────────────────────────
+
+def test_cache_headers():
+    r1 = client.get("/recommendations?limit=1")
+    r2 = client.get("/recommendations?limit=1")
+    assert r1.headers.get("X-Cache") == "MISS"
+    assert r2.headers.get("X-Cache") == "HIT"
+
+
+# ── Limit validation ─────────────────────────────────────────────────────────
+
+def test_limit_too_large_rejected():
+    r = client.get("/recommendations?limit=99")
+    assert r.status_code == 422
+
+
+def test_limit_zero_rejected():
+    r = client.get("/recommendations?limit=0")
+    assert r.status_code == 422

--- a/contracts/crowdfund/src/lib.rs
+++ b/contracts/crowdfund/src/lib.rs
@@ -205,6 +205,10 @@ pub use types::{
     YieldInfo,
     EventYieldConfigured,
     EventYieldClaimed,
+    // #634 Quadratic-Funding Hooks
+    QfContributorInput,
+    QfInputs,
+    EventQfContribution,
 };
 pub use validation::*;
 
@@ -621,6 +625,9 @@ impl CrowdfundContract {
             inst.set(&DataKey::ContributorCount, &(count + 1));
         }
 
+        // Track updated contributor count for events
+        let updated_count: u32 = inst.get(&DataKey::ContributorCount).unwrap_or(0);
+
         // Use cached `largest` — conditional single write
         if new_contrib > largest {
             inst.set(&DataKey::LargestContribution, &new_contrib);
@@ -689,10 +696,21 @@ impl CrowdfundContract {
         env.events().publish(
             ("campaign", "contributed"),
             EventContributed {
-                contributor,
+                contributor: contributor.clone(),
                 amount,
                 new_total: new_contrib,
                 matched_amount,
+            },
+        );
+
+        // ── #634: Emit quadratic-funding weighting inputs ─────────────────────
+        env.events().publish(
+            ("campaign", "qf_contribution"),
+            EventQfContribution {
+                contributor,
+                amount,
+                cumulative: new_contrib,
+                contributor_count: updated_count,
             },
         );
         Ok(())
@@ -3127,6 +3145,45 @@ impl CrowdfundContract {
             contributor_count,
             average_contribution,
             largest_contribution,
+        }
+    }
+
+    /// Returns all inputs needed for off-chain quadratic-funding distribution.
+    ///
+    /// Walks the indexed contributor list and returns each address paired with
+    /// its cumulative contribution.  The sqrt-and-sum step is intentionally
+    /// left to the off-chain QF calculator so the contract stays lightweight.
+    ///
+    /// # Returns
+    /// `QfInputs` — contributor count and per-contributor amounts
+    pub fn get_qf_inputs(env: Env) -> QfInputs {
+        let inst = env.storage().instance();
+        let count: u32 = inst.get(&DataKey::ContributorCount).unwrap_or(0);
+
+        let mut contributors: soroban_sdk::Vec<QfContributorInput> =
+            soroban_sdk::Vec::new(&env);
+
+        for i in 0..count {
+            if let Some(addr) = env
+                .storage()
+                .persistent()
+                .get::<_, Address>(&DataKey::ContributorIndex(i))
+            {
+                let amount: i128 = env
+                    .storage()
+                    .persistent()
+                    .get(&DataKey::Contribution(addr.clone()))
+                    .unwrap_or(0);
+                contributors.push_back(QfContributorInput {
+                    contributor: addr,
+                    amount,
+                });
+            }
+        }
+
+        QfInputs {
+            contributor_count: count,
+            contributors,
         }
     }
 

--- a/contracts/crowdfund/src/types.rs
+++ b/contracts/crowdfund/src/types.rs
@@ -1478,3 +1478,46 @@ pub struct EventGovernanceEmergencyPaused {
 pub struct EventGovernanceEmergencyResumed {
     pub timestamp: u64,
 }
+
+// ── Issue #634: Quadratic-Funding Hooks ──────────────────────────────────────
+
+/// Per-contributor data used for off-chain quadratic-funding distribution.
+///
+/// `sqrt(contribution)` is computed off-chain; the contract exposes the raw
+/// inputs so any QF calculator can work with them without trusted intermediaries.
+#[derive(Clone)]
+#[contracttype]
+pub struct QfContributorInput {
+    /// Contributor address
+    pub contributor: Address,
+    /// Cumulative amount contributed by this address (in stroops)
+    pub amount: i128,
+}
+
+/// Aggregate QF inputs for the whole campaign.
+///
+/// Returned by `get_qf_inputs()`.
+#[derive(Clone)]
+#[contracttype]
+pub struct QfInputs {
+    /// Total number of unique contributors
+    pub contributor_count: u32,
+    /// Per-contributor amounts; ordered by first-contribution time
+    pub contributors: soroban_sdk::Vec<QfContributorInput>,
+}
+
+/// Emitted on every contribution with the per-contributor weighting inputs.
+///
+/// Event topic: `("campaign", "qf_contribution")`
+#[derive(Clone)]
+#[contracttype]
+pub struct EventQfContribution {
+    /// Contributor address
+    pub contributor: Address,
+    /// Incremental amount added in this contribution (in stroops)
+    pub amount: i128,
+    /// Contributor's cumulative total after this contribution (in stroops)
+    pub cumulative: i128,
+    /// Distinct-contributor count after this contribution
+    pub contributor_count: u32,
+}

--- a/contracts/crowdfund/tests/qf_tests.rs
+++ b/contracts/crowdfund/tests/qf_tests.rs
@@ -1,0 +1,80 @@
+#![cfg(test)]
+
+use soroban_sdk::{testutils::Address as _, Address, Env};
+
+mod common;
+use common::setup;
+
+/// Distinct contributor count must be accurate after repeated contributions
+/// from the same address (count should not increment on repeat contributions).
+#[test]
+fn test_qf_distinct_count_no_double_count() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let deadline = 1_000u64;
+    let c = setup(&env, 10_000, deadline, None);
+
+    let alice = Address::generate(&env);
+    c.token_admin.mint(&alice, &3_000i128);
+
+    env.ledger().set_timestamp(100);
+
+    // First contribution
+    c.client.contribute(&alice, &1_000, &c.token_id, &None);
+    assert_eq!(c.client.get_stats().contributor_count, 1);
+
+    // Repeat contribution from same address — count must stay at 1
+    c.client.contribute(&alice, &1_000, &c.token_id, &None);
+    assert_eq!(c.client.get_stats().contributor_count, 1);
+}
+
+/// Distinct contributor count increments for each new address.
+#[test]
+fn test_qf_distinct_count_multiple_contributors() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let c = setup(&env, 50_000, 2_000, None);
+
+    env.ledger().set_timestamp(100);
+
+    for i in 0..5u32 {
+        let addr = Address::generate(&env);
+        c.token_admin.mint(&addr, &1_000i128);
+        c.client.contribute(&addr, &1_000, &c.token_id, &None);
+        assert_eq!(c.client.get_stats().contributor_count, i + 1);
+    }
+}
+
+/// get_qf_inputs returns correct per-contributor amounts.
+#[test]
+fn test_qf_inputs_amounts() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let c = setup(&env, 50_000, 2_000, None);
+    env.ledger().set_timestamp(100);
+
+    let alice = Address::generate(&env);
+    let bob = Address::generate(&env);
+
+    c.token_admin.mint(&alice, &2_000i128);
+    c.token_admin.mint(&bob, &3_000i128);
+
+    c.client.contribute(&alice, &1_500, &c.token_id, &None);
+    c.client.contribute(&bob, &3_000, &c.token_id, &None);
+    // Alice contributes again — cumulative should be 2000 but capped at max
+    // (no max set here, so 1500 + 500 = 2000)
+    c.client.contribute(&alice, &500, &c.token_id, &None);
+
+    let inputs = c.client.get_qf_inputs();
+    assert_eq!(inputs.contributor_count, 2);
+
+    // First contributor indexed is Alice
+    let alice_entry = inputs.contributors.get(0).unwrap();
+    assert_eq!(alice_entry.amount, 2_000);
+
+    let bob_entry = inputs.contributors.get(1).unwrap();
+    assert_eq!(bob_entry.amount, 3_000);
+}

--- a/docs/blue-green-deployment.md
+++ b/docs/blue-green-deployment.md
@@ -296,3 +296,124 @@ Add to your release workflow:
 - [Deployment Guide](./deployment.md)
 - [Docker Guide](./docker.md)
 - [CI/CD Guide](./ci-cd.md)
+
+---
+
+## Backend Services (API & Indexer)
+
+The same blue-green pattern applies to the two backend services:
+
+| Service | Blue port | Green port |
+|---|---|---|
+| Recommendation API | 8000 | 8001 |
+| Fraud Detection API | 8002 | 8003 |
+
+### Architecture
+
+```
+┌─────────────────────────────────────────────────┐
+│                  Load Balancer                  │
+│               (nginx / HAProxy)                 │
+└───────────────┬─────────────────────────────────┘
+                │
+     ┌──────────┴──────────┐
+     │                     │
+ ┌───▼────┐           ┌───▼────┐
+ │  Blue  │           │ Green  │
+ │ :8000  │           │ :8001  │
+ └────────┘           └────────┘
+  (active)             (standby)
+```
+
+### Slot Definitions
+
+Each slot runs a dedicated container (or k8s Deployment) tagged with the image SHA:
+
+```bash
+# Blue slot — currently serving traffic
+docker run -d --name recommendations-blue -p 8000:8000 \
+  fund-my-cause/recommendations:blue-latest
+
+# Green slot — deploy new version here first
+docker run -d --name recommendations-green -p 8001:8000 \
+  fund-my-cause/recommendations:<new-sha>
+```
+
+Repeat the same pattern for the fraud-detection service on ports 8002/8003.
+
+### Health-Gated Traffic Switch
+
+Only switch traffic once the new slot passes its health check:
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+NEW_PORT=${1:?usage: switch-backend.sh <new_port> <service_name>}
+SERVICE=${2:?}
+NGINX_CONF=/etc/nginx/conf.d/${SERVICE}.conf
+
+# 1. Wait for health
+for i in $(seq 1 30); do
+  if curl -sf "http://localhost:${NEW_PORT}/health" > /dev/null; then
+    echo "Health check passed on port ${NEW_PORT}"
+    break
+  fi
+  echo "Waiting... ($i/30)"
+  sleep 5
+  [[ $i -eq 30 ]] && { echo "Health check timed out"; exit 1; }
+done
+
+# 2. Atomically rewrite the upstream and reload
+sed -i "s/server localhost:[0-9]\+;/server localhost:${NEW_PORT};/" "${NGINX_CONF}"
+nginx -s reload
+echo "Traffic switched to port ${NEW_PORT}"
+```
+
+### Database Migration Compatibility
+
+Backend services share a read-only view of indexed chain data. When a migration is needed:
+
+1. **Add columns only** — never drop or rename in the same release.
+2. Deploy the new schema with the *green* slot before switching traffic.
+3. The *blue* slot continues reading the old columns (which still exist) until it is replaced.
+4. After the switch is stable (≥ 1 deployment cycle), drop deprecated columns in a follow-up migration.
+
+This ensures both slots are compatible with the live schema at all times.
+
+### Rollback
+
+```bash
+# Identify the currently active port
+ACTIVE=$(cat /tmp/${SERVICE}_active_port.txt)
+
+# Switch back to the previous port
+PREVIOUS=$([ "$ACTIVE" = "8000" ] && echo "8001" || echo "8000")
+bash scripts/switch-backend.sh "$PREVIOUS" "$SERVICE"
+
+# Stop the failed slot
+docker stop ${SERVICE}-green
+```
+
+Rollback restores the previous slot in < 30 seconds. The failed container is stopped but not deleted — its logs remain available for post-mortem analysis.
+
+### CI/CD Integration
+
+```yaml
+# .github/workflows/blue-green-deploy.yml (backend jobs)
+- name: Deploy green slot
+  run: docker run -d --name ${{ env.SERVICE }}-green -p ${{ env.GREEN_PORT }}:8000
+       fund-my-cause/${{ env.SERVICE }}:${{ github.sha }}
+
+- name: Switch traffic
+  run: bash scripts/switch-backend.sh ${{ env.GREEN_PORT }} ${{ env.SERVICE }}
+
+- name: Stop old blue slot
+  run: docker stop ${{ env.SERVICE }}-blue || true
+```
+
+### Acceptance Criteria
+
+- Backend releases swap with **zero downtime**: health check gates the switch.
+- Rollback **restores the previous slot cleanly** in < 30 seconds.
+- Both slots are always **DB-migration compatible** via additive-only schema changes.

--- a/docs/fraud-detection-heuristics.md
+++ b/docs/fraud-detection-heuristics.md
@@ -1,0 +1,65 @@
+# Fraud Detection Heuristics
+
+Tuning guide for the anomaly detection pipeline (`backend/fraud_detection/pipeline.py`).
+
+## Heuristics
+
+### 1. Wash Contributions
+
+**Pattern**: A wallet contributes then refunds the same campaign repeatedly in a short window — inflating contributor count without leaving real capital.
+
+| Parameter | Default | Description |
+|---|---|---|
+| `WASH_WINDOW_SECONDS` | 3600 | Max seconds between contribution and refund to count as a wash cycle |
+| `WASH_MIN_OCCURRENCES` | 3 | Minimum wash cycles before flagging |
+
+**Severity**: HIGH
+
+**Tuning**: Lower `WASH_MIN_OCCURRENCES` to catch occasional wash traders; raise `WASH_WINDOW_SECONDS` to catch delayed refund patterns.
+
+---
+
+### 2. Contribution Spike
+
+**Pattern**: A campaign receives an abnormally large number of contributions in a short rolling window — indicative of Sybil attacks or bot farms boosting QF matching weight.
+
+| Parameter | Default | Description |
+|---|---|---|
+| `SPIKE_WINDOW_SECONDS` | 600 | Rolling window size in seconds |
+| `SPIKE_MAX_CONTRIBUTIONS` | 50 | Contribution count threshold within the window |
+
+**Severity**: MEDIUM
+
+**Tuning**: Adjust `SPIKE_MAX_CONTRIBUTIONS` based on observed organic peak traffic. A campaign going viral may legitimately spike; correlate with social media signals before actioning.
+
+---
+
+### 3. Duplicate Content
+
+**Pattern**: A new campaign's title is nearly identical to an existing campaign — potentially a scam clone trying to siphon donations.
+
+| Parameter | Default | Description |
+|---|---|---|
+| `DUPLICATE_JACCARD_THRESHOLD` | 0.80 | Minimum token-level Jaccard similarity to flag |
+
+**Severity**: LOW
+
+**Tuning**: 0.80 catches near-exact duplicates while ignoring campaigns that share common words (e.g., "Community Fund"). Lower to 0.65 for stricter detection; raise to 0.90 to reduce false positives.
+
+---
+
+## Moderation Queue
+
+Flags appear at `GET /moderation-queue`. Moderators review and dismiss via `PATCH /moderation-queue/{id}/reviewed`.
+
+Unreviewed HIGH severity flags should be actioned within 1 hour; MEDIUM within 24 hours; LOW within 7 days.
+
+---
+
+## Adding New Heuristics
+
+1. Implement a `scan_*()` function returning `list[Flag]`.
+2. Call it from `run_full_scan()`.
+3. Add a threshold constant at the top of `pipeline.py`.
+4. Document it in this file.
+5. Add a test in `tests_pipeline.py`.


### PR DESCRIPTION
closes #634  — Quadratic-Funding Contribution Weighting Hooks (Contract)
  
  - Added QfContributorInput, QfInputs, and EventQfContribution to contracts/crowdfund/src/types.rs
  - Added get_qf_inputs() getter to the contract — walks indexed contributor storage and returns per-address
  cumulative amounts for off-chain QF calculation
  - contribute() now emits ("campaign", "qf_contribution") carrying amount, cumulative, and contributor_count
   on every contribution
  - Distinct contributor count was already tracked via ContributorPresence + ContributorCount; the new getter
  surfaces it alongside per-contributor sums
  - Tests in contracts/crowdfund/tests/qf_tests.rs: distinct-count correctness after repeat contributions,
  multi-contributor counting, and per-contributor amount accuracy via get_qf_inputs()
  
 closes #635  — Campaign Recommendation Service (Backend)
  
  - New service at backend/recommendations/service.py (FastAPI)
  - Personalisation: boosts campaigns in categories the wallet has previously contributed to; excludes
  campaigns already contributed to
  - Cold-start fallback: returns trending campaigns ranked by recency-weighted activity score
  (contributor_count × log(total_raised) / age_hours)
  - Results cached per (wallet, limit) key with a 5-minute TTL; X-Cache: HIT/MISS header on every response
  - Endpoint: GET /recommendations?wallet=<address>&limit=<n>
  - Tests in backend/recommendations/tests_service.py: cold-start, personalised exclusion, category boost,
  cache headers, limit validation
  
 closes #636  — Fraud/Anomaly Detection Pipeline (Backend)
  
  - New service at backend/fraud_detection/pipeline.py (FastAPI)
  - Three heuristics: wash contributions (contribute → refund cycling), contribution spike (>50 contributions
  in a 10-min window), duplicate content (Jaccard title similarity ≥ 0.80)
  - All flags are appended to an in-memory moderation queue; exposed at GET /moderation-queue with filtering
  by reason/reviewed status
  - Moderators can dismiss flags via PATCH /moderation-queue/{id}/reviewed
  - Scan triggered via POST /scan (runs asynchronously in background)
  - Thresholds documented in docs/fraud-detection-heuristics.md with tuning guidance
  - Tests in backend/fraud_detection/tests_pipeline.py: each heuristic flagged/not-flagged boundary, queue
  endpoint
  
 closes #637  — Blue-Green Deployment for Backend Services (DevOps)
  
  - Extended docs/blue-green-deployment.md with a new Backend Services section
  - Defines blue/green slot port assignments for both services (recommendations: 8000/8001, fraud detection:
  8002/8003)
  - Provides a switch-backend.sh script with a health-gated loop before nginx reload
  - Documents additive-only DB migration strategy to keep both slots compatible across releases
  - Documents rollback procedure: slot restored in <30 seconds, failed container kept for post-mortem
  