### PR TITLE
feat: Add autoscaling policies for API service

### DIFF
--- a/docs/autoscaling.md
+++ b/docs/autoscaling.md
@@ -1,0 +1,80 @@
+# API Autoscaling
+
+## Overview
+The Fund-My-Cause API uses multiple autoscaling strategies to handle varying loads efficiently.
+
+## Scaling Policies
+
+### Horizontal Pod Autoscaling (HPA)
+
+| Metric | Target | Threshold | Behavior |
+|--------|--------|-----------|----------|
+| CPU Utilization | 70% | 70% | Scale up when exceeded |
+| Memory Utilization | 80% | 80% | Scale up when exceeded |
+| Requests Per Second | 100 | 100 req/s | Scale up when exceeded |
+
+### Scaling Behavior
+
+**Scale Up:**
+- Add 2 pods every 30 seconds
+- Or increase by 50% every 30 seconds
+- No stabilization window (immediate)
+
+**Scale Down:**
+- Remove 1 pod every 60 seconds
+- 5-minute stabilization window
+- Prevents thrashing
+
+### Pod Limits
+- **Min:** 2 pods (for high availability)
+- **Max:** 10 pods (to prevent over-scaling)
+
+## Load Test Thresholds
+
+### Target Performance
+
+| Metric | Target | Critical |
+|--------|--------|----------|
+| Response Time (p95) | < 500ms | < 1000ms |
+| Error Rate | < 0.5% | < 1% |
+| Requests Per Second | > 50 | > 100 |
+
+### Load Test Stages
+
+| Stage | Users | Duration | Purpose |
+|-------|-------|----------|---------|
+| 1 | 50 | 2m | Ramp up to baseline |
+| 2 | 50 | 3m | Steady state |
+| 3 | 100 | 2m | Ramp up to medium |
+| 4 | 100 | 3m | Medium load |
+| 5 | 200 | 2m | Ramp up to peak |
+| 6 | 200 | 3m | Peak load |
+| 7 | 0 | 2m | Scale down |
+
+## Running Load Tests
+
+### Prerequisites
+```bash
+# Install k6
+brew install k6  # macOS
+sudo apt-get install k6  # Ubuntu
+# Set environment variables
+export API_URL=http://localhost:3000
+export API_KEY=your-api-key
+
+# Run load test
+./scripts/load-test.sh
+# View summary
+cat performance/load-test-summary.json | jq '.'
+
+# View detailed results
+cat performance/load-test-results.json | jq '.'
+kubectl describe hpa fund-my-cause-api-hpa
+kubectl top pods
+kubectl top nodes
+kubectl describe deployment fund-my-cause-api
+kubectl logs -f deployment/fund-my-cause-api
+resources:
+  requests:
+    cpu: "500m"
+    memory: "1Gi"

--- a/k8s/autoscaling/hpa-api.yaml
+++ b/k8s/autoscaling/hpa-api.yaml
@@ -1,0 +1,56 @@
+# Horizontal Pod Autoscaler for API Service
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: fund-my-cause-api-hpa
+  namespace: default
+  labels:
+    app: fund-my-cause-api
+    component: autoscaling
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: fund-my-cause-api
+  minReplicas: 2
+  maxReplicas: 10
+  metrics:
+    # CPU-based scaling
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 70
+    # Memory-based scaling
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: 80
+    # Request-based scaling (using Prometheus adapter)
+    - type: Pods
+      pods:
+        metric:
+          name: http_requests_per_second
+        target:
+          type: AverageValue
+          averageValue: "100"
+  behavior:
+    scaleDown:
+      stabilizationWindowSeconds: 300
+      policies:
+        - type: Pods
+          value: 1
+          periodSeconds: 60
+    scaleUp:
+      stabilizationWindowSeconds: 0
+      policies:
+        - type: Pods
+          value: 2
+          periodSeconds: 30
+        - type: Percent
+          value: 50
+          periodSeconds: 30
+      selectPolicy: Max

--- a/k8s/autoscaling/keda-scaledobject.yaml
+++ b/k8s/autoscaling/keda-scaledobject.yaml
@@ -1,0 +1,39 @@
+# KEDA ScaledObject for advanced event-based scaling
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: fund-my-cause-api-scaledobject
+  namespace: default
+  labels:
+    app: fund-my-cause-api
+    component: autoscaling
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: fund-my-cause-api
+  minReplicaCount: 2
+  maxReplicaCount: 10
+  pollingInterval: 30
+  cooldownPeriod: 300
+  triggers:
+    # Scale based on Prometheus metrics
+    - type: prometheus
+      metadata:
+        serverAddress: http://prometheus.monitoring.svc:9090
+        metricName: http_requests_total
+        query: |
+          sum(rate(http_requests_total{app="fund-my-cause-api"}[2m]))
+        threshold: "100"
+    # Scale based on queue length (Redis)
+    - type: redis
+      metadata:
+        address: redis.default.svc:6379
+        listName: api-queue
+        listLength: "50"
+    # Scale based on database connections
+    - type: postgresql
+      metadata:
+        connectionString: postgresql://fundmycause:fundmycause123@postgres.default.svc:5432/fundmycause
+        query: "SELECT COUNT(*) FROM pg_stat_activity WHERE state = 'active'"
+        targetQueryValue: "50"

--- a/k8s/autoscaling/vpa-api.yaml
+++ b/k8s/autoscaling/vpa-api.yaml
@@ -1,0 +1,26 @@
+# Vertical Pod Autoscaler for API Service
+apiVersion: autoscaling.k8s.io/v1
+kind: VerticalPodAutoscaler
+metadata:
+  name: fund-my-cause-api-vpa
+  namespace: default
+  labels:
+    app: fund-my-cause-api
+    component: autoscaling
+spec:
+  targetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: fund-my-cause-api
+  updatePolicy:
+    updateMode: "Auto"
+  resourcePolicy:
+    containerPolicies:
+      - containerName: api
+        minAllowed:
+          cpu: "100m"
+          memory: "256Mi"
+        maxAllowed:
+          cpu: "2"
+          memory: "4Gi"
+        controlledResources: ["cpu", "memory"]

--- a/k8s/deployment-api.yaml
+++ b/k8s/deployment-api.yaml
@@ -1,0 +1,70 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: fund-my-cause-api
+  namespace: default
+  labels:
+    app: fund-my-cause-api
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: fund-my-cause-api
+  template:
+    metadata:
+      labels:
+        app: fund-my-cause-api
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "3000"
+    spec:
+      containers:
+      - name: api
+        image: fund-my-cause-api:latest
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 3000
+          name: http
+        env:
+        - name: NODE_ENV
+          value: "production"
+        - name: DATABASE_URL
+          valueFrom:
+            secretKeyRef:
+              name: fund-my-cause-secrets
+              key: database-url
+        - name: REDIS_URL
+          valueFrom:
+            secretKeyRef:
+              name: fund-my-cause-secrets
+              key: redis-url
+        - name: JWT_SECRET
+          valueFrom:
+            secretKeyRef:
+              name: fund-my-cause-secrets
+              key: jwt-secret
+        resources:
+          requests:
+            cpu: "250m"
+            memory: "512Mi"
+          limits:
+            cpu: "1"
+            memory: "2Gi"
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: 3000
+          initialDelaySeconds: 30
+          periodSeconds: 10
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: 3000
+          initialDelaySeconds: 10
+          periodSeconds: 5
+        volumeMounts:
+        - name: tmp
+          mountPath: /tmp
+      volumes:
+      - name: tmp
+        emptyDir: {}

--- a/k8s/servicemonitor.yaml
+++ b/k8s/servicemonitor.yaml
@@ -1,0 +1,19 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: fund-my-cause-api
+  namespace: default
+  labels:
+    app: fund-my-cause-api
+spec:
+  selector:
+    matchLabels:
+      app: fund-my-cause-api
+  endpoints:
+  - port: http
+    interval: 15s
+    path: /metrics
+    metricRelabelings:
+    - sourceLabels: [__name__]
+      action: keep
+      regex: "http_requests_total|http_request_duration_seconds|node_cpu|node_memory"

--- a/performance/k6-load-test.js
+++ b/performance/k6-load-test.js
@@ -1,0 +1,96 @@
+// k6 Load Test for API Autoscaling Validation
+import http from 'k6/http';
+import { check, sleep } from 'k6';
+
+// Test configuration
+export const options = {
+  stages: [
+    // Stage 1: Ramp up to 50 users
+    { duration: '2m', target: 50 },
+    // Stage 2: Stay at 50 users (steady load)
+    { duration: '3m', target: 50 },
+    // Stage 3: Ramp up to 100 users
+    { duration: '2m', target: 100 },
+    // Stage 4: Stay at 100 users (high load)
+    { duration: '3m', target: 100 },
+    // Stage 5: Ramp up to 200 users
+    { duration: '2m', target: 200 },
+    // Stage 6: Stay at 200 users (peak load)
+    { duration: '3m', target: 200 },
+    // Stage 7: Ramp down to 0
+    { duration: '2m', target: 0 },
+  ],
+  thresholds: {
+    http_req_duration: ['p(95)<1000'], // 95% of requests under 1s
+    http_req_failed: ['rate<0.01'],    // Less than 1% failure rate
+    http_reqs: ['rate>50'],            // At least 50 RPS
+  },
+};
+
+// Test data
+const API_URL = __ENV.API_URL || 'http://localhost:3000';
+const API_KEY = __ENV.API_KEY || 'test-key';
+
+// Helper function to generate random data
+function generateData() {
+  return {
+    title: `Campaign ${Date.now()}`,
+    description: 'Test campaign description',
+    goalAmount: Math.floor(Math.random() * 10000) + 1000,
+  };
+}
+
+export default function () {
+  const headers = {
+    'Content-Type': 'application/json',
+    'Authorization': `Bearer ${API_KEY}`,
+  };
+
+  // Test 1: GET campaigns
+  const getCampaigns = http.get(`${API_URL}/api/campaigns`, { headers });
+  check(getCampaigns, {
+    'GET campaigns status is 200': (r) => r.status === 200,
+  });
+
+  // Test 2: GET campaign details
+  const campaignId = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
+  const getCampaign = http.get(`${API_URL}/api/campaigns/${campaignId}`, { headers });
+  check(getCampaign, {
+    'GET campaign status is 200': (r) => r.status === 200,
+  });
+
+  // Test 3: POST create campaign
+  const createCampaign = http.post(
+    `${API_URL}/api/campaigns`,
+    JSON.stringify(generateData()),
+    { headers }
+  );
+  check(createCampaign, {
+    'POST campaign status is 201': (r) => r.status === 201,
+  });
+
+  // Test 4: GraphQL query
+  const graphqlQuery = {
+    query: `
+      query {
+        campaigns {
+          id
+          title
+          raisedAmount
+          goalAmount
+        }
+      }
+    `,
+  };
+  const graphqlRequest = http.post(
+    `${API_URL}/api/graphql`,
+    JSON.stringify(graphqlQuery),
+    { headers }
+  );
+  check(graphqlRequest, {
+    'GraphQL status is 200': (r) => r.status === 200,
+  });
+
+  // Sleep between iterations
+  sleep(Math.random() * 2 + 0.5);
+}

--- a/scripts/load-test.sh
+++ b/scripts/load-test.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+# Load test script for API autoscaling validation
+
+set -e
+
+# Colors
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+RED='\033[0;31m'
+NC='\033[0m'
+
+echo -e "${YELLOW}🚀 Starting API load test...${NC}"
+
+# Check if k6 is installed
+if ! command -v k6 &> /dev/null; then
+    echo -e "${RED}❌ k6 is not installed.${NC}"
+    echo -e "${YELLOW}📦 Installing k6...${NC}"
+    
+    if [[ "$OSTYPE" == "darwin"* ]]; then
+        brew install k6
+    elif [[ "$OSTYPE" == "linux-gnu"* ]]; then
+        sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys C5AD17C747E3415A3642D57D77C6C491D6AC1D69
+        echo "deb https://dl.k6.io/deb stable main" | sudo tee /etc/apt/sources.list.d/k6.list
+        sudo apt-get update
+        sudo apt-get install k6
+    else
+        echo -e "${RED}❌ Please install k6 manually: https://k6.io/docs/getting-started/installation/${NC}"
+        exit 1
+    fi
+fi
+
+# Set environment variables
+export API_URL=${API_URL:-http://localhost:3000}
+export API_KEY=${API_KEY:-test-key}
+
+echo -e "${GREEN}📊 Running load test against ${API_URL}${NC}"
+
+# Run the load test
+k6 run performance/k6-load-test.js \
+    --out json=performance/load-test-results.json \
+    --summary-export=performance/load-test-summary.json
+
+# Check results
+if [ $? -eq 0 ]; then
+    echo -e "${GREEN}✅ Load test completed successfully!${NC}"
+else
+    echo -e "${RED}❌ Load test failed!${NC}"
+    exit 1
+fi
+
+# Parse results
+echo -e "${YELLOW}📊 Load test summary:${NC}"
+cat performance/load-test-summary.json | jq '.metrics | {http_req_failed, http_req_duration, http_reqs}'
+
+echo -e "${GREEN}📁 Results saved to performance/load-test-results.json${NC}"


### PR DESCRIPTION
## API Autoscaling Policies

### Summary
This PR adds comprehensive autoscaling policies for the API service.

### Changes
- ✅ HPA with CPU, memory, and RPS-based scaling
- ✅ VPA for vertical scaling recommendations
- ✅ KEDA ScaledObject for event-based scaling
- ✅ Load test configuration with k6
- ✅ Load test script for validation
- ✅ Complete documentation

### Scaling Policies
- CPU: Scale at 70% utilization
- Memory: Scale at 80% utilization
- RPS: Scale at 100 requests/second
- Min pods: 2
- Max pods: 10

### Load Test Stages
- 50 users: Baseline
- 100 users: Medium load
- 200 users: Peak load

### Files Added
- `k8s/autoscaling/hpa-api.yaml`
- `k8s/autoscaling/vpa-api.yaml`
- `k8s/autoscaling/keda-scaledobject.yaml`
- `k8s/deployment-api.yaml`
- `k8s/servicemonitor.yaml`
- `performance/k6-load-test.js`
- `scripts/load-test.sh`
- `docs/autoscaling.md`

### Testing
```bash
./scripts/load-test.sh

Closes #709