### PR TITLE
fix(auth): enforce JWT_SECRET validation at startup

### DIFF
--- a/services/graphql-api/src/index.ts
+++ b/services/graphql-api/src/index.ts
@@ -22,7 +22,30 @@ const NODE_ENV = process.env.NODE_ENV || "development";
 const RPC_URL = process.env.RPC_URL || "https://soroban-testnet.stellar.org";
 const CONTRACT_NETWORK = process.env.CONTRACT_NETWORK || "testnet";
 const REGISTRY_CONTRACT_ID = process.env.REGISTRY_CONTRACT_ID || "";
-const JWT_SECRET = process.env.JWT_SECRET || "your-secret-key-change-in-production";
+const JWT_SECRET = process.env.JWT_SECRET;
+
+// Validate JWT_SECRET at startup
+if (!JWT_SECRET || JWT_SECRET.trim() === "") {
+  console.error("FATAL: JWT_SECRET environment variable is required and must not be empty");
+  process.exit(1);
+}
+
+const knownDefaults = [
+  "your-secret-key",
+  "your-secret-key-change-in-production",
+  "dev-secret-key-change-in-production",
+];
+
+// Check for known defaults before length check
+if (knownDefaults.includes(JWT_SECRET)) {
+  console.error("FATAL: JWT_SECRET appears to be a default/example value and must be changed");
+  process.exit(1);
+}
+
+if (JWT_SECRET.length < 32) {
+  console.error("FATAL: JWT_SECRET must be at least 32 characters for secure operation");
+  process.exit(1);
+}
 
 /**
  * Initialize and start the GraphQL server

--- a/services/graphql-api/src/services/auth.bugfix.test.ts
+++ b/services/graphql-api/src/services/auth.bugfix.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { AuthService } from "./auth.js";
+
+/**
+ * Bug Condition Exploration Test for JWT_SECRET Hardcoded Fallback Vulnerability
+ * 
+ * **Validates: Requirements 1.1, 1.2, 1.3, 1.4**
+ * 
+ * CRITICAL: This test is EXPECTED TO FAIL on unfixed code.
+ * 
+ * The test verifies that the application correctly rejects insecure JWT_SECRET values
+ * by throwing errors or exiting. On unfixed code, the service accepts these insecure
+ * values, causing the test to fail. When the fix is implemented, this test will pass.
+ * 
+ * Property 1: Bug Condition - Insecure JWT_SECRET Acceptance
+ * For any application startup where JWT_SECRET is unset, empty, shorter than 32 characters,
+ * or set to a known default value, the fixed application SHALL reject it with a clear error.
+ */
+describe("Bug Condition: Insecure JWT_SECRET Acceptance", () => {
+  const KNOWN_DEFAULTS = [
+    "your-secret-key",
+    "your-secret-key-change-in-production",
+    "dev-secret-key-change-in-production",
+  ];
+
+  describe("AuthService constructor validation", () => {
+    it("should reject undefined JWT_SECRET", () => {
+      // Test case 1: JWT_SECRET unset (undefined)
+      // EXPECTED ON UNFIXED CODE: Constructor accepts undefined and uses fallback
+      // EXPECTED AFTER FIX: Constructor throws error
+      expect(() => {
+        new AuthService(undefined as any);
+      }).toThrow(/JWT_SECRET/);
+    });
+
+    it("should reject empty JWT_SECRET", () => {
+      // Test case 2: JWT_SECRET empty string
+      // EXPECTED ON UNFIXED CODE: Constructor accepts empty string and uses fallback
+      // EXPECTED AFTER FIX: Constructor throws error
+      expect(() => {
+        new AuthService("");
+      }).toThrow(/JWT_SECRET/);
+    });
+
+    it("should reject JWT_SECRET shorter than 32 characters", () => {
+      // Test case 3: JWT_SECRET too short
+      // EXPECTED ON UNFIXED CODE: Constructor accepts short secret
+      // EXPECTED AFTER FIX: Constructor throws error mentioning minimum length
+      expect(() => {
+        new AuthService("short");
+      }).toThrow(/32/);
+    });
+
+    it("should reject known default JWT_SECRET values", () => {
+      // Test case 4: JWT_SECRET is a known default value
+      // EXPECTED ON UNFIXED CODE: Constructor accepts default values
+      // EXPECTED AFTER FIX: Constructor throws error for each default
+      for (const defaultValue of KNOWN_DEFAULTS) {
+        expect(() => {
+          new AuthService(defaultValue);
+        }).toThrow(/default|example/i);
+      }
+    });
+
+    it("should reject whitespace-only JWT_SECRET", () => {
+      // Edge case: JWT_SECRET with only whitespace
+      // EXPECTED ON UNFIXED CODE: Constructor accepts whitespace
+      // EXPECTED AFTER FIX: Constructor throws error
+      expect(() => {
+        new AuthService("   ");
+      }).toThrow(/JWT_SECRET/);
+    });
+
+    it("should reject JWT_SECRET with 31 characters (boundary test)", () => {
+      // Boundary test: exactly 31 characters (one below minimum)
+      // EXPECTED ON UNFIXED CODE: Constructor accepts it
+      // EXPECTED AFTER FIX: Constructor throws error
+      const secret31 = "a".repeat(31);
+      expect(() => {
+        new AuthService(secret31);
+      }).toThrow(/32/);
+    });
+  });
+
+  describe("Expected behavior properties", () => {
+    it("Bug Condition Property: Application must fail-fast on insecure secrets", () => {
+      // This test encodes the expected behavior as a property:
+      // For ALL insecure JWT_SECRET values, the application must reject them
+      
+      const insecureSecrets = [
+        undefined,
+        "",
+        "   ",
+        "short",
+        "a".repeat(31),
+        ...KNOWN_DEFAULTS,
+      ];
+
+      for (const insecureSecret of insecureSecrets) {
+        // Each insecure secret should cause the AuthService to throw an error
+        expect(() => {
+          new AuthService(insecureSecret as any);
+        }).toThrow();
+      }
+    });
+
+    it("should accept valid JWT_SECRET (32+ chars, not default)", () => {
+      // Sanity check: Valid secrets should be accepted
+      // This verifies the validation doesn't reject ALL secrets
+      const validSecret = "a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6";
+      
+      expect(() => {
+        new AuthService(validSecret);
+      }).not.toThrow();
+      
+      const authService = new AuthService(validSecret);
+      expect(authService).toBeDefined();
+    });
+  });
+});

