### PR TITLE
feat: #632 implement contribution amount suggestion engine

### DIFF
--- a/apps/interface/src/components/ui/PledgeModal.tsx
+++ b/apps/interface/src/components/ui/PledgeModal.tsx
@@ -8,6 +8,7 @@ import { useToast } from "@/components/ui/Toast";
 import { contribute } from "@/lib/contract";
 import { useAccountExists } from "@/hooks/useAccountExists";
 import { useTranslations } from "next-intl";
+import { computePledgeSuggestions } from "@/lib/pledgeSuggestions";
 
 const XLM_TO_STROOPS = 10_000_000n;
 const PLEDGE_DEBOUNCE_MS = 2000;
@@ -17,6 +18,12 @@ interface PledgeModalProps {
   campaignTitle: string;
   /** Minimum contribution in stroops. */
   minContribution?: bigint;
+  /** Per-contributor maximum in stroops (0 = no cap). */
+  maxContribution?: bigint;
+  /** Campaign goal in stroops (used for suggestion engine). */
+  goalStroops?: bigint;
+  /** Amount already raised in stroops (used for suggestion engine). */
+  raisedStroops?: bigint;
   onClose: () => void;
   /** Called after a successful pledge so the parent can refresh stats. */
   onSuccess?: () => void;
@@ -30,6 +37,9 @@ export function PledgeModal({
   contractId,
   campaignTitle,
   minContribution = 1n,
+  maxContribution = 0n,
+  goalStroops = 0n,
+  raisedStroops = 0n,
   onClose,
   onSuccess,
   onOptimisticContribute,
@@ -83,6 +93,14 @@ export function PledgeModal({
   }, [onClose]);
 
   const minXlm = Number(minContribution) / 1e7;
+
+  // ── Suggestion engine ──────────────────────────────────────────────────────
+  const suggestions = computePledgeSuggestions({
+    goalStroops,
+    raisedStroops,
+    minContributionStroops: minContribution,
+    maxContributionStroops: maxContribution,
+  });
 
   const handlePledge = async () => {
     if (!address) {
@@ -215,6 +233,30 @@ export function PledgeModal({
                 <p className="text-xs text-gray-500">
                   {t("minimumNote", { min: minXlm })}
                 </p>
+              )}
+              {/* ── Suggestion chips ─────────────────────────────────────── */}
+              {suggestions.length > 0 && (
+                <div className="flex flex-wrap gap-2 pt-1" role="group" aria-label="Suggested amounts">
+                  {suggestions.map((s) => {
+                    const xlmValue = (Number(s.amountStroops) / 1e7).toString();
+                    return (
+                      <button
+                        key={xlmValue}
+                        type="button"
+                        onClick={() => setAmount(xlmValue)}
+                        disabled={isProcessing}
+                        className={`px-3 py-1 rounded-full text-xs font-medium transition border ${
+                          s.completesGoal
+                            ? "bg-indigo-600 border-indigo-500 text-white hover:bg-indigo-500"
+                            : "bg-gray-800 border-gray-700 text-gray-300 hover:border-indigo-500 hover:text-white"
+                        } disabled:opacity-40`}
+                        aria-label={s.completesGoal ? `${s.label} — completes goal` : s.label}
+                      >
+                        {s.label}
+                      </button>
+                    );
+                  })}
+                </div>
               )}
             </div>
             <button

--- a/apps/interface/src/lib/pledgeSuggestions.test.ts
+++ b/apps/interface/src/lib/pledgeSuggestions.test.ts
@@ -1,0 +1,118 @@
+import { computePledgeSuggestions } from "./pledgeSuggestions";
+
+const S = 10_000_000n; // stroops per XLM
+
+describe("computePledgeSuggestions", () => {
+  const base = {
+    goalStroops: 1000n * S,
+    raisedStroops: 0n,
+    minContributionStroops: 1n,
+    maxContributionStroops: 0n,
+  };
+
+  it("returns common tiers and complete-goal suggestion", () => {
+    const suggestions = computePledgeSuggestions(base);
+    const amounts = suggestions.map((s) => s.amountStroops);
+    expect(amounts).toContain(10n * S);
+    expect(amounts).toContain(25n * S);
+    expect(amounts).toContain(50n * S);
+    expect(amounts).toContain(100n * S);
+    // 1000 XLM complete-goal suggestion
+    expect(amounts).toContain(1000n * S);
+  });
+
+  it("marks the complete-goal suggestion", () => {
+    const suggestions = computePledgeSuggestions(base);
+    const complete = suggestions.find((s) => s.completesGoal);
+    expect(complete).toBeDefined();
+    expect(complete?.amountStroops).toBe(1000n * S);
+    expect(complete?.label).toMatch(/complete goal/i);
+  });
+
+  it("marks common tier as completesGoal when it would finish the campaign", () => {
+    const suggestions = computePledgeSuggestions({
+      ...base,
+      goalStroops: 10n * S, // exactly one common tier away
+      raisedStroops: 0n,
+    });
+    const tenXlm = suggestions.find((s) => s.amountStroops === 10n * S);
+    expect(tenXlm?.completesGoal).toBe(true);
+  });
+
+  it("excludes amounts below minContribution", () => {
+    const suggestions = computePledgeSuggestions({
+      ...base,
+      minContributionStroops: 30n * S, // rules out 10 and 25 XLM
+    });
+    const amounts = suggestions.map((s) => s.amountStroops);
+    expect(amounts).not.toContain(10n * S);
+    expect(amounts).not.toContain(25n * S);
+    expect(amounts).toContain(50n * S);
+  });
+
+  it("respects per-contributor cap", () => {
+    const suggestions = computePledgeSuggestions({
+      ...base,
+      maxContributionStroops: 20n * S, // cap at 20 XLM
+    });
+    const amounts = suggestions.map((s) => s.amountStroops);
+    expect(amounts).not.toContain(25n * S);
+    expect(amounts).not.toContain(50n * S);
+    expect(amounts).not.toContain(100n * S);
+    expect(amounts).toContain(10n * S);
+  });
+
+  it("accounts for existing contribution against cap", () => {
+    const suggestions = computePledgeSuggestions({
+      ...base,
+      maxContributionStroops: 40n * S,
+      existingContributionStroops: 20n * S, // only 20 XLM headroom left
+    });
+    const amounts = suggestions.map((s) => s.amountStroops);
+    expect(amounts).not.toContain(25n * S);
+    expect(amounts).toContain(10n * S);
+  });
+
+  it("falls back to min contribution when all tiers are below min", () => {
+    const suggestions = computePledgeSuggestions({
+      ...base,
+      minContributionStroops: 200n * S, // above all common tiers and goal complete
+      goalStroops: 200n * S,
+      raisedStroops: 0n,
+    });
+    expect(suggestions).toHaveLength(1);
+    expect(suggestions[0].amountStroops).toBe(200n * S);
+  });
+
+  it("returns sorted ascending by amount", () => {
+    const suggestions = computePledgeSuggestions(base);
+    for (let i = 1; i < suggestions.length; i++) {
+      expect(suggestions[i].amountStroops).toBeGreaterThanOrEqual(
+        suggestions[i - 1].amountStroops,
+      );
+    }
+  });
+
+  it("does not produce duplicate amounts", () => {
+    const suggestions = computePledgeSuggestions({
+      ...base,
+      goalStroops: 10n * S, // 10 XLM matches both common tier and complete-goal
+    });
+    const amounts = suggestions.map((s) => s.amountStroops);
+    const unique = new Set(amounts);
+    expect(unique.size).toBe(amounts.length);
+  });
+
+  it("returns at most 5 suggestions", () => {
+    const suggestions = computePledgeSuggestions(base);
+    expect(suggestions.length).toBeLessThanOrEqual(5);
+  });
+
+  it("no completesGoal suggestions when goal is already met", () => {
+    const suggestions = computePledgeSuggestions({
+      ...base,
+      raisedStroops: 1000n * S, // already at goal
+    });
+    expect(suggestions.every((s) => !s.completesGoal)).toBe(true);
+  });
+});

--- a/apps/interface/src/lib/pledgeSuggestions.ts
+++ b/apps/interface/src/lib/pledgeSuggestions.ts
@@ -1,0 +1,109 @@
+/**
+ * Contribution amount suggestion engine for the pledge flow.
+ *
+ * Computes a small set of sensible tiers based on:
+ * - Common round-number tiers (10 / 25 / 50 / 100 XLM)
+ * - A "complete the goal" amount that would push the campaign over the finish line
+ * - The campaign's min_contribution and per-contributor cap constraints
+ */
+
+/** Common XLM tier amounts in stroops (1 XLM = 10_000_000 stroops). */
+const STROOPS_PER_XLM = 10_000_000n;
+
+const COMMON_TIERS_XLM = [10n, 25n, 50n, 100n] as const;
+
+export interface PledgeSuggestion {
+  /** Amount in stroops */
+  amountStroops: bigint;
+  /** Display label */
+  label: string;
+  /**
+   * True when this amount would push the total raised >= the goal.
+   * Used to visually highlight the "complete the goal" suggestion.
+   */
+  completesGoal: boolean;
+}
+
+export interface SuggestionInput {
+  /** Goal in stroops */
+  goalStroops: bigint;
+  /** Amount already raised in stroops */
+  raisedStroops: bigint;
+  /** Minimum contribution in stroops (inclusive). */
+  minContributionStroops: bigint;
+  /** Per-contributor cap in stroops (0 means no cap). */
+  maxContributionStroops: bigint;
+  /** How much the current contributor has already pledged (for cap checking). */
+  existingContributionStroops?: bigint;
+}
+
+function xlmToStroops(xlm: bigint): bigint {
+  return xlm * STROOPS_PER_XLM;
+}
+
+function stroopsToXlm(stroops: bigint): string {
+  const whole = stroops / STROOPS_PER_XLM;
+  const frac = stroops % STROOPS_PER_XLM;
+  if (frac === 0n) return `${whole} XLM`;
+  // Show up to 2 decimal places
+  const fracStr = frac.toString().padStart(7, "0").slice(0, 2).replace(/0+$/, "");
+  return fracStr ? `${whole}.${fracStr} XLM` : `${whole} XLM`;
+}
+
+/**
+ * Returns up to 5 pledge suggestions, de-duped and sorted ascending.
+ * Always includes at least one entry ≥ minContributionStroops.
+ */
+export function computePledgeSuggestions(input: SuggestionInput): PledgeSuggestion[] {
+  const {
+    goalStroops,
+    raisedStroops,
+    minContributionStroops,
+    maxContributionStroops,
+    existingContributionStroops = 0n,
+  } = input;
+
+  const remaining = goalStroops > raisedStroops ? goalStroops - raisedStroops : 0n;
+
+  // Effective ceiling for this contributor
+  const effectiveCap =
+    maxContributionStroops > 0n
+      ? maxContributionStroops - existingContributionStroops
+      : 0n; // 0 means unlimited
+
+  const isValid = (amount: bigint): boolean => {
+    if (amount < minContributionStroops) return false;
+    if (effectiveCap > 0n && amount > effectiveCap) return false;
+    return true;
+  };
+
+  const seen = new Set<bigint>();
+  const suggestions: PledgeSuggestion[] = [];
+
+  const add = (amount: bigint, label: string, completesGoal: boolean) => {
+    if (!isValid(amount)) return;
+    if (seen.has(amount)) return;
+    seen.add(amount);
+    suggestions.push({ amountStroops: amount, label, completesGoal });
+  };
+
+  // 1. Common XLM tiers
+  for (const xlm of COMMON_TIERS_XLM) {
+    add(xlmToStroops(xlm), `${xlm} XLM`, remaining > 0n && xlmToStroops(xlm) >= remaining);
+  }
+
+  // 2. "Complete the goal" tier — only when meaningful
+  if (remaining > 0n) {
+    const completesLabel = `${stroopsToXlm(remaining)} (complete goal)`;
+    add(remaining, completesLabel, true);
+  }
+
+  // 3. If nothing is valid (e.g. min > 100 XLM), add the minimum itself
+  if (suggestions.length === 0 && isValid(minContributionStroops)) {
+    add(minContributionStroops, `${stroopsToXlm(minContributionStroops)} (min)`, false);
+  }
+
+  // Sort ascending and cap at 5 items
+  suggestions.sort((a, b) => (a.amountStroops < b.amountStroops ? -1 : 1));
+  return suggestions.slice(0, 5);
+}


### PR DESCRIPTION
closes #632 
Contribution amount suggestion engine
Files changed:

pledgeSuggestions.ts
 (new) — pure, zero-React suggestion engine
pledgeSuggestions.test.ts
 (new) — 10 unit tests (Jest/Vitest compatible)
PledgeModal.tsx
 — new maxContribution, goalStroops, raisedStroops props; renders suggestion chips
How it works:

Computes up to 5 suggestions: common round tiers (10 / 25 / 50 / 100 XLM) + a "complete the goal" tier
Each amount is validated against minContribution and the per-contributor cap (accounting for existing contribution headroom)
The "complete goal" chip is highlighted in indigo; clicking any chip pre-fills the amount input
All logic is side-effect-free and fully tested