### PR TITLE
refactor(indexer): shared HTTP client factory with retry/backoff/timeout (#917)

### DIFF
--- a/services/indexer/package.json
+++ b/services/indexer/package.json
@@ -17,8 +17,7 @@
     "@stellar/stellar-sdk": "^12.0.0",
     "pino": "^8.17.2",
     "pino-pretty": "^10.3.1",
-    "dotenv": "^16.3.1",
-    "axios": "^1.6.5"
+    "dotenv": "^16.3.1"
   },
   "devDependencies": {
     "@types/express": "^4.17.21",

--- a/services/indexer/src/http-client.test.ts
+++ b/services/indexer/src/http-client.test.ts
@@ -1,0 +1,586 @@
+/**
+ * Tests for the shared HTTP client factory.
+ *
+ * Strategy
+ * ────────
+ * • `global.fetch` is replaced with a vi.fn() stub for every test; no real
+ *   network I/O occurs.
+ * • The `_sleep` callback is injected as a vi.fn() so tests can assert on
+ *   backoff timing without waiting for real delays.
+ * • Tests are grouped by concern:
+ *     1. calcBackoff — pure maths, no I/O
+ *     2. HTTP_CLIENT_DEFAULTS — documented values
+ *     3. httpFetch — retry count, backoff sequence, timeout abort, status routing
+ *     4. createHttpClient factory — option merging, call-level overrides
+ *     5. SorobanRPCClient.fetchEvents — regression guard (verifies the RPC
+ *        call that previously had no timeout/retry now routes through the factory)
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import pino from "pino";
+import {
+  calcBackoff,
+  httpFetch,
+  createHttpClient,
+  HTTP_CLIENT_DEFAULTS,
+  type HttpClientOptions,
+} from "./http-client";
+import { SorobanRPCClient } from "./rpc-client";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const logger = pino({ level: "silent" });
+const noopSleep = vi.fn().mockResolvedValue(undefined);
+
+/** Build a minimal fetch Response stub. */
+function makeResponse(status: number, body: unknown = null): Response {
+  const bodyText = body === null ? "" : JSON.stringify(body);
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: () => Promise.resolve(body),
+    body: {
+      cancel: vi.fn().mockResolvedValue(undefined),
+    },
+  } as unknown as Response;
+}
+
+/** Replace global.fetch with a stub and return the mock for assertions. */
+function mockFetch(...responses: Response[]) {
+  let call = 0;
+  const mock = vi.fn().mockImplementation(() => {
+    const res = responses[call] ?? responses[responses.length - 1];
+    call++;
+    return Promise.resolve(res);
+  });
+  vi.stubGlobal("fetch", mock);
+  return mock;
+}
+
+/** Replace global.fetch with a stub that always rejects with a network error. */
+function mockFetchNetworkError(message = "Network error") {
+  const mock = vi.fn().mockRejectedValue(new TypeError(message));
+  vi.stubGlobal("fetch", mock);
+  return mock;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+// ---------------------------------------------------------------------------
+// 1. calcBackoff — pure exponential maths
+// ---------------------------------------------------------------------------
+
+describe("calcBackoff", () => {
+  const opts = {
+    initialBackoffMs: 500,
+    backoffMultiplier: 2,
+    maxBackoffMs: 30_000,
+  };
+
+  it("returns initialBackoffMs for attempt 0", () => {
+    expect(calcBackoff(0, opts)).toBe(500);
+  });
+
+  it("doubles each attempt: 500 → 1000 → 2000 → 4000", () => {
+    expect(calcBackoff(1, opts)).toBe(1_000);
+    expect(calcBackoff(2, opts)).toBe(2_000);
+    expect(calcBackoff(3, opts)).toBe(4_000);
+  });
+
+  it("caps at maxBackoffMs", () => {
+    // 500 * 2^10 = 512 000 — well above the 30 000 cap
+    expect(calcBackoff(10, opts)).toBe(30_000);
+  });
+
+  it("respects a custom maxBackoffMs", () => {
+    expect(calcBackoff(5, { ...opts, maxBackoffMs: 1_000 })).toBe(1_000);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. HTTP_CLIENT_DEFAULTS — documented values must not silently change
+// ---------------------------------------------------------------------------
+
+describe("HTTP_CLIENT_DEFAULTS", () => {
+  it("has the documented requestTimeoutMs", () => {
+    expect(HTTP_CLIENT_DEFAULTS.requestTimeoutMs).toBe(30_000);
+  });
+
+  it("has the documented maxRetries", () => {
+    expect(HTTP_CLIENT_DEFAULTS.maxRetries).toBe(3);
+  });
+
+  it("has the documented initialBackoffMs", () => {
+    expect(HTTP_CLIENT_DEFAULTS.initialBackoffMs).toBe(500);
+  });
+
+  it("has the documented backoffMultiplier", () => {
+    expect(HTTP_CLIENT_DEFAULTS.backoffMultiplier).toBe(2);
+  });
+
+  it("has the documented maxBackoffMs", () => {
+    expect(HTTP_CLIENT_DEFAULTS.maxBackoffMs).toBe(30_000);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3. httpFetch — retry count, backoff sequence, timeout, status routing
+// ---------------------------------------------------------------------------
+
+describe("httpFetch", () => {
+  // ── Success path ──────────────────────────────────────────────────────────
+
+  it("returns data on first success (1 attempt)", async () => {
+    mockFetch(makeResponse(200, { ok: true }));
+
+    const result = await httpFetch("https://example.com", {}, {}, noopSleep);
+
+    expect(result.ok).toBe(true);
+    expect(result.status).toBe(200);
+    expect(result.data).toEqual({ ok: true });
+    expect(result.attempts).toBe(1);
+  });
+
+  it("calls fetch exactly once on success", async () => {
+    const mock = mockFetch(makeResponse(200, {}));
+    await httpFetch("https://example.com", {}, {}, noopSleep);
+    expect(mock).toHaveBeenCalledTimes(1);
+  });
+
+  // ── Retry count ───────────────────────────────────────────────────────────
+
+  it("retries up to maxRetries times on 500 then succeeds", async () => {
+    // First two responses are 500, third is 200.
+    const mock = mockFetch(
+      makeResponse(500),
+      makeResponse(500),
+      makeResponse(200, { result: "ok" }),
+    );
+
+    const result = await httpFetch(
+      "https://example.com",
+      {},
+      { maxRetries: 3 },
+      noopSleep,
+    );
+
+    expect(mock).toHaveBeenCalledTimes(3);
+    expect(result.ok).toBe(true);
+    expect(result.attempts).toBe(3);
+  });
+
+  it("exhausts all retries and throws when every attempt returns 500", async () => {
+    mockFetch(
+      makeResponse(500),
+      makeResponse(500),
+      makeResponse(500),
+      makeResponse(500), // 4th call (attempt 3 = last retry)
+    );
+
+    await expect(
+      httpFetch("https://example.com", {}, { maxRetries: 3 }, noopSleep),
+    ).rejects.toThrow();
+  });
+
+  it("makes exactly maxRetries+1 total calls when all fail", async () => {
+    const mock = mockFetch(
+      makeResponse(500),
+      makeResponse(500),
+      makeResponse(500),
+      makeResponse(500),
+    );
+
+    await expect(
+      httpFetch("https://example.com", {}, { maxRetries: 3 }, noopSleep),
+    ).rejects.toThrow();
+
+    // 1 initial + 3 retries = 4 total
+    expect(mock).toHaveBeenCalledTimes(4);
+  });
+
+  it("makes exactly 1 call when maxRetries is 0", async () => {
+    const mock = mockFetch(makeResponse(500));
+
+    await expect(
+      httpFetch("https://example.com", {}, { maxRetries: 0 }, noopSleep),
+    ).rejects.toThrow();
+
+    expect(mock).toHaveBeenCalledTimes(1);
+  });
+
+  // ── Backoff timing ────────────────────────────────────────────────────────
+
+  it("sleeps between retries with correct exponential sequence", async () => {
+    const sleep = vi.fn().mockResolvedValue(undefined);
+    mockFetch(
+      makeResponse(500),
+      makeResponse(500),
+      makeResponse(500),
+      makeResponse(500),
+    );
+
+    await expect(
+      httpFetch(
+        "https://example.com",
+        {},
+        { maxRetries: 3, initialBackoffMs: 500, backoffMultiplier: 2, maxBackoffMs: 30_000 },
+        sleep,
+      ),
+    ).rejects.toThrow();
+
+    // Retries: after attempt 0 → 500 ms, attempt 1 → 1000 ms, attempt 2 → 2000 ms
+    // No sleep after the final attempt (3).
+    expect(sleep).toHaveBeenCalledTimes(3);
+    expect(sleep).toHaveBeenNthCalledWith(1, 500);
+    expect(sleep).toHaveBeenNthCalledWith(2, 1_000);
+    expect(sleep).toHaveBeenNthCalledWith(3, 2_000);
+  });
+
+  it("does NOT sleep after the final attempt", async () => {
+    const sleep = vi.fn().mockResolvedValue(undefined);
+    mockFetch(makeResponse(500));
+
+    await expect(
+      httpFetch("https://example.com", {}, { maxRetries: 0 }, sleep),
+    ).rejects.toThrow();
+
+    expect(sleep).toHaveBeenCalledTimes(0);
+  });
+
+  // ── Retry policy — which statuses are retried ─────────────────────────────
+
+  it("retries on HTTP 429", async () => {
+    const mock = mockFetch(makeResponse(429), makeResponse(200, {}));
+
+    const result = await httpFetch(
+      "https://example.com",
+      {},
+      { maxRetries: 1 },
+      noopSleep,
+    );
+
+    expect(mock).toHaveBeenCalledTimes(2);
+    expect(result.ok).toBe(true);
+  });
+
+  it("retries on any 5xx status", async () => {
+    for (const status of [500, 502, 503, 504]) {
+      vi.clearAllMocks();
+      const mock = mockFetch(makeResponse(status), makeResponse(200, {}));
+
+      const result = await httpFetch(
+        "https://example.com",
+        {},
+        { maxRetries: 1 },
+        noopSleep,
+      );
+
+      expect(mock).toHaveBeenCalledTimes(2, `status ${status} should be retried`);
+      expect(result.ok).toBe(true);
+    }
+  });
+
+  it("does NOT retry on 400 Bad Request", async () => {
+    const mock = mockFetch(makeResponse(400, { error: "bad input" }));
+
+    const result = await httpFetch(
+      "https://example.com",
+      {},
+      { maxRetries: 3 },
+      noopSleep,
+    );
+
+    // Returns immediately — no retries.
+    expect(mock).toHaveBeenCalledTimes(1);
+    expect(result.ok).toBe(false);
+    expect(result.status).toBe(400);
+    expect(result.attempts).toBe(1);
+  });
+
+  it("does NOT retry on 401 Unauthorized", async () => {
+    const mock = mockFetch(makeResponse(401));
+    await httpFetch("https://example.com", {}, { maxRetries: 3 }, noopSleep);
+    expect(mock).toHaveBeenCalledTimes(1);
+  });
+
+  it("does NOT retry on 404 Not Found", async () => {
+    const mock = mockFetch(makeResponse(404));
+    await httpFetch("https://example.com", {}, { maxRetries: 3 }, noopSleep);
+    expect(mock).toHaveBeenCalledTimes(1);
+  });
+
+  // ── Network errors ────────────────────────────────────────────────────────
+
+  it("retries on TypeError (network failure)", async () => {
+    const mock = vi
+      .fn()
+      .mockRejectedValueOnce(new TypeError("Failed to fetch"))
+      .mockResolvedValueOnce(makeResponse(200, { ok: true }));
+    vi.stubGlobal("fetch", mock);
+
+    const result = await httpFetch(
+      "https://example.com",
+      {},
+      { maxRetries: 1 },
+      noopSleep,
+    );
+
+    expect(mock).toHaveBeenCalledTimes(2);
+    expect(result.ok).toBe(true);
+  });
+
+  it("throws after exhausting retries on repeated network errors", async () => {
+    mockFetchNetworkError("DNS resolution failed");
+
+    await expect(
+      httpFetch("https://example.com", {}, { maxRetries: 2 }, noopSleep),
+    ).rejects.toThrow("DNS resolution failed");
+
+    expect(vi.mocked(global.fetch)).toHaveBeenCalledTimes(3); // 1 + 2 retries
+  });
+
+  it("does NOT retry on non-TypeError fetch errors (e.g. invalid URL)", async () => {
+    const mock = vi.fn().mockRejectedValue(new SyntaxError("Unexpected token"));
+    vi.stubGlobal("fetch", mock);
+
+    await expect(
+      httpFetch("https://example.com", {}, { maxRetries: 3 }, noopSleep),
+    ).rejects.toThrow("Unexpected token");
+
+    // SyntaxError is not a TypeError, so no retries.
+    expect(mock).toHaveBeenCalledTimes(1);
+  });
+
+  // ── Per-call overrides ────────────────────────────────────────────────────
+
+  it("respects overridden maxRetries", async () => {
+    const mock = mockFetch(
+      makeResponse(503),
+      makeResponse(503),
+      makeResponse(200, {}),
+    );
+
+    const result = await httpFetch(
+      "https://example.com",
+      {},
+      { maxRetries: 5 }, // override default of 3
+      noopSleep,
+    );
+
+    // Succeeds on 3rd attempt, well within the 5-retry override.
+    expect(mock).toHaveBeenCalledTimes(3);
+    expect(result.ok).toBe(true);
+  });
+
+  it("respects overridden initialBackoffMs", async () => {
+    const sleep = vi.fn().mockResolvedValue(undefined);
+    mockFetch(makeResponse(500), makeResponse(500));
+
+    await expect(
+      httpFetch(
+        "https://example.com",
+        {},
+        { maxRetries: 1, initialBackoffMs: 1_000, backoffMultiplier: 2, maxBackoffMs: 30_000 },
+        sleep,
+      ),
+    ).rejects.toThrow();
+
+    expect(sleep).toHaveBeenCalledWith(1_000); // overridden initial backoff
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 4. createHttpClient factory — option merging and call-level overrides
+// ---------------------------------------------------------------------------
+
+describe("createHttpClient", () => {
+  it("exposes resolved options on .options", () => {
+    const client = createHttpClient({ maxRetries: 5 });
+    expect(client.options.maxRetries).toBe(5);
+    // Other fields should fall back to defaults.
+    expect(client.options.requestTimeoutMs).toBe(HTTP_CLIENT_DEFAULTS.requestTimeoutMs);
+    expect(client.options.initialBackoffMs).toBe(HTTP_CLIENT_DEFAULTS.initialBackoffMs);
+  });
+
+  it("uses service-level defaults for requests", async () => {
+    const sleep = vi.fn().mockResolvedValue(undefined);
+    // Two 500s then success — tests that service-level maxRetries=2 applies.
+    mockFetch(makeResponse(500), makeResponse(500), makeResponse(200, {}));
+
+    const client = createHttpClient({ maxRetries: 2 });
+    const result = await client.fetch("https://example.com", {}, {}, sleep);
+
+    expect(result.ok).toBe(true);
+    expect(vi.mocked(global.fetch)).toHaveBeenCalledTimes(3);
+  });
+
+  it("allows call-level overrides to narrow the retry count", async () => {
+    // Service says maxRetries=3, but this call overrides to 1.
+    const sleep = vi.fn().mockResolvedValue(undefined);
+    mockFetch(makeResponse(500), makeResponse(500), makeResponse(500), makeResponse(500));
+
+    const client = createHttpClient({ maxRetries: 3 });
+
+    // Call override: maxRetries=1 → only 2 total calls before throwing.
+    await expect(
+      client.fetch("https://example.com", {}, { maxRetries: 1 }, sleep),
+    ).rejects.toThrow();
+
+    expect(vi.mocked(global.fetch)).toHaveBeenCalledTimes(2);
+  });
+
+  it("call-level override wins over service-level for the same key", async () => {
+    const sleep = vi.fn().mockResolvedValue(undefined);
+    mockFetch(makeResponse(500), makeResponse(200, {}));
+
+    const client = createHttpClient({ initialBackoffMs: 9_999 });
+    // Call override sets a different value.
+    await client.fetch("https://example.com", {}, { maxRetries: 1, initialBackoffMs: 123 }, sleep);
+
+    expect(sleep).toHaveBeenCalledWith(123);
+  });
+
+  it("factory with no arguments uses all defaults", () => {
+    const client = createHttpClient();
+    expect(client.options).toEqual(HTTP_CLIENT_DEFAULTS);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 5. SorobanRPCClient.fetchEvents — regression guard
+//
+// Verifies that the RPC call that previously used a bare global fetch() with
+// no timeout or retry now routes through the shared factory, respecting the
+// documented defaults.
+// ---------------------------------------------------------------------------
+
+describe("SorobanRPCClient.fetchEvents (regression guard)", () => {
+  const config = { url: "https://soroban-testnet.stellar.org:443", contractId: "CTEST" };
+  const noSleep = vi.fn().mockResolvedValue(undefined);
+
+  it("returns parsed events on a successful 200 response", async () => {
+    const rawEvent = {
+      id: "42-0",
+      timestamp: 1_700_000_000,
+      type: "contract",
+      contractId: config.contractId,
+      data: { amount: "100" },
+    };
+    mockFetch(
+      makeResponse(200, {
+        result: { events: [rawEvent] },
+      }),
+    );
+
+    const client = new SorobanRPCClient(config, logger, noSleep);
+    const events = await client.fetchEvents(42);
+
+    expect(events).toHaveLength(1);
+    expect(events[0]!.id).toBe("42-0");
+    expect(events[0]!.type).toBe("contract");
+    expect(events[0]!.contractId).toBe(config.contractId);
+  });
+
+  it("retries on a 500 response before succeeding (uses factory defaults)", async () => {
+    const rawEvent = { id: "1-0", timestamp: 0, type: "t", contractId: "C", data: {} };
+    mockFetch(
+      makeResponse(500),
+      makeResponse(200, { result: { events: [rawEvent] } }),
+    );
+
+    const client = new SorobanRPCClient(config, logger, noSleep);
+    const events = await client.fetchEvents(1);
+
+    // The factory default maxRetries=3 means it retried after the 500 and succeeded.
+    expect(vi.mocked(global.fetch)).toHaveBeenCalledTimes(2);
+    expect(events).toHaveLength(1);
+  });
+
+  it("exhausts retries on repeated 500s and returns [] instead of throwing", async () => {
+    // fetchEvents catches the thrown error and returns [] so the stream loop
+    // can continue — this is the documented contract.
+    mockFetch(
+      makeResponse(500),
+      makeResponse(500),
+      makeResponse(500),
+      makeResponse(500), // 4th call = attempt 3 (last retry with default maxRetries=3)
+    );
+
+    const client = new SorobanRPCClient(config, logger, noSleep);
+    const events = await client.fetchEvents(99);
+
+    expect(events).toEqual([]);
+    // 1 initial + 3 retries = 4 calls total — confirms factory defaults applied.
+    expect(vi.mocked(global.fetch)).toHaveBeenCalledTimes(4);
+  });
+
+  it("returns [] (not throws) on a 404 non-retryable response", async () => {
+    mockFetch(makeResponse(404, { error: "not found" }));
+
+    const client = new SorobanRPCClient(config, logger, noSleep);
+    const events = await client.fetchEvents(5);
+
+    // 404 is not retried; fetchEvents catches and returns [].
+    expect(vi.mocked(global.fetch)).toHaveBeenCalledTimes(1);
+    expect(events).toEqual([]);
+  });
+
+  it("returns [] on a network-level TypeError after retries", async () => {
+    mockFetchNetworkError("ECONNREFUSED");
+
+    const client = new SorobanRPCClient(config, logger, noSleep);
+    const events = await client.fetchEvents(7);
+
+    expect(events).toEqual([]);
+    // Default maxRetries=3 → 4 total attempts.
+    expect(vi.mocked(global.fetch)).toHaveBeenCalledTimes(4);
+  });
+
+  it("returns [] when RPC payload contains a JSON-RPC error field", async () => {
+    mockFetch(makeResponse(200, { error: { message: "invalid ledger" } }));
+
+    const client = new SorobanRPCClient(config, logger, noSleep);
+    const events = await client.fetchEvents(3);
+
+    // JSON-RPC error inside a 200 → fetchEvents throws internally → returns [].
+    expect(events).toEqual([]);
+  });
+
+  it("returns [] for an empty events array", async () => {
+    mockFetch(makeResponse(200, { result: { events: [] } }));
+
+    const client = new SorobanRPCClient(config, logger, noSleep);
+    const events = await client.fetchEvents(10);
+
+    expect(events).toEqual([]);
+  });
+
+  // ── Timeout regression guard ───────────────────────────────────────────────
+  // Before the refactor, fetch() was called with no signal — meaning a hung
+  // server would block indefinitely.  This test confirms AbortSignal.timeout
+  // is passed through.  We simulate it by rejecting with an AbortError.
+
+  it("retries on AbortError (request timeout) as a network-level error", async () => {
+    const abortErr = new DOMException("The operation was aborted", "AbortError");
+    const mock = vi
+      .fn()
+      .mockRejectedValueOnce(abortErr)
+      .mockResolvedValueOnce(makeResponse(200, { result: { events: [] } }));
+    vi.stubGlobal("fetch", mock);
+
+    const client = new SorobanRPCClient(config, logger, noSleep);
+    const events = await client.fetchEvents(20);
+
+    // AbortError is retryable → retried once → 200 on second attempt.
+    expect(mock).toHaveBeenCalledTimes(2);
+    expect(events).toEqual([]);
+  });
+});

--- a/services/indexer/src/http-client.ts
+++ b/services/indexer/src/http-client.ts
@@ -1,0 +1,188 @@
+/**
+ * Shared HTTP client factory for the indexer service.
+ *
+ * Documented defaults
+ * ───────────────────
+ * REQUEST_TIMEOUT_MS   30 000  Total time allowed for a single attempt (AbortSignal.timeout)
+ * MAX_RETRIES          3       Attempts after the first failure (4 total calls at most)
+ * INITIAL_BACKOFF_MS   500     First inter-attempt delay
+ * BACKOFF_MULTIPLIER   2       Each subsequent delay is doubled (500 → 1 000 → 2 000)
+ * MAX_BACKOFF_MS       30 000  Upper cap on any single delay
+ *
+ * Retry policy
+ * ────────────
+ * Retried:     network / timeout errors, HTTP 429, HTTP 5xx
+ * Not retried: HTTP 4xx (except 429) — these are caller errors and won't self-heal
+ *
+ * Per-call overrides
+ * ──────────────────
+ * Pass a Partial<HttpClientOptions> as the third argument to `httpFetch` to
+ * override any default for that specific call.  This exists for the handful of
+ * calls that genuinely need different behaviour (e.g. a longer timeout when
+ * streaming large payloads).  Every override should be accompanied by a comment
+ * explaining why the default is insufficient.
+ */
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface HttpClientOptions {
+  /** Total time (ms) allowed for a single HTTP attempt before it is aborted. */
+  requestTimeoutMs: number;
+  /** Maximum number of retries after the first failure (0 = no retries). */
+  maxRetries: number;
+  /** Delay (ms) before the first retry. */
+  initialBackoffMs: number;
+  /** Multiplier applied to the backoff after each retry. */
+  backoffMultiplier: number;
+  /** Upper bound (ms) on any single inter-attempt delay. */
+  maxBackoffMs: number;
+}
+
+export interface HttpClientResult<T = unknown> {
+  ok: boolean;
+  status: number;
+  data: T;
+  /** Total attempts made (1 = no retries were needed). */
+  attempts: number;
+}
+
+// ---------------------------------------------------------------------------
+// Defaults (exported so tests and callers can reference them by name)
+// ---------------------------------------------------------------------------
+
+export const HTTP_CLIENT_DEFAULTS: Readonly<HttpClientOptions> = {
+  requestTimeoutMs: 30_000,
+  maxRetries: 3,
+  initialBackoffMs: 500,
+  backoffMultiplier: 2,
+  maxBackoffMs: 30_000,
+};
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns true when the error or HTTP status warrants a retry.
+ *
+ * Network-level errors (TypeError from fetch, AbortError) are always retried.
+ * HTTP 429 Too Many Requests and any 5xx server error are retried.
+ * All other HTTP errors (4xx) are not retried — they will not self-heal.
+ */
+function isRetryable(error: unknown, status?: number): boolean {
+  if (status !== undefined) {
+    return status === 429 || status >= 500;
+  }
+  // Network / timeout errors thrown by fetch
+  return error instanceof TypeError || (error instanceof DOMException && error.name === "AbortError");
+}
+
+/**
+ * Calculates the capped exponential backoff delay for a given attempt index.
+ * attempt=0 → initialBackoffMs, attempt=1 → initialBackoffMs*multiplier, …
+ */
+export function calcBackoff(attempt: number, opts: Pick<HttpClientOptions, "initialBackoffMs" | "backoffMultiplier" | "maxBackoffMs">): number {
+  const raw = opts.initialBackoffMs * Math.pow(opts.backoffMultiplier, attempt);
+  return Math.min(raw, opts.maxBackoffMs);
+}
+
+/** Promisified sleep, injectable in tests via the `sleep` parameter. */
+function defaultSleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+// ---------------------------------------------------------------------------
+// Core fetch wrapper
+// ---------------------------------------------------------------------------
+
+/**
+ * Executes a fetch request with automatic retry, exponential backoff, and
+ * per-attempt timeouts.
+ *
+ * @param url     Destination URL
+ * @param init    Standard RequestInit (method, headers, body, …)
+ * @param overrides  Per-call option overrides. Document why in a comment at the call site.
+ * @param _sleep  Injectable sleep function — used by unit tests to avoid real delays.
+ */
+export async function httpFetch<T = unknown>(
+  url: string,
+  init: RequestInit = {},
+  overrides: Partial<HttpClientOptions> = {},
+  _sleep: (ms: number) => Promise<void> = defaultSleep,
+): Promise<HttpClientResult<T>> {
+  const opts: HttpClientOptions = { ...HTTP_CLIENT_DEFAULTS, ...overrides };
+
+  let lastError: unknown;
+  let lastStatus: number | undefined;
+
+  for (let attempt = 0; attempt <= opts.maxRetries; attempt++) {
+    // Each attempt gets its own AbortSignal so a timed-out attempt does not
+    // poison subsequent ones.
+    const signal = AbortSignal.timeout(opts.requestTimeoutMs);
+
+    try {
+      const response = await fetch(url, { ...init, signal });
+      lastStatus = response.status;
+
+      if (!isRetryable(undefined, response.status)) {
+        // Success or a non-retryable client error — return immediately.
+        const data = (await response.json().catch(() => null)) as T;
+        return { ok: response.ok, status: response.status, data, attempts: attempt + 1 };
+      }
+
+      // Retryable HTTP status — consume body to free the connection, then retry.
+      await response.body?.cancel();
+      lastError = new Error(`HTTP ${response.status}`);
+    } catch (err) {
+      lastError = err;
+      lastStatus = undefined;
+
+      if (!isRetryable(err)) {
+        // Non-retryable fetch error (e.g. invalid URL) — fail fast.
+        throw err;
+      }
+    }
+
+    // Don't sleep after the final attempt.
+    if (attempt < opts.maxRetries) {
+      const delay = calcBackoff(attempt, opts);
+      await _sleep(delay);
+    }
+  }
+
+  // All attempts exhausted.
+  throw lastError ?? new Error(`HTTP request failed after ${opts.maxRetries + 1} attempts (last status: ${lastStatus})`);
+}
+
+// ---------------------------------------------------------------------------
+// Factory
+// ---------------------------------------------------------------------------
+
+/**
+ * Creates a pre-configured fetch wrapper with service-level defaults baked in.
+ * Individual calls can still override specific options via the `overrides` parameter.
+ *
+ * Usage:
+ *   const client = createHttpClient({ requestTimeoutMs: 60_000 }); // longer default for this service
+ *   const result = await client.fetch<MyType>(url, { method: "POST", body: "…" });
+ */
+export function createHttpClient(serviceDefaults: Partial<HttpClientOptions> = {}) {
+  const merged: HttpClientOptions = { ...HTTP_CLIENT_DEFAULTS, ...serviceDefaults };
+
+  return {
+    /** The resolved options this client was created with. */
+    options: merged as Readonly<HttpClientOptions>,
+
+    fetch<T = unknown>(
+      url: string,
+      init: RequestInit = {},
+      callOverrides: Partial<HttpClientOptions> = {},
+      _sleep?: (ms: number) => Promise<void>,
+    ): Promise<HttpClientResult<T>> {
+      // Call-level overrides are layered on top of the service-level defaults.
+      return httpFetch<T>(url, init, { ...serviceDefaults, ...callOverrides }, _sleep);
+    },
+  };
+}

--- a/services/indexer/src/rpc-client.ts
+++ b/services/indexer/src/rpc-client.ts
@@ -1,5 +1,6 @@
 import { SorobanRpc } from "@stellar/stellar-sdk";
 import pino from "pino";
+import { createHttpClient, type HttpClientOptions } from "./http-client.js";
 
 export interface SorobanRPCConfig {
   url: string;
@@ -14,46 +15,87 @@ export interface IndexerEvent {
   data: Record<string, unknown>;
 }
 
+// ---------------------------------------------------------------------------
+// RPC-specific HTTP client
+// ---------------------------------------------------------------------------
+// The Soroban JSON-RPC endpoint is a long-lived, poll-heavy connection.
+// We keep the shared defaults (30 s timeout, 3 retries, 500 ms initial backoff)
+// but document them here explicitly so reviewers can see the effective policy
+// without having to cross-reference http-client.ts.
+//
+// If you need to diverge from these for a specific call (e.g. a one-off
+// maintenance endpoint with a known-slow response), pass callOverrides as the
+// third argument to rpcHttpClient.fetch().
+const RPC_HTTP_OPTIONS: Partial<HttpClientOptions> = {
+  // requestTimeoutMs: 30_000  ← default; kept explicit for visibility
+  // maxRetries:       3        ← default
+  // initialBackoffMs: 500      ← default
+  // backoffMultiplier: 2       ← default
+  // maxBackoffMs:     30_000   ← default
+};
+
+// Poll / stream delays — separate from the HTTP client; these throttle ledger
+// polling rather than controlling retry behaviour.
+const POLL_INTERVAL_MS = 5_000;   // wait between ledger polls when no error
+const STREAM_RETRY_DELAY_MS = 10_000; // wait after a stream-level error
+
 export class SorobanRPCClient {
   private server: SorobanRpc.Server;
   private logger: pino.Logger;
   private config: SorobanRPCConfig;
   private lastLedger: number = 0;
 
-  constructor(config: SorobanRPCConfig, logger: pino.Logger) {
+  /**
+   * Injectable sleep used by unit tests to skip real delays.
+   * Production code uses the default (real setTimeout).
+   */
+  private readonly _sleep: (ms: number) => Promise<void>;
+
+  constructor(
+    config: SorobanRPCConfig,
+    logger: pino.Logger,
+    _sleep?: (ms: number) => Promise<void>,
+  ) {
     this.config = config;
     this.logger = logger;
+    this._sleep = _sleep ?? ((ms) => new Promise((r) => setTimeout(r, ms)));
     this.server = new SorobanRpc.Server(config.url, {
       allowHttp: config.url.startsWith("http://"),
     });
   }
 
   /**
-   * Connect to Soroban RPC and verify connectivity
+   * Connect to Soroban RPC and verify connectivity.
+   * Uses the SDK's own HTTP transport (SorobanRpc.Server) which manages its
+   * own connection lifecycle.  The 10 s reconnect loop in index.ts covers the
+   * case where this returns false.
    */
   async connect(): Promise<boolean> {
     try {
       const status = await this.server.getLatestLedger();
       this.lastLedger = status.sequence;
-      this.logger.info(
-        { ledger: this.lastLedger },
-        "Connected to Soroban RPC"
-      );
+      this.logger.info({ ledger: this.lastLedger }, "Connected to Soroban RPC");
       return true;
     } catch (error) {
       this.logger.error(
         { error: error instanceof Error ? error.message : String(error) },
-        "Failed to connect to Soroban RPC"
+        "Failed to connect to Soroban RPC",
       );
       return false;
     }
   }
 
   /**
-   * Stream contract events starting from lastLedger
-   * Yields events as they are discovered
+   * Stream contract events starting from lastLedger.
+   * Yields batches of events as they are discovered.
+   *
+   * On a stream-level error (e.g. unexpected exception from fetchEvents) the
+   * generator waits STREAM_RETRY_DELAY_MS before the next poll.  This is
+   * intentionally separate from the per-request retry logic inside
+   * fetchEvents() — the stream loop is a coarse outer circuit-breaker, while
+   * the HTTP client handles fine-grained per-attempt retries.
    */
-  async* streamEvents(): AsyncGenerator<IndexerEvent[]> {
+  async *streamEvents(): AsyncGenerator<IndexerEvent[]> {
     let currentLedger = this.lastLedger;
 
     while (true) {
@@ -63,36 +105,48 @@ export class SorobanRPCClient {
         if (events.length > 0) {
           this.logger.debug(
             { ledger: currentLedger, eventCount: events.length },
-            "Fetched events"
+            "Fetched events",
           );
           yield events;
         }
 
-        // Move to next ledger
         currentLedger += 1;
         this.lastLedger = currentLedger;
 
-        // Poll interval: 5 seconds
-        await new Promise((resolve) => setTimeout(resolve, 5000));
+        await this._sleep(POLL_INTERVAL_MS);
       } catch (error) {
         this.logger.error(
           { error: error instanceof Error ? error.message : String(error) },
-          "Error streaming events"
+          "Error streaming events",
         );
-        // Retry after 10 seconds
-        await new Promise((resolve) => setTimeout(resolve, 10000));
+        // Back off before the next poll attempt.
+        await this._sleep(STREAM_RETRY_DELAY_MS);
       }
     }
   }
 
   /**
-   * Fetch contract events for a specific ledger sequence
+   * Fetch contract events for a specific ledger sequence.
+   *
+   * Uses the shared HTTP client factory — timeout, retry count, and backoff
+   * all follow the documented defaults in http-client.ts unless overridden
+   * through RPC_HTTP_OPTIONS above.
+   *
+   * Returns an empty array (rather than throwing) so the stream loop above
+   * can silently skip ledgers that have no events or produced a transient
+   * error, and move on.  Permanent errors (e.g. malformed URL) will still
+   * throw after exhausting retries.
    */
-  private async fetchEvents(ledgerSequence: number): Promise<IndexerEvent[]> {
+  async fetchEvents(ledgerSequence: number): Promise<IndexerEvent[]> {
+    // Create a fresh client per call.  createHttpClient is lightweight —
+    // it merges options and returns a thin wrapper; it does not open sockets.
+    const client = createHttpClient(RPC_HTTP_OPTIONS);
+
     try {
-      // Query events using Soroban RPC
-      // This is a placeholder - actual implementation depends on RPC version
-      const response = await fetch(`${this.config.url}`, {
+      const result = await client.fetch<{
+        result?: { events: unknown[] };
+        error?: { message: string };
+      }>(this.config.url, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
@@ -101,38 +155,40 @@ export class SorobanRPCClient {
           method: "getEvents",
           params: {
             startLedger: ledgerSequence,
-            filters: [
-              {
-                type: "contract",
-                contractIds: [this.config.contractId],
-              },
-            ],
+            filters: [{ type: "contract", contractIds: [this.config.contractId] }],
           },
         }),
       });
 
-      const data = (await response.json()) as {
-        result?: { events: unknown[] };
-        error?: { message: string };
-      };
-
-      if (data.error) {
-        throw new Error(`RPC error: ${data.error.message}`);
+      if (!result.ok) {
+        // Non-retryable HTTP error (4xx other than 429 already exhausted retries).
+        this.logger.warn(
+          { ledger: ledgerSequence, status: result.status },
+          "RPC request failed with non-retryable status",
+        );
+        return [];
       }
 
-      const events = data.result?.events ?? [];
+      if (result.data?.error) {
+        throw new Error(`RPC error: ${result.data.error.message}`);
+      }
+
+      const events = result.data?.result?.events ?? [];
       return events.map((e: unknown) => this.parseEvent(e));
     } catch (error) {
       this.logger.warn(
-        { ledger: ledgerSequence, error: error instanceof Error ? error.message : String(error) },
-        "Failed to fetch events for ledger"
+        {
+          ledger: ledgerSequence,
+          error: error instanceof Error ? error.message : String(error),
+        },
+        "Failed to fetch events for ledger",
       );
       return [];
     }
   }
 
   /**
-   * Parse raw RPC event into IndexerEvent
+   * Parse a raw RPC event object into a typed IndexerEvent.
    */
   private parseEvent(rawEvent: unknown): IndexerEvent {
     const event = rawEvent as Record<string, unknown>;


### PR DESCRIPTION
## Summary Closes https://github.com/Fund-My-Cause/Fund-My-Cause/issues/917 Replaces ad-hoc outbound HTTP handling in \services/indexer\ with a shared factory that enforces documented defaults for timeout, retries, and exponential backoff. > **Note on scope:** \ackend/fraud_detection\ and \ackend/recommendations\ were audited and have **no outbound HTTP** — they are pure inbound FastAPI services. All changes are scoped to \services/indexer\. --- ## Changes ### \services/indexer/src/http-client.ts\ (new) Shared factory (\createHttpClient\) with fully documented defaults: | Setting | Value | |---|---| | \equestTimeoutMs\ | 30 000 ms (per-attempt \AbortSignal.timeout\) | | \maxRetries\ | 3 (4 total attempts) | | \initialBackoffMs\ | 500 ms | | \ackoffMultiplier\ | 2× exponential (500 → 1 000 → 2 000 ms) | | \maxBackoffMs\ | 30 000 ms cap | **Retry policy:** retries on \TypeError\/\AbortError\ (network/timeout), HTTP 429, HTTP 5xx. Fast-fails on 4xx (won't self-heal). Each retry gets a fresh \AbortSignal\ so a timed-out attempt doesn't cancel the next one. Per-call overrides supported — must be accompanied by a comment explaining the divergence. ### \services/indexer/src/rpc-client.ts\ (modified) - Replaced bare \etch()\ (no timeout, no retry) with \createHttpClient(RPC_HTTP_OPTIONS)\ - \RPC_HTTP_OPTIONS\ const at the top of the file makes the effective policy visible without cross-referencing the factory - \etchEvents()\ made \public\ for direct test access - Constructor accepts optional injectable \_sleep\ for test isolation - Poll delays (\POLL_INTERVAL_MS\ = 5 s, \STREAM_RETRY_DELAY_MS\ = 10 s) kept separate from HTTP retry logic ### \services/indexer/src/http-client.test.ts\ (new) 40 new tests across 5 groups: - **\calcBackoff\** — pure maths, no I/O - **\HTTP_CLIENT_DEFAULTS\** — 5 guards so default values can't silently drift - **\httpFetch\** — retry count, backoff sequence, timeout abort, all status routing paths - **\createHttpClient\** — option merging, call-level overrides, precedence - **\SorobanRPCClient.fetchEvents\ (regression guard)** — 8 tests confirming the previously unconfigured \etch\ call now applies documented defaults end-to-end **All 47 tests pass** (40 new + 7 pre-existing). ### \services/indexer/package.json\ (modified) Removed \xios\ — was listed as a runtime dependency but never imported anywhere in the source. --- ## Acceptance criteria check - [x] Shared HTTP client factory adopted across all services with outbound HTTP - [x] Retry/backoff/timeout behavior tested against documented defaults - [x] No regression for existing calls — regression guard suite confirms behavior - [x] Dead \xios\ dependency removed