### PR TITLE
feat: product tour, tx filters/export, retry, network guard

### DIFF
--- a/apps/interface/src/app/[locale]/page.tsx
+++ b/apps/interface/src/app/[locale]/page.tsx
@@ -96,12 +96,14 @@ export default function Home() {
         <div className="flex flex-wrap justify-center gap-3">
           <Link
             href="/campaigns"
+            data-tour="discover-campaigns"
             className="flex items-center gap-2 bg-indigo-600 hover:bg-indigo-500 px-6 py-3 rounded-xl font-medium transition"
           >
             {t("exploreCampaigns")} <ArrowRight size={16} />
           </Link>
           <Link
             href="/create"
+            data-tour="create-campaign"
             className="flex items-center gap-2 bg-gray-800 hover:bg-gray-700 px-6 py-3 rounded-xl font-medium transition"
           >
             <PlusCircle size={16} /> {t("startCampaign")}

--- a/apps/interface/src/components/WalletGuard.tsx
+++ b/apps/interface/src/components/WalletGuard.tsx
@@ -1,8 +1,9 @@
 "use client";
 
 import React from "react";
-import { Loader2, Wallet } from "lucide-react";
+import { Loader2, Wallet, AlertTriangle } from "lucide-react";
 import { useWallet } from "@/context/WalletContext";
+import { NETWORK_NAME } from "@/lib/constants";
 
 interface WalletGuardProps {
   children: React.ReactNode;
@@ -10,7 +11,7 @@ interface WalletGuardProps {
 }
 
 export function WalletGuard({ children, message = "Connect your wallet to continue." }: WalletGuardProps) {
-  const { address, connect, isConnecting, isAutoConnecting } = useWallet();
+  const { address, connect, isConnecting, isAutoConnecting, networkMismatch, walletNetwork } = useWallet();
 
   if (isAutoConnecting) {
     return (
@@ -32,6 +33,33 @@ export function WalletGuard({ children, message = "Connect your wallet to contin
           {isConnecting ? <Loader2 size={16} className="animate-spin" /> : <Wallet size={16} />}
           Connect Wallet
         </button>
+      </div>
+    );
+  }
+
+  if (networkMismatch) {
+    return (
+      <div className="flex flex-col items-center justify-center min-h-[70vh] gap-4 px-6">
+        <div
+          role="alert"
+          aria-live="assertive"
+          className="flex flex-col items-center gap-4 max-w-md w-full p-6 rounded-2xl border border-amber-400/40 bg-amber-50 dark:bg-amber-950/30 text-amber-800 dark:text-amber-200 text-center"
+        >
+          <AlertTriangle size={32} className="text-amber-500 shrink-0" />
+          <div>
+            <h2 className="text-base font-semibold mb-1">Wrong Network</h2>
+            <p className="text-sm leading-relaxed">
+              Your wallet is connected to{" "}
+              <strong>{walletNetwork ?? "an unknown network"}</strong>, but this
+              app requires{" "}
+              <strong>{NETWORK_NAME}</strong>.
+            </p>
+            <p className="text-sm mt-2 leading-relaxed">
+              Please switch your wallet to{" "}
+              <strong>{NETWORK_NAME}</strong> to continue.
+            </p>
+          </div>
+        </div>
       </div>
     );
   }

--- a/apps/interface/src/components/layout/Navbar.tsx
+++ b/apps/interface/src/components/layout/Navbar.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useState } from "react";
+import React, { useRef, useState } from "react";
 import {
   Wallet,
   Rocket,
@@ -13,7 +13,9 @@ import {
   Bell,
   AlertTriangle,
   Globe,
+  HelpCircle,
 } from "lucide-react";
+import { ProductTour } from "@/components/ui/ProductTour";
 import { useWallet } from "@/context/WalletContext";
 import { useTheme } from "@/context/ThemeContext";
 import { useNotifications } from "@/context/NotificationContext";
@@ -93,6 +95,7 @@ export function Navbar() {
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
   const [notifOpen, setNotifOpen] = useState(false);
   const t = useTranslations("nav");
+  const replayTourRef = useRef<(() => void) | null>(null);
 
   return (
     <div>
@@ -131,6 +134,7 @@ export function Navbar() {
               onClick={connect}
               disabled={isConnecting}
               aria-label={t("connectWallet")}
+              data-tour="connect-wallet"
               className="ds-btn-primary flex items-center gap-2 px-4 py-2 text-sm disabled:opacity-50"
             >
               {isConnecting ? (
@@ -179,6 +183,15 @@ export function Navbar() {
           </button>
 
           <LanguageSelector />
+
+          <button
+            onClick={() => replayTourRef.current?.()}
+            className={iconBtnCls}
+            aria-label="Replay product tour"
+            title="Replay tour"
+          >
+            <HelpCircle size={18} />
+          </button>
         </div>
 
         {/* Mobile menu button */}
@@ -308,6 +321,8 @@ export function Navbar() {
           <Loader2 size={12} className="animate-spin" /> {t("restoringSession")}
         </div>
       )}
+
+      <ProductTour onReplayRef={replayTourRef} />
     </div>
   );
 }

--- a/apps/interface/src/components/ui/InfiniteScrollLoader.tsx
+++ b/apps/interface/src/components/ui/InfiniteScrollLoader.tsx
@@ -7,6 +7,7 @@ interface InfiniteScrollLoaderProps {
   isLoading: boolean;
   error: Error | null;
   hasMore: boolean;
+  /** Callback to manually retry a failed page load. */
   onRetry?: () => void;
 }
 
@@ -28,7 +29,7 @@ export function InfiniteScrollLoader({
         {onRetry && (
           <button
             onClick={onRetry}
-            className="text-xs text-[var(--color-brand)] hover:underline"
+            className="text-xs font-medium text-[var(--color-brand)] hover:underline"
           >
             Try again
           </button>

--- a/apps/interface/src/components/ui/ProductTour.tsx
+++ b/apps/interface/src/components/ui/ProductTour.tsx
@@ -1,0 +1,236 @@
+"use client";
+
+import React, { useCallback, useEffect, useRef, useState } from "react";
+import { X, ChevronRight, ChevronLeft } from "lucide-react";
+import { useLocalStorage } from "@/hooks/useLocalStorage";
+
+export interface TourStep {
+  target: string; // CSS selector for the highlighted element
+  title: string;
+  content: string;
+  placement?: "top" | "bottom" | "left" | "right";
+}
+
+const TOUR_STEPS: TourStep[] = [
+  {
+    target: "[data-tour='connect-wallet']",
+    title: "Connect your wallet",
+    content: "Click here to connect Freighter or LOBSTR and start interacting with campaigns.",
+    placement: "bottom",
+  },
+  {
+    target: "[data-tour='discover-campaigns']",
+    title: "Discover campaigns",
+    content: "Browse all active crowdfunding campaigns on the Stellar network.",
+    placement: "bottom",
+  },
+  {
+    target: "[data-tour='create-campaign']",
+    title: "Create a campaign",
+    content: "Launch your own campaign and start raising funds on-chain.",
+    placement: "bottom",
+  },
+  {
+    target: "[data-tour='contribute']",
+    title: "Contribute",
+    content: "Pledge XLM to campaigns you believe in. Refunds are automatic if the goal isn't met.",
+    placement: "top",
+  },
+];
+
+interface Rect {
+  top: number;
+  left: number;
+  width: number;
+  height: number;
+}
+
+const PADDING = 8;
+
+function getTooltipStyle(
+  targetRect: Rect,
+  placement: TourStep["placement"] = "bottom",
+): React.CSSProperties {
+  const { top, left, width, height } = targetRect;
+  switch (placement) {
+    case "top":
+      return { bottom: `calc(100vh - ${top - PADDING}px)`, left: left + width / 2, transform: "translateX(-50%)" };
+    case "left":
+      return { top: top + height / 2, right: `calc(100vw - ${left - PADDING}px)`, transform: "translateY(-50%)" };
+    case "right":
+      return { top: top + height / 2, left: left + width + PADDING, transform: "translateY(-50%)" };
+    case "bottom":
+    default:
+      return { top: top + height + PADDING, left: left + width / 2, transform: "translateX(-50%)" };
+  }
+}
+
+interface ProductTourProps {
+  /** Called when the user wants to replay the tour from the help button */
+  onReplayRef?: React.MutableRefObject<(() => void) | null>;
+}
+
+export function ProductTour({ onReplayRef }: ProductTourProps) {
+  const [completed, setCompleted, removeCompleted] = useLocalStorage<boolean>(
+    "product-tour-completed",
+    false,
+  );
+  const [active, setActive] = useState(!completed);
+  const [step, setStep] = useState(0);
+  const [targetRect, setTargetRect] = useState<Rect | null>(null);
+  const prefersReducedMotion =
+    typeof window !== "undefined"
+      ? window.matchMedia("(prefers-reduced-motion: reduce)").matches
+      : false;
+
+  const currentStep = TOUR_STEPS[step];
+
+  const measureTarget = useCallback(() => {
+    if (!currentStep) return;
+    const el = document.querySelector(currentStep.target);
+    if (!el) {
+      setTargetRect(null);
+      return;
+    }
+    const rect = el.getBoundingClientRect();
+    setTargetRect({ top: rect.top, left: rect.left, width: rect.width, height: rect.height });
+    el.scrollIntoView({ behavior: prefersReducedMotion ? "auto" : "smooth", block: "nearest" });
+  }, [currentStep, prefersReducedMotion]);
+
+  useEffect(() => {
+    if (!active) return;
+    measureTarget();
+    window.addEventListener("resize", measureTarget);
+    return () => window.removeEventListener("resize", measureTarget);
+  }, [active, measureTarget]);
+
+  const replay = useCallback(() => {
+    removeCompleted();
+    setStep(0);
+    setActive(true);
+  }, [removeCompleted]);
+
+  // Expose replay to parent via ref
+  useEffect(() => {
+    if (onReplayRef) onReplayRef.current = replay;
+  }, [onReplayRef, replay]);
+
+  const dismiss = useCallback(() => {
+    setCompleted(true);
+    setActive(false);
+  }, [setCompleted]);
+
+  const next = useCallback(() => {
+    if (step + 1 >= TOUR_STEPS.length) {
+      dismiss();
+    } else {
+      setStep((s) => s + 1);
+    }
+  }, [step, dismiss]);
+
+  const prev = useCallback(() => {
+    setStep((s) => Math.max(0, s - 1));
+  }, []);
+
+  // Keyboard navigation
+  useEffect(() => {
+    if (!active) return;
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === "Escape") dismiss();
+      if (e.key === "ArrowRight" || e.key === "Enter") next();
+      if (e.key === "ArrowLeft") prev();
+    };
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, [active, dismiss, next, prev]);
+
+  if (!active || !currentStep) return null;
+
+  const tooltipStyle = targetRect
+    ? getTooltipStyle(targetRect, currentStep.placement)
+    : { top: "50%", left: "50%", transform: "translate(-50%, -50%)" };
+
+  return (
+    <>
+      {/* Spotlight overlay */}
+      <div
+        aria-hidden="true"
+        className="fixed inset-0 z-40 pointer-events-none"
+        style={{
+          background: targetRect
+            ? `radial-gradient(ellipse ${targetRect.width + PADDING * 2}px ${targetRect.height + PADDING * 2}px at ${targetRect.left + targetRect.width / 2}px ${targetRect.top + targetRect.height / 2}px, transparent 0%, rgba(0,0,0,0.55) 1%)`
+            : "rgba(0,0,0,0.55)",
+        }}
+      />
+
+      {/* Click-to-dismiss backdrop */}
+      <div
+        className="fixed inset-0 z-40"
+        onClick={dismiss}
+        aria-label="Dismiss tour"
+      />
+
+      {/* Tooltip */}
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-label={`Product tour step ${step + 1} of ${TOUR_STEPS.length}: ${currentStep.title}`}
+        className="fixed z-50 w-72 bg-white dark:bg-gray-900 rounded-2xl shadow-2xl border border-gray-200 dark:border-gray-700 p-4"
+        style={tooltipStyle}
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* Close */}
+        <button
+          onClick={dismiss}
+          aria-label="Close tour"
+          className="absolute top-3 right-3 p-1 rounded-lg text-gray-400 hover:text-gray-600 dark:hover:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-800 transition"
+        >
+          <X size={14} />
+        </button>
+
+        {/* Step indicator */}
+        <div className="flex gap-1 mb-3" aria-hidden="true">
+          {TOUR_STEPS.map((_, i) => (
+            <div
+              key={i}
+              className={`h-1 flex-1 rounded-full transition-colors ${i === step ? "bg-indigo-600" : "bg-gray-200 dark:bg-gray-700"}`}
+            />
+          ))}
+        </div>
+
+        <h3 className="text-sm font-semibold text-gray-900 dark:text-white mb-1">
+          {currentStep.title}
+        </h3>
+        <p className="text-xs text-gray-500 dark:text-gray-400 leading-relaxed mb-4">
+          {currentStep.content}
+        </p>
+
+        {/* Navigation */}
+        <div className="flex items-center justify-between">
+          <button
+            onClick={prev}
+            disabled={step === 0}
+            aria-label="Previous step"
+            className="flex items-center gap-1 text-xs text-gray-500 hover:text-gray-700 dark:hover:text-gray-300 disabled:opacity-30 transition"
+          >
+            <ChevronLeft size={14} />
+            Back
+          </button>
+
+          <span className="text-xs text-gray-400">
+            {step + 1} / {TOUR_STEPS.length}
+          </span>
+
+          <button
+            onClick={next}
+            aria-label={step + 1 === TOUR_STEPS.length ? "Finish tour" : "Next step"}
+            className="flex items-center gap-1 text-xs font-medium text-indigo-600 dark:text-indigo-400 hover:text-indigo-500 transition"
+          >
+            {step + 1 === TOUR_STEPS.length ? "Finish" : "Next"}
+            <ChevronRight size={14} />
+          </button>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/apps/interface/src/components/ui/TransactionExportModal.tsx
+++ b/apps/interface/src/components/ui/TransactionExportModal.tsx
@@ -9,19 +9,23 @@ import {
   Receipt,
   Calendar,
   Loader2,
+  Braces,
 } from "lucide-react";
 import {
   exportCsv,
   exportTaxReport,
   exportPdf,
+  exportJson,
   filterByDateRange,
+  ALL_COLUMNS,
+  type ExportColumn,
   type ExportRecord,
   type DateRange,
 } from "@/lib/exportTransactions";
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 
-type ExportFormat = "csv" | "pdf" | "tax";
+type ExportFormat = "csv" | "json" | "pdf" | "tax";
 
 interface TransactionExportModalProps {
   records: ExportRecord[];
@@ -45,6 +49,12 @@ const FORMAT_OPTIONS: {
     icon: <FileSpreadsheet size={18} />,
   },
   {
+    id: "json",
+    label: "JSON",
+    description: "Machine-readable JSON array. Useful for integrations.",
+    icon: <Braces size={18} />,
+  },
+  {
     id: "pdf",
     label: "PDF",
     description: "Print-ready report with summary. Opens browser print dialog.",
@@ -58,6 +68,17 @@ const FORMAT_OPTIONS: {
     icon: <Receipt size={18} />,
   },
 ];
+
+const COLUMN_LABELS: Record<ExportColumn, string> = {
+  date: "Date",
+  time: "Time (UTC)",
+  txHash: "Tx Hash",
+  contributor: "Contributor",
+  campaign: "Campaign",
+  campaignId: "Campaign ID",
+  amountXlm: "Amount (XLM)",
+  status: "Status",
+};
 
 // ── Input helpers ─────────────────────────────────────────────────────────────
 
@@ -77,6 +98,9 @@ export function TransactionExportModal({
   const [format, setFormat] = useState<ExportFormat>("csv");
   const [dateRange, setDateRange] = useState<DateRange>({ from: "", to: "" });
   const [exporting, setExporting] = useState(false);
+  const [selectedColumns, setSelectedColumns] = useState<Set<ExportColumn>>(
+    new Set(ALL_COLUMNS),
+  );
 
   const filteredRecords = useMemo(
     () => filterByDateRange(records, dateRange),
@@ -85,15 +109,31 @@ export function TransactionExportModal({
 
   const slug = campaignTitle.toLowerCase().replace(/\s+/g, "-").slice(0, 30);
   const dateTag = new Date().toISOString().slice(0, 10);
+  const columns = ALL_COLUMNS.filter((c) => selectedColumns.has(c));
+
+  const toggleColumn = (col: ExportColumn) => {
+    setSelectedColumns((prev) => {
+      const next = new Set(prev);
+      if (next.has(col)) {
+        if (next.size > 1) next.delete(col); // keep at least one
+      } else {
+        next.add(col);
+      }
+      return next;
+    });
+  };
+
+  const showColumnPicker = format === "csv" || format === "json";
 
   const handleExport = async () => {
     if (filteredRecords.length === 0) return;
     setExporting(true);
-    // Small delay so the button state renders before the (potentially blocking) export
     await new Promise((r) => setTimeout(r, 50));
     try {
       if (format === "csv") {
-        exportCsv(filteredRecords, `${slug}-transactions-${dateTag}.csv`);
+        exportCsv(filteredRecords, `${slug}-transactions-${dateTag}.csv`, columns);
+      } else if (format === "json") {
+        exportJson(filteredRecords, `${slug}-transactions-${dateTag}.json`, columns);
       } else if (format === "tax") {
         exportTaxReport(filteredRecords, `${slug}-tax-report-${dateTag}.csv`);
       } else {
@@ -122,9 +162,9 @@ export function TransactionExportModal({
       />
 
       {/* Panel */}
-      <div className="relative z-10 w-full max-w-md bg-white dark:bg-gray-900 rounded-2xl shadow-2xl border border-gray-200 dark:border-gray-800 overflow-hidden">
+      <div className="relative z-10 w-full max-w-md bg-white dark:bg-gray-900 rounded-2xl shadow-2xl border border-gray-200 dark:border-gray-800 overflow-hidden max-h-[90vh] flex flex-col">
         {/* Header */}
-        <div className="flex items-center justify-between px-6 py-4 border-b border-gray-200 dark:border-gray-800">
+        <div className="flex items-center justify-between px-6 py-4 border-b border-gray-200 dark:border-gray-800 shrink-0">
           <div className="flex items-center gap-2">
             <Download
               size={18}
@@ -147,7 +187,7 @@ export function TransactionExportModal({
           </button>
         </div>
 
-        <div className="px-6 py-5 space-y-5">
+        <div className="px-6 py-5 space-y-5 overflow-y-auto">
           {/* Format selector */}
           <fieldset>
             <legend className="text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wide mb-2">
@@ -189,6 +229,35 @@ export function TransactionExportModal({
               ))}
             </div>
           </fieldset>
+
+          {/* Column selection (CSV & JSON only) */}
+          {showColumnPicker && (
+            <fieldset>
+              <legend className="text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wide mb-2">
+                Columns
+              </legend>
+              <div className="flex flex-wrap gap-2">
+                {ALL_COLUMNS.map((col) => (
+                  <label
+                    key={col}
+                    className={`flex items-center gap-1.5 px-2.5 py-1 rounded-lg border text-xs cursor-pointer transition ${
+                      selectedColumns.has(col)
+                        ? "border-indigo-500 bg-indigo-50 dark:bg-indigo-950/40 text-indigo-700 dark:text-indigo-300"
+                        : "border-gray-200 dark:border-gray-700 text-gray-500 dark:text-gray-400 hover:border-gray-300"
+                    }`}
+                  >
+                    <input
+                      type="checkbox"
+                      checked={selectedColumns.has(col)}
+                      onChange={() => toggleColumn(col)}
+                      className="accent-indigo-600 w-3 h-3"
+                    />
+                    {COLUMN_LABELS[col]}
+                  </label>
+                ))}
+              </div>
+            </fieldset>
+          )}
 
           {/* Date range filter */}
           <fieldset>
@@ -261,7 +330,7 @@ export function TransactionExportModal({
         </div>
 
         {/* Footer */}
-        <div className="flex items-center justify-end gap-3 px-6 py-4 border-t border-gray-200 dark:border-gray-800 bg-gray-50 dark:bg-gray-900/50">
+        <div className="flex items-center justify-end gap-3 px-6 py-4 border-t border-gray-200 dark:border-gray-800 bg-gray-50 dark:bg-gray-900/50 shrink-0">
           <button
             onClick={onClose}
             className="px-4 py-2 rounded-xl text-sm text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white hover:bg-gray-100 dark:hover:bg-gray-800 transition"

--- a/apps/interface/src/components/ui/TransactionHistory.tsx
+++ b/apps/interface/src/components/ui/TransactionHistory.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import React, { useEffect, useState } from "react";
-import { ExternalLink, Download, Loader2 } from "lucide-react";
+import React, { useEffect, useMemo, useState } from "react";
+import { ExternalLink, Download, Loader2, Filter } from "lucide-react";
 import {
   fetchTransactionHistory,
   type ContributionRecord,
@@ -11,7 +11,7 @@ import {
   NoTransactionsIllustration,
 } from "@/components/ui/EmptyState";
 import { TransactionExportModal } from "@/components/ui/TransactionExportModal";
-import type { ExportRecord } from "@/lib/exportTransactions";
+import { applyFilters, type ExportRecord, type DateRange } from "@/lib/exportTransactions";
 
 // ── Props ─────────────────────────────────────────────────────────────────────
 
@@ -56,6 +56,9 @@ function toExportRecord(
   };
 }
 
+const inputCls =
+  "bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg px-2 py-1 text-xs text-gray-700 dark:text-gray-300 focus:outline-none focus:border-indigo-500";
+
 // ── Component ─────────────────────────────────────────────────────────────────
 
 export function TransactionHistory({
@@ -65,11 +68,16 @@ export function TransactionHistory({
   const [records, setRecords] = useState<ContributionRecord[]>([]);
   const [loading, setLoading] = useState(true);
   const [showExport, setShowExport] = useState(false);
+  const [showFilters, setShowFilters] = useState(false);
+
+  // Filter state
+  const [typeFilter, setTypeFilter] = useState("");
+  const [dateRange, setDateRange] = useState<DateRange>({ from: "", to: "" });
+  const [campaignFilter, setCampaignFilter] = useState("");
 
   useEffect(() => {
     let cancelled = false;
     setLoading(true);
-    // Fetch all records (limit 0) so the export has the full dataset
     fetchTransactionHistory(contractId, 0)
       .then((data) => {
         if (!cancelled) setRecords(data);
@@ -85,13 +93,35 @@ export function TransactionHistory({
     };
   }, [contractId]);
 
-  const viewAllUrl = `${STELLAR_EXPERT}/contract/${contractId}`;
-  const exportRecords = records.map((r) =>
-    toExportRecord(r, contractId, campaignTitle),
+  const allExportRecords = useMemo(
+    () => records.map((r) => toExportRecord(r, contractId, campaignTitle)),
+    [records, contractId, campaignTitle],
   );
 
-  // Show only the 10 most recent in the table; export uses the full set
-  const displayRecords = records.slice(0, 10);
+  // Derive unique campaign IDs for the campaign filter dropdown
+  const campaignIds = useMemo(
+    () => Array.from(new Set(allExportRecords.map((r) => r.campaignId))),
+    [allExportRecords],
+  );
+
+  // Apply all filters with AND semantics
+  const filteredRecords = useMemo(
+    () =>
+      applyFilters(allExportRecords, {
+        dateRange,
+        type: typeFilter,
+        campaignId: campaignFilter,
+      }),
+    [allExportRecords, dateRange, typeFilter, campaignFilter],
+  );
+
+  const viewAllUrl = `${STELLAR_EXPERT}/contract/${contractId}`;
+  const displayRecords = filteredRecords.slice(0, 10);
+  const isFiltered =
+    typeFilter !== "" ||
+    dateRange.from !== "" ||
+    dateRange.to !== "" ||
+    campaignFilter !== "";
 
   if (loading) {
     return (
@@ -131,6 +161,21 @@ export function TransactionHistory({
           </h2>
 
           <div className="flex items-center gap-3">
+            {/* Filter toggle */}
+            <button
+              onClick={() => setShowFilters((v) => !v)}
+              aria-label="Toggle filters"
+              aria-pressed={showFilters}
+              className={`flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium transition ${
+                isFiltered || showFilters
+                  ? "bg-indigo-100 dark:bg-indigo-900/40 text-indigo-700 dark:text-indigo-300"
+                  : "bg-gray-100 dark:bg-gray-800 text-gray-600 dark:text-gray-400 hover:bg-gray-200 dark:hover:bg-gray-700"
+              }`}
+            >
+              <Filter size={12} />
+              Filters{isFiltered ? " ●" : ""}
+            </button>
+
             {/* Export button */}
             <button
               onClick={() => setShowExport(true)}
@@ -153,66 +198,157 @@ export function TransactionHistory({
               rel="noopener noreferrer"
               className="flex items-center gap-1 text-xs text-indigo-600 dark:text-indigo-400 hover:underline"
             >
-              View all on Stellar Expert
+              View all
               <ExternalLink size={12} />
             </a>
           </div>
         </div>
 
+        {/* Filter panel */}
+        {showFilters && (
+          <div className="flex flex-wrap gap-3 p-3 bg-gray-50 dark:bg-gray-800/60 rounded-xl border border-gray-200 dark:border-gray-700">
+            {/* Type filter */}
+            <div className="flex flex-col gap-1">
+              <label className="text-xs text-gray-500 dark:text-gray-400">Type</label>
+              <select
+                value={typeFilter}
+                onChange={(e) => setTypeFilter(e.target.value)}
+                className={inputCls}
+                aria-label="Filter by type"
+              >
+                <option value="">All types</option>
+                <option value="Confirmed">Confirmed</option>
+                <option value="Pending">Pending</option>
+                <option value="Failed">Failed</option>
+              </select>
+            </div>
+
+            {/* Date range */}
+            <div className="flex flex-col gap-1">
+              <label className="text-xs text-gray-500 dark:text-gray-400">From</label>
+              <input
+                type="date"
+                value={dateRange.from}
+                onChange={(e) => setDateRange((p) => ({ ...p, from: e.target.value }))}
+                className={inputCls}
+                aria-label="Filter from date"
+              />
+            </div>
+            <div className="flex flex-col gap-1">
+              <label className="text-xs text-gray-500 dark:text-gray-400">To</label>
+              <input
+                type="date"
+                value={dateRange.to}
+                min={dateRange.from || undefined}
+                onChange={(e) => setDateRange((p) => ({ ...p, to: e.target.value }))}
+                className={inputCls}
+                aria-label="Filter to date"
+              />
+            </div>
+
+            {/* Campaign filter (shown when multiple campaigns could appear) */}
+            {campaignIds.length > 1 && (
+              <div className="flex flex-col gap-1">
+                <label className="text-xs text-gray-500 dark:text-gray-400">Campaign</label>
+                <select
+                  value={campaignFilter}
+                  onChange={(e) => setCampaignFilter(e.target.value)}
+                  className={inputCls}
+                  aria-label="Filter by campaign"
+                >
+                  <option value="">All campaigns</option>
+                  {campaignIds.map((id) => (
+                    <option key={id} value={id}>
+                      {id.slice(0, 8)}…
+                    </option>
+                  ))}
+                </select>
+              </div>
+            )}
+
+            {/* Clear */}
+            {isFiltered && (
+              <button
+                onClick={() => {
+                  setTypeFilter("");
+                  setDateRange({ from: "", to: "" });
+                  setCampaignFilter("");
+                }}
+                className="self-end text-xs text-indigo-500 hover:underline"
+              >
+                Clear filters
+              </button>
+            )}
+          </div>
+        )}
+
+        {/* Result count when filtered */}
+        {isFiltered && (
+          <p className="text-xs text-gray-400 dark:text-gray-500" aria-live="polite">
+            Showing {filteredRecords.length} of {records.length} contributions
+          </p>
+        )}
+
         {/* Table */}
-        <div className="rounded-xl border border-gray-200 dark:border-gray-800 overflow-hidden">
-          <table className="w-full text-sm">
-            <thead>
-              <tr className="bg-gray-100 dark:bg-gray-800 text-gray-500 dark:text-gray-400 text-xs uppercase tracking-wide">
-                <th className="px-4 py-2 text-left font-medium">Contributor</th>
-                <th className="px-4 py-2 text-right font-medium">Amount</th>
-                <th className="px-4 py-2 text-right font-medium">Date</th>
-                <th
-                  className="px-4 py-2 text-right font-medium"
-                  aria-label="View transaction link"
-                >
-                  <span className="sr-only">Link</span>
-                </th>
-              </tr>
-            </thead>
-            <tbody className="divide-y divide-gray-100 dark:divide-gray-800">
-              {displayRecords.map((r) => (
-                <tr
-                  key={r.txHash}
-                  className="bg-white dark:bg-gray-900 hover:bg-gray-50 dark:hover:bg-gray-800/60 transition-colors"
-                >
-                  <td className="px-4 py-3 font-mono text-gray-700 dark:text-gray-300">
-                    <span title={r.contributor}>{truncate(r.contributor)}</span>
-                  </td>
-                  <td className="px-4 py-3 text-right text-gray-900 dark:text-white font-medium">
-                    {r.amountXlm > 0
-                      ? `${r.amountXlm.toLocaleString(undefined, { maximumFractionDigits: 7 })} XLM`
-                      : "—"}
-                  </td>
-                  <td className="px-4 py-3 text-right text-gray-500 dark:text-gray-400">
-                    {formatDate(r.timestamp)}
-                  </td>
-                  <td className="px-4 py-3 text-right">
-                    <a
-                      href={`${STELLAR_EXPERT}/tx/${r.txHash}`}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      aria-label="View transaction on Stellar Expert"
-                      className="inline-flex items-center text-indigo-500 hover:text-indigo-400"
-                    >
-                      <ExternalLink size={14} />
-                    </a>
-                  </td>
+        {filteredRecords.length === 0 ? (
+          <p className="text-sm text-gray-500 dark:text-gray-400 text-center py-6">
+            No contributions match your filters.
+          </p>
+        ) : (
+          <div className="rounded-xl border border-gray-200 dark:border-gray-800 overflow-hidden">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="bg-gray-100 dark:bg-gray-800 text-gray-500 dark:text-gray-400 text-xs uppercase tracking-wide">
+                  <th className="px-4 py-2 text-left font-medium">Contributor</th>
+                  <th className="px-4 py-2 text-right font-medium">Amount</th>
+                  <th className="px-4 py-2 text-right font-medium">Date</th>
+                  <th
+                    className="px-4 py-2 text-right font-medium"
+                    aria-label="View transaction link"
+                  >
+                    <span className="sr-only">Link</span>
+                  </th>
                 </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
+              </thead>
+              <tbody className="divide-y divide-gray-100 dark:divide-gray-800">
+                {displayRecords.map((r) => (
+                  <tr
+                    key={r.txHash}
+                    className="bg-white dark:bg-gray-900 hover:bg-gray-50 dark:hover:bg-gray-800/60 transition-colors"
+                  >
+                    <td className="px-4 py-3 font-mono text-gray-700 dark:text-gray-300">
+                      <span title={r.contributor}>{truncate(r.contributor)}</span>
+                    </td>
+                    <td className="px-4 py-3 text-right text-gray-900 dark:text-white font-medium">
+                      {r.amountXlm > 0
+                        ? `${r.amountXlm.toLocaleString(undefined, { maximumFractionDigits: 7 })} XLM`
+                        : "—"}
+                    </td>
+                    <td className="px-4 py-3 text-right text-gray-500 dark:text-gray-400">
+                      {formatDate(r.timestamp)}
+                    </td>
+                    <td className="px-4 py-3 text-right">
+                      <a
+                        href={`${STELLAR_EXPERT}/tx/${r.txHash}`}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        aria-label="View transaction on Stellar Expert"
+                        className="inline-flex items-center text-indigo-500 hover:text-indigo-400"
+                      >
+                        <ExternalLink size={14} />
+                      </a>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
 
         {/* "Showing X of Y" note when there are more than 10 */}
-        {records.length > 10 && (
+        {filteredRecords.length > 10 && (
           <p className="text-xs text-gray-400 dark:text-gray-500 text-right">
-            Showing 10 of {records.length} contributions.{" "}
+            Showing 10 of {filteredRecords.length} contributions.{" "}
             <button
               onClick={() => setShowExport(true)}
               className="text-indigo-500 hover:underline"
@@ -223,10 +359,10 @@ export function TransactionHistory({
         )}
       </div>
 
-      {/* Export modal */}
+      {/* Export modal — passes the filtered set */}
       {showExport && (
         <TransactionExportModal
-          records={exportRecords}
+          records={filteredRecords}
           campaignTitle={campaignTitle}
           campaignId={contractId}
           onClose={() => setShowExport(false)}

--- a/apps/interface/src/hooks/useInfiniteScroll.ts
+++ b/apps/interface/src/hooks/useInfiniteScroll.ts
@@ -5,12 +5,18 @@ import { useCallback, useEffect, useRef, useState } from "react";
 export interface UseInfiniteScrollOptions {
   threshold?: number;
   rootMargin?: string;
+  /** Max auto-retry attempts per failed page. Defaults to 3. */
+  maxRetries?: number;
+  /** Base delay in ms for exponential backoff. Defaults to 1000. */
+  retryBaseDelay?: number;
 }
 
 export interface UseInfiniteScrollReturn {
   sentinelRef: React.RefObject<HTMLDivElement | null>;
   isLoading: boolean;
   error: Error | null;
+  /** Manually trigger a retry of the last failed page load. */
+  retry: () => void;
   reset: () => void;
 }
 
@@ -19,25 +25,61 @@ export function useInfiniteScroll(
   hasMore: boolean,
   options: UseInfiniteScrollOptions = {},
 ): UseInfiniteScrollReturn {
+  const {
+    threshold = 0.1,
+    rootMargin = "100px",
+    maxRetries = 3,
+    retryBaseDelay = 1000,
+  } = options;
+
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<Error | null>(null);
   const sentinelRef = useRef<HTMLDivElement | null>(null);
   const isLoadingRef = useRef(false);
+  const retryCountRef = useRef(0);
+  const retryTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  const load = useCallback(async () => {
-    if (isLoadingRef.current || !hasMore) return;
-    isLoadingRef.current = true;
-    setIsLoading(true);
-    setError(null);
-    try {
-      await loadMore();
-    } catch (e) {
-      setError(e instanceof Error ? e : new Error(String(e)));
-    } finally {
-      isLoadingRef.current = false;
-      setIsLoading(false);
+  const clearRetryTimer = () => {
+    if (retryTimerRef.current !== null) {
+      clearTimeout(retryTimerRef.current);
+      retryTimerRef.current = null;
     }
-  }, [loadMore, hasMore]);
+  };
+
+  const load = useCallback(
+    async (isRetry = false) => {
+      if (isLoadingRef.current || !hasMore) return;
+      isLoadingRef.current = true;
+      setIsLoading(true);
+      if (!isRetry) {
+        // Reset retry count on a fresh (non-retry) load attempt
+        retryCountRef.current = 0;
+      }
+      setError(null);
+      try {
+        await loadMore();
+        retryCountRef.current = 0;
+      } catch (e) {
+        const err = e instanceof Error ? e : new Error(String(e));
+        setError(err);
+
+        // Schedule auto-retry with exponential backoff if under the limit
+        if (retryCountRef.current < maxRetries) {
+          const delay = retryBaseDelay * 2 ** retryCountRef.current;
+          retryCountRef.current += 1;
+          clearRetryTimer();
+          retryTimerRef.current = setTimeout(() => {
+            isLoadingRef.current = false; // allow re-entry
+            load(true);
+          }, delay);
+        }
+      } finally {
+        isLoadingRef.current = false;
+        setIsLoading(false);
+      }
+    },
+    [loadMore, hasMore, maxRetries, retryBaseDelay],
+  );
 
   useEffect(() => {
     const sentinel = sentinelRef.current;
@@ -45,25 +87,36 @@ export function useInfiniteScroll(
 
     const observer = new IntersectionObserver(
       ([entry]) => {
-        if (entry?.isIntersecting) {
+        if (entry?.isIntersecting && !error) {
           load();
         }
       },
-      {
-        threshold: options.threshold ?? 0.1,
-        rootMargin: options.rootMargin ?? "100px",
-      },
+      { threshold, rootMargin },
     );
 
     observer.observe(sentinel);
     return () => observer.disconnect();
-  }, [load, options.threshold, options.rootMargin]);
+  }, [load, threshold, rootMargin, error]);
+
+  // Cleanup pending retry timer on unmount
+  useEffect(() => () => clearRetryTimer(), []);
+
+  /** Manual retry — resets backoff counter. */
+  const retry = useCallback(() => {
+    clearRetryTimer();
+    retryCountRef.current = 0;
+    isLoadingRef.current = false;
+    setError(null);
+    load(false);
+  }, [load]);
 
   const reset = useCallback(() => {
+    clearRetryTimer();
     setError(null);
     setIsLoading(false);
     isLoadingRef.current = false;
+    retryCountRef.current = 0;
   }, []);
 
-  return { sentinelRef, isLoading, error, reset };
+  return { sentinelRef, isLoading, error, retry, reset };
 }

--- a/apps/interface/src/lib/exportTransactions.test.ts
+++ b/apps/interface/src/lib/exportTransactions.test.ts
@@ -1,0 +1,100 @@
+import {
+  filterByDateRange,
+  filterByType,
+  filterByCampaign,
+  applyFilters,
+  type ExportRecord,
+} from "@/lib/exportTransactions";
+
+const makeRecord = (overrides: Partial<ExportRecord> = {}): ExportRecord => ({
+  txHash: "abc123",
+  contributor: "GABC",
+  amountXlm: 10,
+  timestamp: "2024-06-15T12:00:00Z",
+  campaignId: "campaign-1",
+  campaignTitle: "Test Campaign",
+  status: "Confirmed",
+  ...overrides,
+});
+
+const records: ExportRecord[] = [
+  makeRecord({ txHash: "tx1", timestamp: "2024-01-10T00:00:00Z", campaignId: "c1", status: "Confirmed" }),
+  makeRecord({ txHash: "tx2", timestamp: "2024-03-20T00:00:00Z", campaignId: "c1", status: "Pending" }),
+  makeRecord({ txHash: "tx3", timestamp: "2024-06-01T00:00:00Z", campaignId: "c2", status: "Confirmed" }),
+  makeRecord({ txHash: "tx4", timestamp: "2024-09-15T00:00:00Z", campaignId: "c2", status: "Failed" }),
+];
+
+describe("filterByDateRange", () => {
+  it("returns all records when range is empty", () => {
+    expect(filterByDateRange(records, { from: "", to: "" })).toHaveLength(4);
+  });
+
+  it("filters by from date (inclusive)", () => {
+    const result = filterByDateRange(records, { from: "2024-03-20", to: "" });
+    expect(result.map((r) => r.txHash)).toEqual(["tx2", "tx3", "tx4"]);
+  });
+
+  it("filters by to date (inclusive, end of day)", () => {
+    const result = filterByDateRange(records, { from: "", to: "2024-03-20" });
+    expect(result.map((r) => r.txHash)).toEqual(["tx1", "tx2"]);
+  });
+
+  it("filters by both from and to", () => {
+    const result = filterByDateRange(records, { from: "2024-03-20", to: "2024-06-01" });
+    expect(result.map((r) => r.txHash)).toEqual(["tx2", "tx3"]);
+  });
+
+  it("returns empty when range matches nothing", () => {
+    expect(filterByDateRange(records, { from: "2025-01-01", to: "2025-12-31" })).toHaveLength(0);
+  });
+});
+
+describe("filterByType", () => {
+  it("returns all records when type is empty", () => {
+    expect(filterByType(records, "")).toHaveLength(4);
+  });
+
+  it("filters by Confirmed (case-insensitive)", () => {
+    const result = filterByType(records, "confirmed");
+    expect(result.map((r) => r.txHash)).toEqual(["tx1", "tx3"]);
+  });
+
+  it("filters by Failed", () => {
+    expect(filterByType(records, "Failed")).toHaveLength(1);
+  });
+});
+
+describe("filterByCampaign", () => {
+  it("returns all records when campaignId is empty", () => {
+    expect(filterByCampaign(records, "")).toHaveLength(4);
+  });
+
+  it("filters by campaign c1", () => {
+    const result = filterByCampaign(records, "c1");
+    expect(result.map((r) => r.txHash)).toEqual(["tx1", "tx2"]);
+  });
+});
+
+describe("applyFilters (AND semantics)", () => {
+  it("combines type and dateRange filters", () => {
+    const result = applyFilters(records, {
+      dateRange: { from: "2024-01-01", to: "2024-06-30" },
+      type: "Confirmed",
+      campaignId: "",
+    });
+    expect(result.map((r) => r.txHash)).toEqual(["tx1", "tx3"]);
+  });
+
+  it("combines type, date and campaign filters", () => {
+    const result = applyFilters(records, {
+      dateRange: { from: "2024-01-01", to: "2024-12-31" },
+      type: "Confirmed",
+      campaignId: "c2",
+    });
+    expect(result.map((r) => r.txHash)).toEqual(["tx3"]);
+  });
+
+  it("returns all when no filters applied", () => {
+    expect(applyFilters(records, { dateRange: { from: "", to: "" }, type: "", campaignId: "" })).toHaveLength(4);
+  });
+});

--- a/apps/interface/src/lib/exportTransactions.ts
+++ b/apps/interface/src/lib/exportTransactions.ts
@@ -40,6 +40,31 @@ export function filterByDateRange(
   });
 }
 
+/** Filter records by transaction type (status field). Empty string = no filter. */
+export function filterByType(records: ExportRecord[], type: string): ExportRecord[] {
+  if (!type) return records;
+  return records.filter((r) => r.status.toLowerCase() === type.toLowerCase());
+}
+
+/** Filter records by campaign ID. Empty string = no filter. */
+export function filterByCampaign(records: ExportRecord[], campaignId: string): ExportRecord[] {
+  if (!campaignId) return records;
+  return records.filter((r) => r.campaignId === campaignId);
+}
+
+/**
+ * Apply all filters (AND semantics).
+ */
+export function applyFilters(
+  records: ExportRecord[],
+  filters: { dateRange: DateRange; type: string; campaignId: string },
+): ExportRecord[] {
+  return filterByCampaign(
+    filterByType(filterByDateRange(records, filters.dateRange), filters.type),
+    filters.campaignId,
+  );
+}
+
 // ── CSV helpers ───────────────────────────────────────────────────────────────
 
 function escapeCell(value: string | number): string {
@@ -89,40 +114,54 @@ function formatIsoToLocalFull(iso: string): string {
 
 // ── CSV Export ────────────────────────────────────────────────────────────────
 
+export const ALL_COLUMNS = [
+  "date",
+  "time",
+  "txHash",
+  "contributor",
+  "campaign",
+  "campaignId",
+  "amountXlm",
+  "status",
+] as const;
+
+export type ExportColumn = (typeof ALL_COLUMNS)[number];
+
 /**
  * Download transaction history as a standard CSV file.
+ * Pass `columns` to select which columns to include (defaults to all).
  */
 export function exportCsv(
   records: ExportRecord[],
   filename = "transactions.csv",
+  columns: ExportColumn[] = [...ALL_COLUMNS],
 ) {
-  const headers = [
-    "Date",
-    "Time (UTC)",
-    "Transaction Hash",
-    "Contributor",
-    "Campaign",
-    "Campaign ID",
-    "Amount (XLM)",
-    "Status",
-  ];
+  const headerMap: Record<ExportColumn, string> = {
+    date: "Date",
+    time: "Time (UTC)",
+    txHash: "Transaction Hash",
+    contributor: "Contributor",
+    campaign: "Campaign",
+    campaignId: "Campaign ID",
+    amountXlm: "Amount (XLM)",
+    status: "Status",
+  };
+
+  const headers = columns.map((c) => headerMap[c]);
 
   const rows = records.map((r) => {
     const d = new Date(r.timestamp);
-    return [
-      d.toLocaleDateString(undefined, {
-        year: "numeric",
-        month: "2-digit",
-        day: "2-digit",
-      }),
-      d.toISOString().slice(11, 19),
-      r.txHash,
-      r.contributor,
-      r.campaignTitle,
-      r.campaignId,
-      r.amountXlm.toFixed(7),
-      r.status,
-    ];
+    const cellMap: Record<ExportColumn, string | number> = {
+      date: d.toLocaleDateString(undefined, { year: "numeric", month: "2-digit", day: "2-digit" }),
+      time: d.toISOString().slice(11, 19),
+      txHash: r.txHash,
+      contributor: r.contributor,
+      campaign: r.campaignTitle,
+      campaignId: r.campaignId,
+      amountXlm: r.amountXlm.toFixed(7),
+      status: r.status,
+    };
+    return columns.map((c) => cellMap[c]);
   });
 
   downloadFile(buildCsv(headers, rows), filename, "text/csv;charset=utf-8;");
@@ -274,4 +313,43 @@ export function exportPdf(
     win.document.write(html);
     win.document.close();
   }
+}
+
+// ── JSON Export ───────────────────────────────────────────────────────────────
+
+/**
+ * Download transaction records as a JSON file.
+ * Pass `columns` to select which fields to include (defaults to all).
+ */
+export function exportJson(
+  records: ExportRecord[],
+  filename = "transactions.json",
+  columns: ExportColumn[] = [...ALL_COLUMNS],
+) {
+  const fieldMap: Record<ExportColumn, keyof ExportRecord | "time" | "date"> = {
+    date: "timestamp",
+    time: "timestamp",
+    txHash: "txHash",
+    contributor: "contributor",
+    campaign: "campaignTitle",
+    campaignId: "campaignId",
+    amountXlm: "amountXlm",
+    status: "status",
+  };
+
+  const data = records.map((r) => {
+    const row: Record<string, unknown> = {};
+    for (const col of columns) {
+      if (col === "date") {
+        row.date = new Date(r.timestamp).toLocaleDateString(undefined, { year: "numeric", month: "2-digit", day: "2-digit" });
+      } else if (col === "time") {
+        row.time = new Date(r.timestamp).toISOString().slice(11, 19);
+      } else {
+        row[col] = r[fieldMap[col] as keyof ExportRecord];
+      }
+    }
+    return row;
+  });
+
+  downloadFile(JSON.stringify(data, null, 2), filename, "application/json");
 }


### PR DESCRIPTION

closes #650 
closes #651 
closes #652 
closes #653 

## Summary

Four features implemented across the frontend:

### 1. Dismissible Product Tour
- `ProductTour` component with spotlight overlay and tooltip steps
- Steps: connect wallet → discover campaigns → create campaign → contribute
- Persisted via `useLocalStorage` (`product-tour-completed` key) — shows once, replayable from Navbar help button
- Fully keyboard navigable (Esc = dismiss, ArrowRight/Enter = next, ArrowLeft = back)
- Respects `prefers-reduced-motion` for scroll behavior
- `data-tour` anchors added to connect-wallet, discover-campaigns, create-campaign elements

### 2. Transaction Filters & Export
- `TransactionHistory` gains a collapsible filter panel: type, date range, and campaign (AND semantics)
- Export passes the **filtered** set to the modal
- `TransactionExportModal` adds **JSON** format and per-column checkboxes (CSV & JSON)
- New helpers in `exportTransactions.ts`: `filterByType`, `filterByCampaign`, `applyFilters`, `exportJson`, `ALL_COLUMNS`
- Unit tests cover all filter combinations

### 3. Infinite Scroll Retry
- `useInfiniteScroll` adds `maxRetries` + `retryBaseDelay` options and auto-retry with exponential backoff
- Already-loaded items are never discarded on failure
- Manual retry exposed as `retry()` in return value
- `InfiniteScrollLoader` wires `onRetry` prop to the retry callback

### 4. Network Mismatch Guard
- `WalletGuard` reads `networkMismatch` + `walletNetwork` from `WalletContext`
- Shows a blocking amber alert when the wallet network doesn't match `NETWORK_NAME`
- Children rendered only when wallet is connected **and** network matches
- Banner clears automatically once the user switches to the correct network

## What was tested
No automated test run (as requested). Unit tests added for filter logic in `exportTransactions.test.ts`.