--- a/services/graphql-api/src/services/auth.preservation.test.ts
+++ b/services/graphql-api/src/services/auth.preservation.test.ts
@@ -1,0 +1,240 @@
+import { describe, it, expect } from "vitest";
+import { AuthService } from "./auth.js";
+import jwt from "jsonwebtoken";
+
+/**
+ * Preservation Property Tests for JWT_SECRET Hardcoded Fallback Bugfix
+ * 
+ * **Validates: Requirements 3.1, 3.2, 3.3, 3.4, 3.5, 3.6, 3.7, 3.8**
+ * 
+ * IMPORTANT: These tests run on UNFIXED code to observe baseline behavior.
+ * They verify that valid JWT_SECRET values (32+ chars, not defaults) work correctly.
+ * 
+ * Property 2: Preservation - Normal Operation with Valid JWT_SECRET
+ * For any application startup where JWT_SECRET is set to a string of 32 or more
+ * characters that is not in the known defaults list, the fixed application SHALL
+ * start normally and produce the same JWT generation and verification behavior
+ * as the original code.
+ * 
+ * EXPECTED OUTCOME: All tests PASS on unfixed code (baseline behavior to preserve)
+ */
+describe("Preservation Property: Normal Operation with Valid JWT_SECRET", () => {
+  const KNOWN_DEFAULTS = [
+    "your-secret-key",
+    "your-secret-key-change-in-production",
+    "dev-secret-key-change-in-production",
+  ];
+
+  /**
+   * Generate valid JWT_SECRET test cases
+   * Valid = 32+ characters AND not in known defaults
+   */
+  const generateValidSecrets = (): string[] => {
+    return [
+      // Exactly 32 characters (boundary case)
+      "a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6",
+      // More than 32 characters
+      "very-long-secret-key-for-testing-purposes-12345678",
+      // 64 characters (common for production secrets)
+      "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+      // With special characters
+      "my-$ecret-K3y!@#$%^&*()-_+={}[]|:;<>?,./~`",
+      // 100 characters
+      "a".repeat(100),
+      // Mixed case and numbers
+      "Aa1Bb2Cc3Dd4Ee5Ff6Gg7Hh8Ii9Jj0Kk1Ll2Mm3Nn4Oo5Pp6",
+    ];
+  };
+
+  describe("Property: Service starts normally with valid JWT_SECRET", () => {
+    it("should successfully instantiate AuthService with 32+ char secrets not in defaults", () => {
+      const validSecrets = generateValidSecrets();
+
+      for (const secret of validSecrets) {
+        // Verify the secret meets our criteria
+        expect(secret.length).toBeGreaterThanOrEqual(32);
+        expect(KNOWN_DEFAULTS).not.toContain(secret);
+
+        // OBSERVE: Service starts successfully with valid secret
+        expect(() => {
+          const authService = new AuthService(secret);
+          expect(authService).toBeDefined();
+        }).not.toThrow();
+      }
+    });
+  });
+
+  describe("Property: Token generation produces valid JWTs with address and iat claims", () => {
+    it("should generate tokens with address and iat claims for all valid secrets", () => {
+      const validSecrets = generateValidSecrets();
+      const testAddress = "GADDRESS123TEST";
+
+      for (const secret of validSecrets) {
+        const authService = new AuthService(secret);
+
+        // OBSERVE: generateToken produces a valid JWT
+        const token = authService.generateToken(testAddress);
+        expect(token).toBeDefined();
+        expect(typeof token).toBe("string");
+        expect(token.split(".").length).toBe(3); // JWT format: header.payload.signature
+
+        // OBSERVE: Token contains address claim and iat claim
+        const decoded = jwt.decode(token) as any;
+        expect(decoded).not.toBeNull();
+        expect(decoded.address).toBe(testAddress);
+        expect(decoded.iat).toBeDefined();
+        expect(typeof decoded.iat).toBe("number");
+      }
+    });
+  });
+
+  describe("Property: Token verification succeeds with correct signature", () => {
+    it("should successfully verify tokens generated with the same secret", () => {
+      const validSecrets = generateValidSecrets();
+      const testAddress = "GADDRESS456TEST";
+
+      for (const secret of validSecrets) {
+        const authService = new AuthService(secret);
+
+        // OBSERVE: Token generation and verification round-trip works
+        const token = authService.generateToken(testAddress);
+        const verified = authService.verifyToken(token);
+
+        // OBSERVE: Verification succeeds and returns correct data
+        expect(verified).not.toBeNull();
+        expect(verified?.address).toBe(testAddress);
+        expect(typeof verified?.iat).toBe("number");
+      }
+    });
+
+    it("should reject tokens when verified with a different secret", () => {
+      const secret1 = "a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6";
+      const secret2 = "z9y8x7w6v5u4t3s2r1q0p9o8n7m6l5k4";
+      
+      const authService1 = new AuthService(secret1);
+      const authService2 = new AuthService(secret2);
+
+      const token = authService1.generateToken("GADDRESS789TEST");
+
+      // OBSERVE: Token verification fails with wrong secret
+      const verifiedWithWrongSecret = authService2.verifyToken(token);
+      expect(verifiedWithWrongSecret).toBeNull();
+    });
+  });
+
+  describe("Property: Tokens use HS256 algorithm", () => {
+    it("should use HS256 algorithm for all valid secrets", () => {
+      const validSecrets = generateValidSecrets();
+      const testAddress = "GADDRESSHS256TEST";
+
+      for (const secret of validSecrets) {
+        const authService = new AuthService(secret);
+        const token = authService.generateToken(testAddress);
+
+        // OBSERVE: Token uses HS256 algorithm
+        const decoded = jwt.decode(token, { complete: true }) as any;
+        expect(decoded).not.toBeNull();
+        expect(decoded.header.alg).toBe("HS256");
+
+        // OBSERVE: Token can be verified using HS256 algorithm
+        const verified = jwt.verify(token, secret, { algorithms: ["HS256"] }) as any;
+        expect(verified.address).toBe(testAddress);
+      }
+    });
+  });
+
+  describe("Property: Token expiry logic works correctly", () => {
+    it("should respect token expiry settings for all valid secrets", () => {
+      const secret = "a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6";
+      const authService = new AuthService(secret, "24h");
+      
+      const token = authService.generateToken("GADDRESSEXPIRYTEST");
+      const decoded = jwt.decode(token) as any;
+
+      // OBSERVE: Token has exp claim
+      expect(decoded.exp).toBeDefined();
+      expect(typeof decoded.exp).toBe("number");
+
+      // OBSERVE: isTokenExpired returns false for fresh token
+      expect(authService.isTokenExpired(token)).toBe(false);
+
+      // OBSERVE: getTokenExpiry returns valid Date
+      const expiry = authService.getTokenExpiry(token);
+      expect(expiry).not.toBeNull();
+      expect(expiry).toBeInstanceOf(Date);
+    });
+  });
+
+  describe("Property: Multiple addresses can be encoded", () => {
+    it("should generate unique tokens for different addresses using the same secret", () => {
+      const secret = "a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6";
+      const authService = new AuthService(secret);
+
+      const addresses = [
+        "GADDRESS001",
+        "GADDRESS002",
+        "GADDRESS003",
+        "STELLAR_ADDRESS_LONG_FORMAT_TEST",
+        "A",
+      ];
+
+      const tokens = addresses.map(addr => authService.generateToken(addr));
+
+      // OBSERVE: Each address produces a different token
+      const uniqueTokens = new Set(tokens);
+      expect(uniqueTokens.size).toBe(addresses.length);
+
+      // OBSERVE: Each token verifies back to its original address
+      for (let i = 0; i < addresses.length; i++) {
+        const verified = authService.verifyToken(tokens[i]);
+        expect(verified?.address).toBe(addresses[i]);
+      }
+    });
+  });
+
+  describe("Property: Special characters in secrets are handled correctly", () => {
+    it("should work with secrets containing various special characters", () => {
+      const secretsWithSpecialChars = [
+        "my-secret-key-with-dashes-32chars!",
+        "my_secret_key_with_underscores_32",
+        "my.secret.key.with.dots.32chars!",
+        "my$secret@key#with%symbols&32chars",
+        "my secret key with spaces 32chars!",
+      ];
+
+      const testAddress = "GADDRESSSPECIALTEST";
+
+      for (const secret of secretsWithSpecialChars) {
+        // OBSERVE: AuthService handles special characters in secrets
+        const authService = new AuthService(secret);
+        const token = authService.generateToken(testAddress);
+        const verified = authService.verifyToken(token);
+
+        expect(verified).not.toBeNull();
+        expect(verified?.address).toBe(testAddress);
+      }
+    });
+  });
+
+  describe("Property: Long secrets work correctly", () => {
+    it("should handle very long secrets (100+ characters)", () => {
+      const longSecrets = [
+        "a".repeat(100),
+        "b".repeat(256),
+        "c".repeat(500),
+      ];
+
+      const testAddress = "GADDRESSLONGTEST";
+
+      for (const secret of longSecrets) {
+        // OBSERVE: Long secrets work correctly
+        const authService = new AuthService(secret);
+        const token = authService.generateToken(testAddress);
+        const verified = authService.verifyToken(token);
+
+        expect(verified).not.toBeNull();
+        expect(verified?.address).toBe(testAddress);
+      }
+    });
+  });
+});

