### PR TITLE
feat: #631 add saved-search and alert subscription feature

### DIFF
--- a/apps/interface/src/app/campaigns/page.tsx
+++ b/apps/interface/src/app/campaigns/page.tsx
@@ -14,11 +14,14 @@ import { BreadcrumbProvider } from "@/context/BreadcrumbContext";
 import { AdvancedSearch } from "@/components/search/AdvancedSearch";
 import { SearchResults } from "@/components/search/SearchResults";
 import { useAdvancedSearch } from "@/hooks/useAdvancedSearch";
+import { useSavedSearches } from "@/hooks/useSavedSearches";
+import { useWallet } from "@/context/WalletContext";
 
 // ── Inner component (requires useSearchParams, wrapped in Suspense) ────────────
 
 function CampaignsInner() {
   const { selected, clear } = useComparison();
+  const { address } = useWallet();
   const [pledge, setPledge] = useState<string | null>(null);
   const [shareTarget, setShareTarget] = useState<{
     id: string;
@@ -43,7 +46,11 @@ function CampaignsInner() {
     clearAdvancedFilters,
     clearAll,
     clearSearch,
+    restoreFilters,
   } = useAdvancedSearch(ALL_CAMPAIGNS);
+
+  const { savedSearches, saveSearch, editSearch, removeSearch } =
+    useSavedSearches(ALL_CAMPAIGNS, address ?? "");
 
   return (
     <>
@@ -61,6 +68,11 @@ function CampaignsInner() {
         onToggleAdvanced={() => setShowAdvanced(!showAdvanced)}
         hasActiveFilters={hasActiveFilters}
         recentSearches={preferences.recentSearches}
+        savedSearches={savedSearches}
+        onSaveSearch={(name) => saveSearch(name, filters)}
+        onRestoreSearch={restoreFilters}
+        onDeleteSearch={removeSearch}
+        onRenameSearch={(id, name) => editSearch(id, { name })}
       />
 
       <div className="mt-6">

--- a/apps/interface/src/components/search/AdvancedSearch.tsx
+++ b/apps/interface/src/components/search/AdvancedSearch.tsx
@@ -4,8 +4,10 @@ import { useState, useEffect } from "react";
 import { Search, X, SlidersHorizontal, Sparkles } from "lucide-react";
 import { CATEGORY_TAXONOMY } from "@/lib/categories";
 import { SearchSuggestions } from "@/components/ui/SearchSuggestions";
+import { SavedSearchManager } from "@/components/search/SavedSearchManager";
 import type { SearchFilters } from "@/services/search.service";
 import type { SearchSuggestion } from "@/hooks/useSearchSuggestions";
+import type { SavedSearch } from "@/services/savedSearch.service";
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 
@@ -29,6 +31,16 @@ interface Props {
   recentSearches?: string[];
   /** Called when user wants to clear only the search query */
   onClearSearch: () => void;
+  /** Saved searches for the current wallet. */
+  savedSearches?: SavedSearch[];
+  /** Persist the current filters under a name. */
+  onSaveSearch?: (name: string) => void;
+  /** Restore a saved search's filters. */
+  onRestoreSearch?: (filters: SearchFilters) => void;
+  /** Delete a saved search. */
+  onDeleteSearch?: (id: string) => void;
+  /** Rename a saved search. */
+  onRenameSearch?: (id: string, name: string) => void;
 }
 
 // ── Constants ─────────────────────────────────────────────────────────────────
@@ -70,6 +82,11 @@ export function AdvancedSearch({
   onToggleAdvanced,
   hasActiveFilters,
   recentSearches = [],
+  savedSearches = [],
+  onSaveSearch,
+  onRestoreSearch,
+  onDeleteSearch,
+  onRenameSearch,
 }: Props) {
   const [activeIndex, setActiveIndex] = useState(-1);
   const [dropdownOpen, setDropdownOpen] = useState(false);
@@ -149,7 +166,8 @@ export function AdvancedSearch({
                 setActiveIndex((i) => Math.max(i - 1, -1));
               } else if (e.key === "Enter" && activeIndex >= 0) {
                 e.preventDefault();
-                handleSuggestionSelect(suggestions[activeIndex]);
+                const s = suggestions[activeIndex];
+                if (s) handleSuggestionSelect(s);
               } else if (e.key === "Escape") {
                 setDropdownOpen(false);
               }
@@ -365,6 +383,21 @@ export function AdvancedSearch({
               Apply
             </button>
           </div>
+        </div>
+      )}
+
+      {/* ── Saved searches panel ─────────────────────────────────────────── */}
+      {onSaveSearch && (
+        <div className="rounded-2xl border border-gray-700 bg-gray-900 p-4">
+          <h3 className="mb-3 text-sm font-semibold text-gray-300">Saved Searches</h3>
+          <SavedSearchManager
+            savedSearches={savedSearches}
+            onRestore={onRestoreSearch ?? (() => {})}
+            onDelete={onDeleteSearch ?? (() => {})}
+            onRename={onRenameSearch ?? (() => {})}
+            onSaveCurrent={onSaveSearch}
+            hasActiveFilters={hasActiveFilters}
+          />
         </div>
       )}
 

--- a/apps/interface/src/components/search/SavedSearchManager.tsx
+++ b/apps/interface/src/components/search/SavedSearchManager.tsx
@@ -1,0 +1,171 @@
+"use client";
+
+import React, { useState } from "react";
+import { Bookmark, Trash2, Pencil, Check, X } from "lucide-react";
+import type { SavedSearch } from "@/services/savedSearch.service";
+import type { SearchFilters } from "@/services/search.service";
+
+interface Props {
+  savedSearches: SavedSearch[];
+  /** Restore a saved search's filters into the search UI. */
+  onRestore: (filters: SearchFilters) => void;
+  onDelete: (id: string) => void;
+  onRename: (id: string, name: string) => void;
+  /** Save current active filters with a name. */
+  onSaveCurrent: (name: string) => void;
+  hasActiveFilters: boolean;
+}
+
+export function SavedSearchManager({
+  savedSearches,
+  onRestore,
+  onDelete,
+  onRename,
+  onSaveCurrent,
+  hasActiveFilters,
+}: Props) {
+  const [saveName, setSaveName] = useState("");
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [editingName, setEditingName] = useState("");
+  const [showSaveInput, setShowSaveInput] = useState(false);
+
+  const handleSave = () => {
+    const trimmed = saveName.trim();
+    if (!trimmed) return;
+    onSaveCurrent(trimmed);
+    setSaveName("");
+    setShowSaveInput(false);
+  };
+
+  const handleRename = (id: string) => {
+    const trimmed = editingName.trim();
+    if (!trimmed) return;
+    onRename(id, trimmed);
+    setEditingId(null);
+    setEditingName("");
+  };
+
+  const startEdit = (search: SavedSearch) => {
+    setEditingId(search.id);
+    setEditingName(search.name);
+  };
+
+  return (
+    <div className="space-y-3">
+      {/* Save current search */}
+      {hasActiveFilters && (
+        <div className="space-y-2">
+          {showSaveInput ? (
+            <div className="flex gap-2">
+              <input
+                autoFocus
+                type="text"
+                value={saveName}
+                onChange={(e) => setSaveName(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter") handleSave();
+                  if (e.key === "Escape") setShowSaveInput(false);
+                }}
+                placeholder="Name this search…"
+                className="flex-1 bg-gray-800 border border-gray-700 rounded-lg px-3 py-1.5 text-sm text-white placeholder-gray-500 focus:outline-none focus:border-indigo-500"
+                aria-label="Name for saved search"
+              />
+              <button
+                onClick={handleSave}
+                disabled={!saveName.trim()}
+                className="p-1.5 rounded-lg bg-indigo-600 hover:bg-indigo-700 text-white disabled:opacity-40"
+                aria-label="Confirm save"
+              >
+                <Check size={14} aria-hidden="true" />
+              </button>
+              <button
+                onClick={() => setShowSaveInput(false)}
+                className="p-1.5 rounded-lg bg-gray-700 hover:bg-gray-600 text-white"
+                aria-label="Cancel"
+              >
+                <X size={14} aria-hidden="true" />
+              </button>
+            </div>
+          ) : (
+            <button
+              onClick={() => setShowSaveInput(true)}
+              className="flex items-center gap-1.5 text-sm text-indigo-400 hover:text-indigo-300"
+            >
+              <Bookmark size={14} aria-hidden="true" />
+              Save current search
+            </button>
+          )}
+        </div>
+      )}
+
+      {/* Saved search list */}
+      {savedSearches.length === 0 ? (
+        <p className="text-xs text-gray-500">No saved searches yet.</p>
+      ) : (
+        <ul className="space-y-1" aria-label="Saved searches">
+          {savedSearches.map((search) => (
+            <li
+              key={search.id}
+              className="flex items-center gap-2 group rounded-lg px-2 py-1.5 hover:bg-gray-800"
+            >
+              {editingId === search.id ? (
+                <>
+                  <input
+                    autoFocus
+                    type="text"
+                    value={editingName}
+                    onChange={(e) => setEditingName(e.target.value)}
+                    onKeyDown={(e) => {
+                      if (e.key === "Enter") handleRename(search.id);
+                      if (e.key === "Escape") setEditingId(null);
+                    }}
+                    className="flex-1 bg-gray-700 border border-gray-600 rounded px-2 py-0.5 text-sm text-white focus:outline-none"
+                    aria-label="Edit search name"
+                  />
+                  <button
+                    onClick={() => handleRename(search.id)}
+                    className="p-1 text-green-400 hover:text-green-300"
+                    aria-label="Confirm rename"
+                  >
+                    <Check size={13} aria-hidden="true" />
+                  </button>
+                  <button
+                    onClick={() => setEditingId(null)}
+                    className="p-1 text-gray-400 hover:text-gray-300"
+                    aria-label="Cancel rename"
+                  >
+                    <X size={13} aria-hidden="true" />
+                  </button>
+                </>
+              ) : (
+                <>
+                  <button
+                    onClick={() => onRestore(search.filters)}
+                    className="flex-1 text-left text-sm text-gray-200 hover:text-white truncate"
+                    aria-label={`Restore saved search: ${search.name}`}
+                  >
+                    {search.name}
+                  </button>
+                  <button
+                    onClick={() => startEdit(search)}
+                    className="p-1 text-gray-500 hover:text-gray-300 opacity-0 group-hover:opacity-100 transition-opacity"
+                    aria-label={`Rename saved search: ${search.name}`}
+                  >
+                    <Pencil size={13} aria-hidden="true" />
+                  </button>
+                  <button
+                    onClick={() => onDelete(search.id)}
+                    className="p-1 text-gray-500 hover:text-red-400 opacity-0 group-hover:opacity-100 transition-opacity"
+                    aria-label={`Delete saved search: ${search.name}`}
+                  >
+                    <Trash2 size={13} aria-hidden="true" />
+                  </button>
+                </>
+              )}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/apps/interface/src/hooks/useAdvancedSearch.ts
+++ b/apps/interface/src/hooks/useAdvancedSearch.ts
@@ -22,6 +22,8 @@ import type {
 
 export type { SearchFilters, SearchResult, SortOption, FilterStatus };
 export type { ScoredCampaign, SearchFacets } from "@/services/search.service";
+export { useSavedSearches } from "@/hooks/useSavedSearches";
+export type { SavedSearch } from "@/services/savedSearch.service";
 
 const BASE_PATH = "/campaigns";
 
@@ -200,6 +202,25 @@ export function useAdvancedSearch(campaigns: Campaign[]) {
     router.replace(BASE_PATH, { scroll: false });
   }, [router]);
 
+  /** Restore a full filter set from a saved search. */
+  const restoreFilters = useCallback(
+    (f: SearchFilters) => {
+      const params = new URLSearchParams();
+      if (f.query) params.set("q", f.query);
+      if (f.category) params.set("category", f.category);
+      if (f.status && f.status !== "all") params.set("filter", f.status);
+      if (f.goalMin !== undefined) params.set("goalMin", String(f.goalMin));
+      if (f.goalMax !== undefined) params.set("goalMax", String(f.goalMax));
+      if (f.dateFrom) params.set("dateFrom", f.dateFrom);
+      if (f.dateTo) params.set("dateTo", f.dateTo);
+      if (f.sort && f.sort !== "recent") params.set("sort", f.sort);
+      if (f.query) setInputValue(f.query);
+      const qs = params.toString();
+      router.replace(qs ? `${BASE_PATH}?${qs}` : BASE_PATH, { scroll: false });
+    },
+    [router],
+  );
+
   // Clears only the search query, leaving other filters intact
   const clearSearch = useCallback(() => {
     setInputValue("");
@@ -228,5 +249,6 @@ export function useAdvancedSearch(campaigns: Campaign[]) {
     clearAdvancedFilters,
     clearAll,
     clearSearch,
+    restoreFilters,
   };
 }

--- a/apps/interface/src/hooks/useSavedSearches.ts
+++ b/apps/interface/src/hooks/useSavedSearches.ts
@@ -1,0 +1,81 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import type { SearchFilters } from "@/services/search.service";
+import type { Campaign } from "@/types/campaign";
+import {
+  SavedSearch,
+  loadSavedSearches,
+  persistSavedSearches,
+  createSavedSearch,
+  updateSavedSearch,
+  deleteSavedSearch,
+  checkSavedSearchAlerts,
+} from "@/services/savedSearch.service";
+import { useNotifications } from "@/context/NotificationContext";
+import { loadPreferences } from "@/services/search.service";
+
+/** Interval between alert-polling cycles (ms). */
+const POLL_INTERVAL_MS = 60_000;
+
+export function useSavedSearches(campaigns: Campaign[], walletAddress: string) {
+  const [savedSearches, setSavedSearches] = useState<SavedSearch[]>([]);
+  const { addNotification } = useNotifications();
+
+  // Load from localStorage on mount
+  useEffect(() => {
+    setSavedSearches(loadSavedSearches());
+  }, []);
+
+  // Persist whenever the list changes
+  useEffect(() => {
+    persistSavedSearches(savedSearches);
+  }, [savedSearches]);
+
+  // Poll for new campaign matches and fire notifications
+  useEffect(() => {
+    if (!walletAddress || savedSearches.length === 0 || campaigns.length === 0) return;
+
+    const check = () => {
+      // checkSavedSearchAlerts mutates seenIds in place; we must spread to
+      // trigger a React re-render so the updated seenIds are persisted.
+      const alerts = checkSavedSearchAlerts(
+        savedSearches,
+        campaigns,
+        walletAddress,
+      );
+      if (alerts.length > 0) {
+        setSavedSearches((prev) => [...prev]); // flush updated seenIds
+        for (const alert of alerts) {
+          addNotification({
+            type: "info",
+            title: `New matches for "${alert.savedSearch.name}"`,
+            message: `${alert.newCampaigns.length} new campaign${alert.newCampaigns.length > 1 ? "s" : ""} match your saved search.`,
+          });
+        }
+      }
+    };
+
+    check(); // run immediately on mount / dependency change
+    const id = setInterval(check, POLL_INTERVAL_MS);
+    return () => clearInterval(id);
+  }, [savedSearches, campaigns, walletAddress, addNotification]);
+
+  const saveSearch = useCallback(
+    (name: string, filters: SearchFilters) => {
+      const entry = createSavedSearch(name, filters, walletAddress || "anonymous", campaigns);
+      setSavedSearches((prev) => [entry, ...prev]);
+    },
+    [campaigns, walletAddress],
+  );
+
+  const editSearch = useCallback((id: string, patch: Partial<Pick<SavedSearch, "name" | "filters">>) => {
+    setSavedSearches((prev) => updateSavedSearch(prev, id, patch));
+  }, []);
+
+  const removeSearch = useCallback((id: string) => {
+    setSavedSearches((prev) => deleteSavedSearch(prev, id));
+  }, []);
+
+  return { savedSearches, saveSearch, editSearch, removeSearch };
+}

--- a/apps/interface/src/services/savedSearch.service.ts
+++ b/apps/interface/src/services/savedSearch.service.ts
@@ -1,0 +1,126 @@
+/**
+ * Saved-search persistence and alert matching service.
+ *
+ * Each saved search stores a name, the current filter set, and the set of
+ * campaign IDs that were already seen so notifications only fire for *new*
+ * matches.
+ */
+
+import type { SearchFilters } from "@/services/search.service";
+import type { Campaign } from "@/types/campaign";
+import {
+  advancedSearch,
+  loadPreferences,
+} from "@/services/search.service";
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+export interface SavedSearch {
+  id: string;
+  name: string;
+  filters: SearchFilters;
+  /** Wallet address the search belongs to (or "anonymous"). */
+  walletAddress: string;
+  createdAt: number;
+  /** IDs of campaigns that were already seen by the alert engine. */
+  seenIds: string[];
+}
+
+// ── Storage key ───────────────────────────────────────────────────────────────
+
+const STORAGE_KEY = "fmc:saved-searches";
+
+// ── Persistence helpers ───────────────────────────────────────────────────────
+
+export function loadSavedSearches(): SavedSearch[] {
+  if (typeof window === "undefined") return [];
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    return raw ? (JSON.parse(raw) as SavedSearch[]) : [];
+  } catch {
+    return [];
+  }
+}
+
+export function persistSavedSearches(searches: SavedSearch[]): void {
+  if (typeof window === "undefined") return;
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(searches));
+  } catch {
+    // Ignore storage errors
+  }
+}
+
+// ── CRUD helpers ──────────────────────────────────────────────────────────────
+
+export function createSavedSearch(
+  name: string,
+  filters: SearchFilters,
+  walletAddress: string,
+  campaigns: Campaign[],
+): SavedSearch {
+  const result = advancedSearch(campaigns, { ...filters, page: 1, pageSize: 9999 }, loadPreferences());
+  const seenIds = result.items.map((s) => s.campaign.id);
+  return {
+    id: `${Date.now()}-${Math.random().toString(36).slice(2)}`,
+    name: name.trim(),
+    filters,
+    walletAddress,
+    createdAt: Date.now(),
+    seenIds,
+  };
+}
+
+export function updateSavedSearch(
+  searches: SavedSearch[],
+  id: string,
+  patch: Partial<Pick<SavedSearch, "name" | "filters">>,
+): SavedSearch[] {
+  return searches.map((s) => (s.id === id ? { ...s, ...patch } : s));
+}
+
+export function deleteSavedSearch(searches: SavedSearch[], id: string): SavedSearch[] {
+  return searches.filter((s) => s.id !== id);
+}
+
+// ── Alert matching ────────────────────────────────────────────────────────────
+
+export interface SavedSearchAlert {
+  savedSearch: SavedSearch;
+  newCampaigns: Campaign[];
+}
+
+/**
+ * Checks all saved searches against the latest campaign list and returns any
+ * that now match campaigns the user hasn't seen yet.  Also updates `seenIds`
+ * in-place so subsequent calls don't re-fire the same alerts.
+ */
+export function checkSavedSearchAlerts(
+  searches: SavedSearch[],
+  campaigns: Campaign[],
+  walletAddress: string,
+): SavedSearchAlert[] {
+  const alerts: SavedSearchAlert[] = [];
+
+  for (const search of searches) {
+    if (search.walletAddress !== walletAddress) continue;
+
+    const result = advancedSearch(campaigns, {
+      ...search.filters,
+      page: 1,
+      pageSize: 9999,
+    }, loadPreferences());
+
+    const newCampaigns = result.items
+      .map((s) => s.campaign)
+      .filter((c) => !search.seenIds.includes(c.id));
+
+    if (newCampaigns.length > 0) {
+      // Mark as seen immediately to avoid duplicate alerts
+      search.seenIds = [...search.seenIds, ...newCampaigns.map((c) => c.id)];
+      alerts.push({ savedSearch: search, newCampaigns });
+    }
+  }
+
+  return alerts;
+}


### PR DESCRIPTION
closes #631 
Files changed:

savedSearch.service.ts
 (new) — pure CRUD helpers and alert-matching engine
useSavedSearches.ts
 (new) — React hook with localStorage persistence and polling (60 s interval)
SavedSearchManager.tsx
 (new) — inline UI panel for save / rename / delete / restore
useAdvancedSearch.ts
 — exports restoreFilters(), re-exports hook and types
AdvancedSearch.tsx
 — new optional saved-search props + renders SavedSearchManager
page.tsx
 — wires useSavedSearches and passes props to AdvancedSearch
How it works:

Saved searches are stored per wallet address in localStorage under fmc:saved-searches
On save, the current SearchFilters snapshot plus the set of already-matched campaign IDs (seenIds) are persisted
The polling loop calls checkSavedSearchAlerts every 60 s; new matches emit a NotificationContext notification
Restoring a saved search rebuilds the full URL query string via restoreFilters()