--- a/services/graphql-api/src/services/auth.test.ts
+++ b/services/graphql-api/src/services/auth.test.ts
@@ -3,7 +3,8 @@ import jwt from "jsonwebtoken";
 import { AuthService } from "./auth.js";
 
 describe("AuthService", () => {
-  const secret = "test-secret-key";
+  // Use a valid 32+ character secret for testing
+  const secret = "test-secret-key-32-chars-minimum!";
   let auth: AuthService;
 
   beforeEach(() => {
@@ -30,7 +31,8 @@ describe("AuthService", () => {
 
     it("rejects a token verified against a different secret", () => {
       const token = auth.generateToken("GADDRESS123");
-      const otherAuth = new AuthService("a-completely-different-secret", "24h");
+      // Use another valid 32+ character secret
+      const otherAuth = new AuthService("a-completely-different-secret-32c", "24h");
 
       expect(otherAuth.verifyToken(token)).toBeNull();
     });
@@ -53,27 +55,29 @@ describe("AuthService", () => {
     });
   });
 
-  describe("constructor defaults", () => {
-    const originalSecret = process.env.JWT_SECRET;
-
-    afterEach(() => {
-      if (originalSecret === undefined) {
-        delete process.env.JWT_SECRET;
-      } else {
-        process.env.JWT_SECRET = originalSecret;
-      }
+  describe("constructor validation", () => {
+    it("throws error when JWT_SECRET is too short (less than 32 characters)", () => {
+      expect(() => {
+        new AuthService("short-secret");
+      }).toThrow(/32 characters/);
     });
 
-    it("currently falls back to a hardcoded default secret when JWT_SECRET is unset (tracked by issue #10 — should throw instead)", () => {
-      delete process.env.JWT_SECRET;
-      const insecureAuth = new AuthService();
-      const token = insecureAuth.generateToken("GADDRESS123");
+    it("throws error when JWT_SECRET is undefined", () => {
+      expect(() => {
+        new AuthService(undefined as any);
+      }).toThrow(/JWT_SECRET/);
+    });
 
-      // Documents the present (insecure) behavior: a token signed under the
-      // fallback secret verifies against another instance that has no secret
-      // configured either, since both silently agree on "your-secret-key".
-      const anotherInsecureAuth = new AuthService();
-      expect(anotherInsecureAuth.verifyToken(token)).not.toBeNull();
+    it("throws error when JWT_SECRET is empty", () => {
+      expect(() => {
+        new AuthService("");
+      }).toThrow(/JWT_SECRET/);
+    });
+
+    it("accepts valid JWT_SECRET (32+ characters)", () => {
+      expect(() => {
+        new AuthService("valid-secret-32-characters-long!");
+      }).not.toThrow();
     });
   });
 
@@ -99,7 +103,8 @@ describe("AuthService", () => {
   describe("decodeToken", () => {
     it("decodes token payload without verifying the signature", () => {
       const token = auth.generateToken("GADDRESS123");
-      const otherAuth = new AuthService("different-secret", "24h");
+      // Use another valid 32+ character secret
+      const otherAuth = new AuthService("different-secret-32-chars-minimum", "24h");
       const decoded = otherAuth.decodeToken(token);
 
       expect(decoded.address).toBe("GADDRESS123");

--- a/services/graphql-api/src/services/auth.ts
+++ b/services/graphql-api/src/services/auth.ts
@@ -7,7 +7,33 @@ export class AuthService {
   private jwtSecret: string;
   private tokenExpiry: string;
 
-  constructor(jwtSecret: string = process.env.JWT_SECRET || "your-secret-key", tokenExpiry: string = "24h") {
+  /**
+   * Validate JWT secret meets security requirements
+   * @throws Error if secret is invalid
+   */
+  static validateJwtSecret(secret: string | undefined): void {
+    const knownDefaults = [
+      "your-secret-key",
+      "your-secret-key-change-in-production",
+      "dev-secret-key-change-in-production",
+    ];
+
+    if (!secret || secret.trim() === "") {
+      throw new Error("JWT_SECRET environment variable is required and must not be empty");
+    }
+
+    // Check for known defaults before length check
+    if (knownDefaults.includes(secret)) {
+      throw new Error("JWT_SECRET appears to be a default/example value and must be changed");
+    }
+
+    if (secret.length < 32) {
+      throw new Error("JWT_SECRET must be at least 32 characters for secure operation");
+    }
+  }
+
+  constructor(jwtSecret: string, tokenExpiry: string = "24h") {
+    AuthService.validateJwtSecret(jwtSecret);
     this.jwtSecret = jwtSecret;
     this.tokenExpiry = tokenExpiry;
   }


### PR DESCRIPTION
## Fix: Remove hardcoded JWT_SECRET fallback to prevent authentication bypass

Closes #839

### Problem
The GraphQL API service defaulted JWT_SECRET to hardcoded string literals (`"your-secret-key"` and `"your-secret-key-change-in-production"`) when the environment variable was unset. This created a critical authentication vulnerability: anyone who reads the source code could forge valid JWTs against any misconfigured deployment, completely bypassing authentication.

### Solution
Implemented fail-fast validation that ensures the service exits immediately at startup if:
- JWT_SECRET is unset or empty
- JWT_SECRET is shorter than 32 characters (minimum security threshold)
- JWT_SECRET matches known default/example values

### Changes Made

#### `services/graphql-api/src/index.ts`
- Removed hardcoded fallback from JWT_SECRET initialization
- Added startup validation that exits with code 1 and clear FATAL error messages for insecure secrets
- Validates before service initialization to prevent silent failures

#### `services/graphql-api/src/services/auth.ts`
- Removed default parameter from AuthService constructor
- Added static `validateJwtSecret()` method with comprehensive security checks
- Constructor now validates JWT_SECRET before use, throwing descriptive errors

### Testing
- **Bug Condition Tests**: 8 tests verify the service correctly rejects insecure secrets
- **Preservation Tests**: 9 property-based tests confirm no regressions in JWT operations with valid secrets
- **Integration Tests**: All 106 tests pass, validating the fix doesn't break existing functionality

### Validation
Ran comprehensive test suite confirming:
- ✅ Service exits immediately with clear error messages for insecure secrets
- ✅ Service starts normally with valid secrets (32+ chars, not defaults)
- ✅ JWT generation/verification behavior unchanged for properly-configured deployments
- ✅ HS256 algorithm, token structure, and expiry logic preserved
- ✅ No regressions in GraphQL API, resolvers, rate limiting, or other services

### Security Impact
This fix prevents authentication bypass by ensuring:
1. No deployments can start with publicly-known secrets
2. Minimum cryptographic strength requirements are enforced
3. Configuration errors are caught at startup, not discovered in production
4. Clear error messages guide operators to fix misconfigurations

### Backward Compatibility
Deployments with properly-configured JWT_SECRET (32+ characters, not default values) are completely unaffected. Only misconfigured deployments will be prevented from starting, which is the intended security improvement.
