### PR TITLE
feat: resolve issues #819 #905 #906 #907

### DIFF
--- a/apps/interface/src/lib/webhooks/__tests__/webhook.service.test.ts
+++ b/apps/interface/src/lib/webhooks/__tests__/webhook.service.test.ts
@@ -1,0 +1,241 @@
+/**
+ * Unit tests for webhook.service.ts — Issue #819
+ *
+ * Focuses on the signature utilities (signPayload / verifySignature) which
+ * were previously untested, and verifies that the full exported surface
+ * remains stable so the dead-export script can catch regressions.
+ */
+
+import * as crypto from "crypto";
+import { signPayload, verifySignature } from "../webhook.service";
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+/** Generate a realistic 32-byte hex signing secret. */
+function makeSecret(): string {
+  return crypto.randomBytes(32).toString("hex");
+}
+
+// ── signPayload ───────────────────────────────────────────────────────────────
+
+describe("signPayload", () => {
+  it("returns a 64-character lowercase hex string (SHA-256 output)", () => {
+    const sig = signPayload(
+      makeSecret(),
+      '{"event":"campaign.created"}',
+      Date.now(),
+    );
+    expect(sig).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it("produces the same signature for identical inputs", () => {
+    const secret = makeSecret();
+    const body = '{"event":"contribution.received","amount":100}';
+    const ts = 1_700_000_000_000;
+
+    const sig1 = signPayload(secret, body, ts);
+    const sig2 = signPayload(secret, body, ts);
+    expect(sig1).toBe(sig2);
+  });
+
+  it("produces a different signature when the secret changes", () => {
+    const body = '{"event":"campaign.funded"}';
+    const ts = 1_700_000_000_000;
+
+    const sig1 = signPayload(makeSecret(), body, ts);
+    const sig2 = signPayload(makeSecret(), body, ts);
+    // Astronomically unlikely to collide
+    expect(sig1).not.toBe(sig2);
+  });
+
+  it("produces a different signature when the body changes", () => {
+    const secret = makeSecret();
+    const ts = 1_700_000_000_000;
+
+    const sig1 = signPayload(secret, '{"event":"campaign.created"}', ts);
+    const sig2 = signPayload(secret, '{"event":"campaign.cancelled"}', ts);
+    expect(sig1).not.toBe(sig2);
+  });
+
+  it("produces a different signature when the timestamp changes", () => {
+    const secret = makeSecret();
+    const body = '{"event":"milestone.reached"}';
+
+    const sig1 = signPayload(secret, body, 1_000);
+    const sig2 = signPayload(secret, body, 2_000);
+    expect(sig1).not.toBe(sig2);
+  });
+
+  it("uses the format `${timestamp}.${body}` as the HMAC message", () => {
+    const secret = makeSecret();
+    const body = "hello";
+    const ts = 9999;
+
+    const expected = crypto
+      .createHmac("sha256", secret)
+      .update(`${ts}.${body}`)
+      .digest("hex");
+
+    expect(signPayload(secret, body, ts)).toBe(expected);
+  });
+
+  it("accepts an empty body string without throwing", () => {
+    expect(() => signPayload(makeSecret(), "", Date.now())).not.toThrow();
+  });
+});
+
+// ── verifySignature ───────────────────────────────────────────────────────────
+
+describe("verifySignature", () => {
+  it("returns true for a valid signature within the default tolerance", () => {
+    const secret = makeSecret();
+    const body = '{"event":"campaign.created"}';
+    const ts = Date.now();
+    const sig = signPayload(secret, body, ts);
+
+    expect(verifySignature(secret, sig, body, ts)).toBe(true);
+  });
+
+  it("returns false when the signature is tampered", () => {
+    const secret = makeSecret();
+    const body = '{"event":"campaign.created"}';
+    const ts = Date.now();
+    const sig = signPayload(secret, body, ts);
+
+    // Flip the first byte
+    const tampered =
+      (parseInt(sig.slice(0, 2), 16) ^ 0xff).toString(16).padStart(2, "0") +
+      sig.slice(2);
+    expect(verifySignature(secret, tampered, body, ts)).toBe(false);
+  });
+
+  it("returns false when the body was modified after signing", () => {
+    const secret = makeSecret();
+    const originalBody = '{"event":"campaign.created","amount":100}';
+    const tamperedBody = '{"event":"campaign.created","amount":999}';
+    const ts = Date.now();
+    const sig = signPayload(secret, originalBody, ts);
+
+    expect(verifySignature(secret, sig, tamperedBody, ts)).toBe(false);
+  });
+
+  it("returns false when the secret is wrong", () => {
+    const secret = makeSecret();
+    const body = '{"event":"campaign.funded"}';
+    const ts = Date.now();
+    const sig = signPayload(secret, body, ts);
+
+    expect(verifySignature(makeSecret(), sig, body, ts)).toBe(false);
+  });
+
+  it("returns false when the timestamp exceeds the default 5-minute tolerance", () => {
+    const secret = makeSecret();
+    const body = '{"event":"contribution.received"}';
+    const sixMinutesAgo = Date.now() - 6 * 60 * 1000;
+    const sig = signPayload(secret, body, sixMinutesAgo);
+
+    expect(verifySignature(secret, sig, body, sixMinutesAgo)).toBe(false);
+  });
+
+  it("returns false when the timestamp is in the future beyond tolerance", () => {
+    const secret = makeSecret();
+    const body = '{"event":"milestone.reached"}';
+    const sixMinutesFromNow = Date.now() + 6 * 60 * 1000;
+    const sig = signPayload(secret, body, sixMinutesFromNow);
+
+    expect(verifySignature(secret, sig, body, sixMinutesFromNow)).toBe(false);
+  });
+
+  it("respects a custom tolerance window", () => {
+    const secret = makeSecret();
+    const body = '{"event":"campaign.updated"}';
+    const tenSecondsAgo = Date.now() - 10_000;
+    const sig = signPayload(secret, body, tenSecondsAgo);
+
+    // 5-second tolerance → should fail
+    expect(verifySignature(secret, sig, body, tenSecondsAgo, 5_000)).toBe(
+      false,
+    );
+    // 30-second tolerance → should pass
+    expect(verifySignature(secret, sig, body, tenSecondsAgo, 30_000)).toBe(
+      true,
+    );
+  });
+
+  it("returns true when timestamp is exactly at the tolerance boundary", () => {
+    const secret = makeSecret();
+    const body = '{"event":"campaign.cancelled"}';
+    const tolerance = 60_000; // 1 minute
+    // Use a timestamp slightly within the boundary (1 ms inside)
+    const ts = Date.now() - tolerance + 1;
+    const sig = signPayload(secret, body, ts);
+
+    expect(verifySignature(secret, sig, body, ts, tolerance)).toBe(true);
+  });
+
+  it("round-trips correctly with signPayload for all event types", () => {
+    const eventTypes = [
+      "campaign.created",
+      "campaign.updated",
+      "campaign.funded",
+      "campaign.successful",
+      "campaign.cancelled",
+      "contribution.received",
+      "milestone.reached",
+    ] as const;
+
+    for (const event of eventTypes) {
+      const secret = makeSecret();
+      const body = JSON.stringify({
+        event,
+        data: { id: "test-id" },
+        timestamp: Date.now(),
+      });
+      const ts = Date.now();
+      const sig = signPayload(secret, body, ts);
+      expect(verifySignature(secret, sig, body, ts)).toBe(true);
+    }
+  });
+});
+
+// ── Export surface guard ──────────────────────────────────────────────────────
+
+describe("webhook.service export surface", () => {
+  /**
+   * This test guards against accidental removal of symbols that ARE part of the
+   * public API.  Symbols removed in Issue #819 (WebhookSubscription,
+   * WebhookDelivery, dispatchEvent) are intentionally absent from this list —
+   * they are internal implementation details with no external consumers.
+   */
+  it("exports all expected public symbols (regression guard for dead-export removals)", async () => {
+    const mod = await import("../webhook.service");
+    const expectedExports = [
+      "signPayload",
+      "verifySignature",
+      "registerWebhook",
+      "updateWebhook",
+      "deleteWebhook",
+      "listWebhooks",
+      "rotateSecret",
+      "getDeliveryLog",
+      "getDeadLetterQueue",
+    ];
+    for (const name of expectedExports) {
+      expect(mod).toHaveProperty(name);
+      expect(typeof (mod as Record<string, unknown>)[name]).toBe("function");
+    }
+  });
+
+  it("does NOT export previously-dead symbols (Issue #819 regression guard)", async () => {
+    const mod = await import("../webhook.service");
+    // These were dead exports with no consumers; they are now internal.
+    const removedExports = [
+      "WebhookSubscription",
+      "WebhookDelivery",
+      "dispatchEvent",
+    ];
+    for (const name of removedExports) {
+      expect(mod).not.toHaveProperty(name);
+    }
+  });
+});

--- a/apps/interface/src/lib/webhooks/webhook.service.ts
+++ b/apps/interface/src/lib/webhooks/webhook.service.ts
@@ -4,22 +4,28 @@
  * Let creators/integrators subscribe to campaign events via webhooks.
  * Features: registration, signing-secret management, signed payload delivery,
  * retries with exponential backoff, dead-letter queue, delivery log.
+ *
+ * Dead exports removed — Issue #819:
+ *   - WebhookSubscription: internal type; not imported by any consumer
+ *   - WebhookDelivery:     internal type; not imported by any consumer
+ *   - dispatchEvent:       internal delivery mechanism; no route calls it
  */
 
-import * as crypto from 'crypto';
+import * as crypto from "crypto";
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 
 export type WebhookEventType =
-  | 'campaign.created'
-  | 'campaign.updated'
-  | 'campaign.funded'
-  | 'campaign.successful'
-  | 'campaign.cancelled'
-  | 'contribution.received'
-  | 'milestone.reached';
+  | "campaign.created"
+  | "campaign.updated"
+  | "campaign.funded"
+  | "campaign.successful"
+  | "campaign.cancelled"
+  | "contribution.received"
+  | "milestone.reached";
 
-export interface WebhookSubscription {
+/** Internal subscription record — not part of the public module API. */
+interface WebhookSubscription {
   id: string;
   url: string;
   events: WebhookEventType[];
@@ -30,12 +36,13 @@ export interface WebhookSubscription {
   ownerId: string;
 }
 
-export interface WebhookDelivery {
+/** Internal delivery record — not part of the public module API. */
+interface WebhookDelivery {
   id: string;
   webhookId: string;
   event: WebhookEventType;
   payload: Record<string, unknown>;
-  status: 'pending' | 'success' | 'failed' | 'dead';
+  status: "pending" | "success" | "failed" | "dead";
   attempts: number;
   lastAttemptAt: string | null;
   nextRetryAt: string | null;
@@ -49,13 +56,6 @@ export interface WebhookDelivery {
 const subscriptions = new Map<string, WebhookSubscription>();
 const deliveries = new Map<string, WebhookDelivery>();
 
-// ── Constants ─────────────────────────────────────────────────────────────────
-
-const MAX_ATTEMPTS = 5;
-const RETRY_DELAYS_MS = [0, 30_000, 300_000, 1_800_000, 7_200_000]; // 0s, 30s, 5m, 30m, 2h
-const SIGNATURE_HEADER = 'x-fmc-signature';
-const TIMESTAMP_HEADER = 'x-fmc-timestamp';
-
 // ── Signature helpers ─────────────────────────────────────────────────────────
 
 /**
@@ -63,11 +63,15 @@ const TIMESTAMP_HEADER = 'x-fmc-timestamp';
  *
  * Signature = HMAC-SHA256(secret, `${timestamp}.${body}`)
  */
-export function signPayload(secret: string, body: string, timestamp: number): string {
+export function signPayload(
+  secret: string,
+  body: string,
+  timestamp: number,
+): string {
   return crypto
-    .createHmac('sha256', secret)
+    .createHmac("sha256", secret)
     .update(`${timestamp}.${body}`)
-    .digest('hex');
+    .digest("hex");
 }
 
 /**
@@ -88,7 +92,10 @@ export function verifySignature(
 ): boolean {
   if (Math.abs(Date.now() - timestamp) > tolerance) return false;
   const expected = signPayload(secret, body, timestamp);
-  return crypto.timingSafeEqual(Buffer.from(signature, 'hex'), Buffer.from(expected, 'hex'));
+  return crypto.timingSafeEqual(
+    Buffer.from(signature, "hex"),
+    Buffer.from(expected, "hex"),
+  );
 }
 
 // ── Registration ──────────────────────────────────────────────────────────────
@@ -102,15 +109,15 @@ export function registerWebhook(
   url: string,
   events: WebhookEventType[],
 ): WebhookSubscription {
-  if (!url.startsWith('https://')) {
-    throw new Error('Webhook URL must use HTTPS');
+  if (!url.startsWith("https://")) {
+    throw new Error("Webhook URL must use HTTPS");
   }
   if (events.length === 0) {
-    throw new Error('At least one event type is required');
+    throw new Error("At least one event type is required");
   }
 
   const id = crypto.randomUUID();
-  const secret = crypto.randomBytes(32).toString('hex');
+  const secret = crypto.randomBytes(32).toString("hex");
 
   const sub: WebhookSubscription = {
     id,
@@ -130,11 +137,11 @@ export function registerWebhook(
 export function updateWebhook(
   id: string,
   ownerId: string,
-  updates: Partial<Pick<WebhookSubscription, 'url' | 'events' | 'active'>>,
+  updates: Partial<Pick<WebhookSubscription, "url" | "events" | "active">>,
 ): WebhookSubscription {
   const sub = subscriptions.get(id);
-  if (!sub) throw new Error('Webhook not found');
-  if (sub.ownerId !== ownerId) throw new Error('Unauthorized');
+  if (!sub) throw new Error("Webhook not found");
+  if (sub.ownerId !== ownerId) throw new Error("Unauthorized");
 
   Object.assign(sub, updates);
   subscriptions.set(id, sub);
@@ -144,120 +151,26 @@ export function updateWebhook(
 /** Delete a webhook subscription. */
 export function deleteWebhook(id: string, ownerId: string): void {
   const sub = subscriptions.get(id);
-  if (!sub) throw new Error('Webhook not found');
-  if (sub.ownerId !== ownerId) throw new Error('Unauthorized');
+  if (!sub) throw new Error("Webhook not found");
+  if (sub.ownerId !== ownerId) throw new Error("Unauthorized");
   subscriptions.delete(id);
 }
 
 /** List all webhooks for an owner. */
 export function listWebhooks(ownerId: string): WebhookSubscription[] {
   return Array.from(subscriptions.values())
-    .filter(s => s.ownerId === ownerId)
-    .map(s => ({ ...s, secret: s.secret.slice(0, 8) + '...' })); // mask secret
+    .filter((s) => s.ownerId === ownerId)
+    .map((s) => ({ ...s, secret: s.secret.slice(0, 8) + "..." })); // mask secret
 }
 
 /** Rotate the signing secret for a webhook. */
 export function rotateSecret(id: string, ownerId: string): string {
   const sub = subscriptions.get(id);
-  if (!sub) throw new Error('Webhook not found');
-  if (sub.ownerId !== ownerId) throw new Error('Unauthorized');
-  sub.secret = crypto.randomBytes(32).toString('hex');
+  if (!sub) throw new Error("Webhook not found");
+  if (sub.ownerId !== ownerId) throw new Error("Unauthorized");
+  sub.secret = crypto.randomBytes(32).toString("hex");
   subscriptions.set(id, sub);
   return sub.secret;
-}
-
-// ── Delivery ──────────────────────────────────────────────────────────────────
-
-/**
- * Dispatch a campaign event to all matching webhook subscriptions.
- * Creates delivery records and attempts immediate delivery.
- */
-export async function dispatchEvent(
-  event: WebhookEventType,
-  payload: Record<string, unknown>,
-): Promise<void> {
-  const matching = Array.from(subscriptions.values()).filter(
-    s => s.active && s.events.includes(event),
-  );
-
-  await Promise.allSettled(matching.map(sub => attemptDelivery(sub, event, payload, true)));
-}
-
-/**
- * Attempt delivery to a single webhook. Creates or updates a delivery record.
- */
-async function attemptDelivery(
-  sub: WebhookSubscription,
-  event: WebhookEventType,
-  payload: Record<string, unknown>,
-  isFirst = false,
-): Promise<void> {
-  const deliveryId = isFirst ? crypto.randomUUID() : undefined;
-  const body = JSON.stringify({ event, data: payload, timestamp: Date.now() });
-  const ts = Date.now();
-  const sig = signPayload(sub.secret, body, ts);
-
-  let delivery: WebhookDelivery = deliveryId
-    ? {
-        id: deliveryId,
-        webhookId: sub.id,
-        event,
-        payload,
-        status: 'pending',
-        attempts: 0,
-        lastAttemptAt: null,
-        nextRetryAt: null,
-        responseCode: null,
-        error: null,
-        createdAt: new Date().toISOString(),
-      }
-    : deliveries.get(deliveryId!)!;
-
-  if (deliveryId) deliveries.set(delivery.id, delivery);
-
-  delivery.attempts++;
-  delivery.lastAttemptAt = new Date().toISOString();
-
-  try {
-    const res = await fetch(sub.url, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        [SIGNATURE_HEADER]: sig,
-        [TIMESTAMP_HEADER]: String(ts),
-        'User-Agent': 'Fund-My-Cause-Webhooks/1.0',
-      },
-      body,
-      signal: AbortSignal.timeout(10_000),
-    });
-
-    delivery.responseCode = res.status;
-
-    if (res.ok) {
-      delivery.status = 'success';
-      delivery.nextRetryAt = null;
-    } else {
-      throw new Error(`HTTP ${res.status}`);
-    }
-  } catch (err) {
-    delivery.error = err instanceof Error ? err.message : 'Unknown error';
-    delivery.responseCode = delivery.responseCode ?? null;
-
-    if (delivery.attempts >= MAX_ATTEMPTS) {
-      delivery.status = 'dead';
-    } else {
-      delivery.status = 'failed';
-      const delay = RETRY_DELAYS_MS[delivery.attempts] ?? RETRY_DELAYS_MS.at(-1)!;
-      delivery.nextRetryAt = new Date(Date.now() + delay).toISOString();
-
-      // Schedule retry
-      setTimeout(() => {
-        void attemptDelivery(sub, event, payload, false);
-      }, delay);
-    }
-  }
-
-  deliveries.set(delivery.id, delivery);
 }
 
 // ── Delivery log ──────────────────────────────────────────────────────────────
@@ -269,15 +182,23 @@ export function getDeliveryLog(
   limit = 50,
 ): WebhookDelivery[] {
   const sub = subscriptions.get(webhookId);
-  if (!sub || sub.ownerId !== ownerId) throw new Error('Webhook not found');
+  if (!sub || sub.ownerId !== ownerId) throw new Error("Webhook not found");
 
   return Array.from(deliveries.values())
-    .filter(d => d.webhookId === webhookId)
-    .sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime())
+    .filter((d) => d.webhookId === webhookId)
+    .sort(
+      (a, b) =>
+        new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
+    )
     .slice(0, limit);
 }
 
 /** List all dead-letter deliveries for a webhook. */
-export function getDeadLetterQueue(webhookId: string, ownerId: string): WebhookDelivery[] {
-  return getDeliveryLog(webhookId, ownerId, 200).filter(d => d.status === 'dead');
+export function getDeadLetterQueue(
+  webhookId: string,
+  ownerId: string,
+): WebhookDelivery[] {
+  return getDeliveryLog(webhookId, ownerId, 200).filter(
+    (d) => d.status === "dead",
+  );
 }

--- a/scripts/check-dead-exports.js
+++ b/scripts/check-dead-exports.js
@@ -1,0 +1,282 @@
+#!/usr/bin/env node
+/**
+ * check-dead-exports.js — Issue #819
+ *
+ * Scans apps/interface/src/lib/webhooks/*.ts for exported symbols and checks
+ * whether each symbol is imported anywhere else in the project.
+ *
+ * Usage:
+ *   node scripts/check-dead-exports.js
+ *   node scripts/check-dead-exports.js --verbose
+ *
+ * Exit codes:
+ *   0 — no dead exports found (or only expected utility-only exports)
+ *   1 — dead exports found (not imported by any consumer file)
+ */
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+// ── Configuration ─────────────────────────────────────────────────────────────
+
+const REPO_ROOT = path.resolve(__dirname, '..');
+
+/** Directory whose exports we want to audit. */
+const AUDIT_DIR = path.join(REPO_ROOT, 'apps/interface/src/lib/webhooks');
+
+/**
+ * Source roots to search for import references.
+ * The audit files themselves are excluded from consumer checks.
+ */
+const SEARCH_ROOTS = [
+  path.join(REPO_ROOT, 'apps/interface/src'),
+];
+
+/** File extensions to scan. */
+const SCAN_EXTENSIONS = ['.ts', '.tsx'];
+
+/**
+ * Exports that are part of the public SDK/utility API and are intentionally
+ * exported even if not consumed inside this application. Listing them here
+ * prevents false positives without suppressing truly dead code.
+ *
+ * Rationale:
+ *  - signPayload    — public utility for webhook consumers to build signatures
+ *  - verifySignature — public utility for webhook consumers to verify payloads
+ */
+const KNOWN_PUBLIC_API = new Set(['signPayload', 'verifySignature']);
+
+const VERBOSE = process.argv.includes('--verbose');
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+/** Recursively collect all files matching the given extensions. */
+function collectFiles(dir, extensions, results = []) {
+  if (!fs.existsSync(dir)) return results;
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      // Skip hidden dirs, node_modules, .next, __mocks__, dist
+      if (['.', 'node_modules', '.next', 'dist', 'build', '.cache'].some(s => entry.name.startsWith(s))) continue;
+      collectFiles(full, extensions, results);
+    } else if (extensions.includes(path.extname(entry.name))) {
+      results.push(full);
+    }
+  }
+  return results;
+}
+
+/**
+ * Parse exported symbols from a TypeScript file using regex heuristics.
+ * Returns an array of { name, line } objects.
+ *
+ * Handles:
+ *   export function foo(...)
+ *   export async function foo(...)
+ *   export const foo = ...
+ *   export type Foo = ...
+ *   export interface Foo { ... }
+ *   export class Foo { ... }
+ *   export enum Foo { ... }
+ *   export { foo, bar }           (re-exports)
+ *   export { foo as bar }         (re-exports with alias)
+ */
+function parseExports(filePath) {
+  const src = fs.readFileSync(filePath, 'utf8');
+  const lines = src.split('\n');
+  const symbols = [];
+
+  // Pattern 1: `export [async] function|const|let|var|class|type|interface|enum <Name>`
+  const declPattern = /^export\s+(?:async\s+)?(?:function|const|let|var|class|type|interface|enum)\s+([A-Za-z_$][A-Za-z0-9_$]*)/;
+
+  // Pattern 2: `export { foo, bar as baz, ... }`  (may span multiple lines but we check single-line form)
+  const namedExportPattern = /^export\s*\{([^}]+)\}/;
+
+  // Pattern 3: `export default function|class <Name>` (if named)
+  const defaultPattern = /^export\s+default\s+(?:function|class)\s+([A-Za-z_$][A-Za-z0-9_$]*)/;
+
+  lines.forEach((line, idx) => {
+    const lineNum = idx + 1;
+    const trimmed = line.trim();
+
+    let m;
+
+    if ((m = declPattern.exec(trimmed))) {
+      symbols.push({ name: m[1], line: lineNum });
+      return;
+    }
+
+    if ((m = defaultPattern.exec(trimmed))) {
+      symbols.push({ name: m[1], line: lineNum });
+      return;
+    }
+
+    if ((m = namedExportPattern.exec(trimmed))) {
+      // Parse `foo, bar as baz, type Baz` — extract the *exported* name (after "as")
+      const entries = m[1].split(',').map(s => s.trim()).filter(Boolean);
+      for (const entry of entries) {
+        // skip `type` keyword-only entries with no name
+        const parts = entry.replace(/^type\s+/, '').split(/\s+as\s+/);
+        const exportedName = (parts[1] ?? parts[0]).trim();
+        if (exportedName && /^[A-Za-z_$]/.test(exportedName)) {
+          symbols.push({ name: exportedName, line: lineNum });
+        }
+      }
+    }
+  });
+
+  return symbols;
+}
+
+/**
+ * Check whether a symbol name is imported/used in any file outside the
+ * audit directory.
+ *
+ * We look for:
+ *   - import { ..., name, ... }
+ *   - import { ..., name as alias, ... }
+ *   - import * as ns from ... (namespace imports — hard to trace statically,
+ *     so we conservatively skip flagging these)
+ *
+ * Returns the list of files that reference the symbol.
+ */
+function findConsumers(symbolName, allFiles, auditFiles) {
+  const auditSet = new Set(auditFiles);
+  const consumers = [];
+
+  // Named import: `{ symbolName` or `, symbolName` followed by optional ` as`
+  // Also matches re-export: `export { symbolName`
+  const importRe = new RegExp(
+    `(?:^|[{,]\\s*)(?:type\\s+)?${escapeRegex(symbolName)}(?:\\s+as\\s+[A-Za-z_$][A-Za-z0-9_$]*)?\\s*(?:,|\\})`,
+    'm',
+  );
+
+  for (const file of allFiles) {
+    if (auditSet.has(file)) continue; // skip the source file itself
+    try {
+      const src = fs.readFileSync(file, 'utf8');
+      if (importRe.test(src)) {
+        consumers.push(file);
+      }
+    } catch {
+      // unreadable file — skip
+    }
+  }
+
+  return consumers;
+}
+
+function escapeRegex(str) {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function relativePath(absPath) {
+  return path.relative(REPO_ROOT, absPath);
+}
+
+// ── Main ──────────────────────────────────────────────────────────────────────
+
+function main() {
+  // 1. Collect audit files (files whose exports we check)
+  const auditFiles = collectFiles(AUDIT_DIR, SCAN_EXTENSIONS);
+  if (auditFiles.length === 0) {
+    console.error(`[check-dead-exports] No files found in ${relativePath(AUDIT_DIR)}`);
+    process.exit(0);
+  }
+
+  // 2. Collect all project files to search for consumers
+  const allFiles = [];
+  for (const root of SEARCH_ROOTS) {
+    collectFiles(root, SCAN_EXTENSIONS, allFiles);
+  }
+
+  if (VERBOSE) {
+    console.log(`Auditing ${auditFiles.length} file(s) in ${relativePath(AUDIT_DIR)}`);
+    console.log(`Searching ${allFiles.length} file(s) across project\n`);
+  }
+
+  // 3. For each audit file, extract exports and check usage
+  const deadExports = [];
+  const publicApiExports = [];
+  const usedExports = [];
+
+  for (const auditFile of auditFiles) {
+    const symbols = parseExports(auditFile);
+
+    if (VERBOSE) {
+      console.log(`\n── ${relativePath(auditFile)} (${symbols.length} exports) ──`);
+    }
+
+    for (const { name, line } of symbols) {
+      const consumers = findConsumers(name, allFiles, [auditFile]);
+
+      if (VERBOSE) {
+        const status = consumers.length > 0
+          ? `✓ used in ${consumers.length} file(s)`
+          : KNOWN_PUBLIC_API.has(name)
+            ? `⚠ public API (not imported internally)`
+            : `✗ DEAD`;
+        console.log(`  L${String(line).padEnd(4)} ${name.padEnd(30)} ${status}`);
+        if (consumers.length > 0 && VERBOSE) {
+          for (const c of consumers) {
+            console.log(`           → ${relativePath(c)}`);
+          }
+        }
+      }
+
+      const entry = { file: relativePath(auditFile), name, line };
+      if (consumers.length === 0) {
+        if (KNOWN_PUBLIC_API.has(name)) {
+          publicApiExports.push(entry);
+        } else {
+          deadExports.push(entry);
+        }
+      } else {
+        usedExports.push({ ...entry, consumers: consumers.map(relativePath) });
+      }
+    }
+  }
+
+  // 4. Report
+  console.log('\n═══════════════════════════════════════════════════════');
+  console.log('  check-dead-exports — webhook export audit');
+  console.log('═══════════════════════════════════════════════════════\n');
+
+  if (usedExports.length > 0) {
+    console.log(`✓  Used exports (${usedExports.length}):`);
+    for (const e of usedExports) {
+      console.log(`   ${e.file}:${e.line}  ${e.name}`);
+    }
+    console.log();
+  }
+
+  if (publicApiExports.length > 0) {
+    console.log(`⚠  Public API exports — exported but not imported internally (${publicApiExports.length}):`);
+    console.log(`   These are intentional public utilities (SDK/consumer-facing).`);
+    console.log(`   Add them to KNOWN_PUBLIC_API in this script if you want to suppress.`);
+    for (const e of publicApiExports) {
+      console.log(`   ${e.file}:${e.line}  ${e.name}`);
+    }
+    console.log();
+  }
+
+  if (deadExports.length === 0) {
+    console.log('✓  No dead exports found.\n');
+    process.exit(0);
+  } else {
+    console.log(`✗  Dead exports found (${deadExports.length}) — not imported anywhere:\n`);
+    for (const e of deadExports) {
+      console.log(`   ${e.file}:${e.line}  ${e.name}`);
+    }
+    console.log(
+      '\n  These symbols are exported but never imported by any consumer file.',
+      '\n  Consider removing them or moving them to an internal (non-exported) scope.',
+      '\n',
+    );
+    process.exit(1);
+  }
+}
+
+main();

--- a/services/graphql-api/.env.example
+++ b/services/graphql-api/.env.example
@@ -1,31 +1,42 @@
 # GraphQL API Configuration
 
 # Server settings
+# Port the GraphQL HTTP and WebSocket server listens on
 GRAPHQL_PORT=4000
+# Runtime environment: development | production | test
 NODE_ENV=development
 
 # Redis settings
+# Connection URL for the Redis instance used for caching and rate limiting
 REDIS_URL=redis://localhost:6379
 
 # Stellar contract settings
+# Soroban RPC endpoint used to query and submit transactions
 RPC_URL=https://soroban-testnet.stellar.org
+# Target network: testnet | mainnet (controls the network passphrase)
 CONTRACT_NETWORK=testnet
 
 # Authentication
-JWT_SECRET=your-secret-key-change-in-production
+# Secret used to sign and verify JWT tokens — must be at least 32 characters
+# and must NOT be set to the example value in any non-local environment
+JWT_SECRET=change-me-to-a-long-random-secret-value
 
-# CORS settings (comma-separated)
+# CORS settings
+# Comma-separated list of allowed origins for browser clients
 CORS_ORIGIN=http://localhost:3000,http://localhost:5173
 
-# Rate limiting
-RATE_LIMIT_WINDOW=60
-RATE_LIMIT_MAX_REQUESTS=100
-RATE_LIMIT_IP_MAX_REQUESTS=1000
-RATE_LIMIT_USER_MAX_REQUESTS=10000
-
 # Logging
+# Pino log level: trace | debug | info | warn | error | fatal
 LOG_LEVEL=info
 
 # Contract addresses
+# On-chain contract ID of the campaign registry (leave blank to disable registry queries)
 REGISTRY_CONTRACT_ID=
-ACHIEVEMENT_CONTRACT_ID=
+
+# Cursor pagination
+# HMAC secret used to sign opaque pagination cursors — change in production
+CURSOR_SECRET=dev-cursor-secret-changeme
+
+# Fraud detection service
+# Base URL of the optional off-chain fraud-detection sidecar
+FRAUD_DETECTION_URL=http://localhost:8000

--- a/services/indexer/src/__tests__/circuit-breaker.test.ts
+++ b/services/indexer/src/__tests__/circuit-breaker.test.ts
@@ -1,0 +1,279 @@
+/**
+ * Circuit breaker unit tests — Issue #906
+ *
+ * Uses an injectable `now` function to control time without fake timers.
+ * Written for vitest (the indexer's test runner).
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { CircuitBreaker, CircuitOpenError } from '../circuit-breaker.js';
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function makeNow(initialMs = 0): { now: () => number; advance: (ms: number) => void } {
+  let t = initialMs;
+  return {
+    now:     () => t,
+    advance: (ms) => { t += ms; },
+  };
+}
+
+const successFn = () => Promise.resolve('ok');
+const failFn = (msg = 'upstream error') => (): Promise<never> =>
+  Promise.reject(new Error(msg));
+
+// ── Initial state ─────────────────────────────────────────────────────────────
+
+describe('CircuitBreaker — initial state', () => {
+  it('starts in CLOSED state', () => {
+    const cb = new CircuitBreaker();
+    expect(cb.currentState).toBe('CLOSED');
+  });
+
+  it('starts with zero metrics', () => {
+    const cb = new CircuitBreaker();
+    const m  = cb.getMetrics();
+    expect(m.totalCalls).toBe(0);
+    expect(m.successfulCalls).toBe(0);
+    expect(m.failedCalls).toBe(0);
+    expect(m.circuitOpenRejections).toBe(0);
+    expect(m.failureCount).toBe(0);
+    expect(m.openedAt).toBeNull();
+  });
+});
+
+// ── CLOSED behaviour ──────────────────────────────────────────────────────────
+
+describe('CircuitBreaker — CLOSED state', () => {
+  it('forwards successful calls', async () => {
+    const cb = new CircuitBreaker();
+    const result = await cb.call(successFn);
+    expect(result).toBe('ok');
+  });
+
+  it('increments successfulCalls on success', async () => {
+    const cb = new CircuitBreaker();
+    await cb.call(successFn);
+    await cb.call(successFn);
+    expect(cb.getMetrics().successfulCalls).toBe(2);
+  });
+
+  it('does not trip after fewer failures than threshold', async () => {
+    const cb = new CircuitBreaker({ failureThreshold: 5 });
+    for (let i = 0; i < 4; i++) {
+      await cb.call(failFn()).catch(() => {});
+    }
+    expect(cb.currentState).toBe('CLOSED');
+  });
+
+  it('trips to OPEN after failureThreshold consecutive failures', async () => {
+    const clock = makeNow();
+    const cb    = new CircuitBreaker({ failureThreshold: 3, now: clock.now });
+
+    for (let i = 0; i < 3; i++) {
+      await cb.call(failFn()).catch(() => {});
+    }
+    expect(cb.currentState).toBe('OPEN');
+  });
+
+  it('resets failureCount on a successful call', async () => {
+    const cb = new CircuitBreaker({ failureThreshold: 5 });
+    await cb.call(failFn()).catch(() => {});
+    await cb.call(failFn()).catch(() => {});
+    await cb.call(successFn);
+    expect(cb.getMetrics().failureCount).toBe(0);
+    expect(cb.currentState).toBe('CLOSED');
+  });
+
+  it('records failedCalls metric', async () => {
+    const cb = new CircuitBreaker({ failureThreshold: 10 });
+    await cb.call(failFn()).catch(() => {});
+    await cb.call(failFn()).catch(() => {});
+    expect(cb.getMetrics().failedCalls).toBe(2);
+  });
+});
+
+// ── OPEN behaviour ────────────────────────────────────────────────────────────
+
+async function buildOpenBreaker(failureThreshold = 3) {
+  const clock = makeNow();
+  const cb    = new CircuitBreaker({ failureThreshold, cooldownMs: 30_000, now: clock.now });
+  for (let i = 0; i < failureThreshold; i++) {
+    await cb.call(failFn()).catch(() => {});
+  }
+  return { cb, clock };
+}
+
+describe('CircuitBreaker — OPEN state', () => {
+  it('rejects calls with CircuitOpenError', async () => {
+    const { cb } = await buildOpenBreaker();
+    await expect(cb.call(successFn)).rejects.toBeInstanceOf(CircuitOpenError);
+  });
+
+  it('does NOT invoke the wrapped function when OPEN', async () => {
+    const { cb } = await buildOpenBreaker();
+    const spy = vi.fn().mockResolvedValue('should-not-be-called');
+    await cb.call(spy).catch(() => {});
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it('increments circuitOpenRejections', async () => {
+    const { cb } = await buildOpenBreaker();
+    await cb.call(successFn).catch(() => {});
+    await cb.call(successFn).catch(() => {});
+    expect(cb.getMetrics().circuitOpenRejections).toBe(2);
+  });
+
+  it('stays OPEN while cooldown has not elapsed', async () => {
+    const { cb, clock } = await buildOpenBreaker();
+    clock.advance(29_999);
+    expect(cb.currentState).toBe('OPEN');
+  });
+
+  it('transitions to HALF_OPEN after cooldownMs elapses', async () => {
+    const { cb, clock } = await buildOpenBreaker();
+    clock.advance(30_000);
+    expect(cb.currentState).toBe('HALF_OPEN');
+  });
+});
+
+// ── HALF_OPEN behaviour ───────────────────────────────────────────────────────
+
+async function buildHalfOpenBreaker() {
+  const clock = makeNow();
+  const cb    = new CircuitBreaker({ failureThreshold: 3, cooldownMs: 10_000, now: clock.now });
+
+  for (let i = 0; i < 3; i++) {
+    await cb.call(failFn()).catch(() => {});
+  }
+  expect(cb.currentState).toBe('OPEN');
+  clock.advance(10_001);
+  expect(cb.currentState).toBe('HALF_OPEN');
+
+  return { cb, clock };
+}
+
+describe('CircuitBreaker — HALF_OPEN state', () => {
+  it('allows a trial call through', async () => {
+    const { cb } = await buildHalfOpenBreaker();
+    await expect(cb.call(successFn)).resolves.toBe('ok');
+  });
+
+  it('transitions to CLOSED after a successful trial', async () => {
+    const { cb } = await buildHalfOpenBreaker();
+    await cb.call(successFn);
+    expect(cb.currentState).toBe('CLOSED');
+    expect(cb.getMetrics().failureCount).toBe(0);
+  });
+
+  it('transitions back to OPEN after a failed trial', async () => {
+    const { cb } = await buildHalfOpenBreaker();
+    await cb.call(failFn()).catch(() => {});
+    expect(cb.currentState).toBe('OPEN');
+  });
+
+  it('resets the cooldown timer when the trial fails', async () => {
+    const { cb, clock } = await buildHalfOpenBreaker();
+    await cb.call(failFn()).catch(() => {});
+
+    clock.advance(9_999);
+    expect(cb.currentState).toBe('OPEN');
+
+    clock.advance(2);
+    expect(cb.currentState).toBe('HALF_OPEN');
+  });
+});
+
+// ── Full outage simulation ────────────────────────────────────────────────────
+
+describe('CircuitBreaker — sustained Horizon downtime simulation', () => {
+  it('opens under sustained failure, then recovers when Horizon comes back', async () => {
+    const clock = makeNow();
+    const cb    = new CircuitBreaker({ failureThreshold: 3, cooldownMs: 5_000, now: clock.now });
+
+    // 1. Simulate 10 consecutive Horizon failures
+    for (let i = 0; i < 10; i++) {
+      await cb.call(failFn('horizon timeout')).catch(() => {});
+    }
+    expect(cb.currentState).toBe('OPEN');
+
+    // 2. Calls during outage are immediately rejected
+    for (let i = 0; i < 5; i++) {
+      await expect(cb.call(successFn)).rejects.toBeInstanceOf(CircuitOpenError);
+    }
+    expect(cb.getMetrics().circuitOpenRejections).toBe(5);
+
+    // 3. Advance past cooldown → HALF_OPEN
+    clock.advance(5_001);
+    expect(cb.currentState).toBe('HALF_OPEN');
+
+    // 4. Still down — trial fails → back to OPEN
+    await cb.call(failFn('still down')).catch(() => {});
+    expect(cb.currentState).toBe('OPEN');
+
+    // 5. Advance past second cooldown
+    clock.advance(5_001);
+    expect(cb.currentState).toBe('HALF_OPEN');
+
+    // 6. Horizon recovers — trial succeeds → CLOSED
+    await cb.call(successFn);
+    expect(cb.currentState).toBe('CLOSED');
+    expect(cb.getMetrics().failureCount).toBe(0);
+
+    // 7. Normal operation resumes
+    const result = await cb.call(successFn);
+    expect(result).toBe('ok');
+  });
+});
+
+// ── reset() ───────────────────────────────────────────────────────────────────
+
+describe('CircuitBreaker — reset()', () => {
+  it('resets to CLOSED and zeroes all counters', async () => {
+    const clock = makeNow();
+    const cb    = new CircuitBreaker({ failureThreshold: 2, now: clock.now });
+
+    await cb.call(failFn()).catch(() => {});
+    await cb.call(failFn()).catch(() => {});
+    expect(cb.currentState).toBe('OPEN');
+
+    cb.reset();
+
+    const m = cb.getMetrics();
+    expect(m.state).toBe('CLOSED');
+    expect(m.failureCount).toBe(0);
+    expect(m.openedAt).toBeNull();
+    expect(m.totalCalls).toBe(0);
+    expect(m.successfulCalls).toBe(0);
+    expect(m.failedCalls).toBe(0);
+    expect(m.circuitOpenRejections).toBe(0);
+  });
+});
+
+// ── getMetrics() ──────────────────────────────────────────────────────────────
+
+describe('CircuitBreaker — getMetrics()', () => {
+  it('reports openedAt timestamp when tripped', async () => {
+    const clock = makeNow(1_000_000);
+    const cb    = new CircuitBreaker({ failureThreshold: 1, now: clock.now });
+
+    await cb.call(failFn()).catch(() => {});
+    expect(cb.getMetrics().openedAt).toBe(1_000_000);
+  });
+
+  it('tracks totalCalls including OPEN rejections', async () => {
+    const clock = makeNow();
+    const cb    = new CircuitBreaker({ failureThreshold: 2, cooldownMs: 5_000, now: clock.now });
+
+    await cb.call(successFn);              // 1 total
+    await cb.call(failFn()).catch(() => {}); // 2 total
+    await cb.call(failFn()).catch(() => {}); // 3 total → OPEN
+    await cb.call(successFn).catch(() => {}); // 4 total, rejection
+
+    const m = cb.getMetrics();
+    expect(m.totalCalls).toBe(4);
+    expect(m.successfulCalls).toBe(1);
+    expect(m.failedCalls).toBe(2);
+    expect(m.circuitOpenRejections).toBe(1);
+  });
+});

--- a/services/indexer/src/circuit-breaker.ts
+++ b/services/indexer/src/circuit-breaker.ts
@@ -1,0 +1,231 @@
+/**
+ * CircuitBreaker — Issue #906
+ *
+ * A three-state circuit breaker that wraps outbound Horizon/RPC calls in
+ * services/indexer, preventing cascading failures when the upstream is down.
+ *
+ * ## States
+ *
+ * ```
+ *          failureThreshold consecutive failures
+ *   CLOSED ──────────────────────────────────────► OPEN
+ *     ▲                                               │
+ *     │  trial succeeds                               │ cooldownMs elapses
+ *     │                                               ▼
+ *     └──────────────────────────────────────── HALF_OPEN
+ *           (trial fails → back to OPEN, reset cooldown)
+ * ```
+ *
+ * ### CLOSED (normal operation)
+ * Every call is forwarded to the wrapped function.  On `failureThreshold`
+ * consecutive failures the breaker trips to OPEN.  Any success resets the
+ * consecutive-failure counter.
+ *
+ * ### OPEN (tripped)
+ * Calls are rejected immediately with `CircuitOpenError` — no network request
+ * is made.  After `cooldownMs` milliseconds the breaker moves to HALF_OPEN.
+ *
+ * ### HALF_OPEN (probing)
+ * One trial call is allowed through.
+ * - **Success** → CLOSED, reset counters.
+ * - **Failure** → OPEN, restart cooldown.
+ *
+ * ## Configuration
+ *
+ * | Option           | Default  | Description                                      |
+ * |------------------|----------|--------------------------------------------------|
+ * | failureThreshold | 5        | Consecutive failures before tripping             |
+ * | cooldownMs       | 30_000   | ms to wait before entering HALF_OPEN             |
+ * | now              | Date.now | Injectable clock — use in tests to skip delays   |
+ *
+ * ## Metrics
+ *
+ * Call `getMetrics()` for Prometheus-compatible counters:
+ * totalCalls, successfulCalls, failedCalls, circuitOpenRejections,
+ * plus current state and failureCount.
+ */
+
+// ── Errors ────────────────────────────────────────────────────────────────────
+
+/** Thrown when a call is rejected because the circuit is currently OPEN. */
+export class CircuitOpenError extends Error {
+  constructor(message = 'Circuit is open — calls are suspended until cooldown elapses') {
+    super(message);
+    this.name = 'CircuitOpenError';
+  }
+}
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+/** The three states of the circuit breaker state machine. */
+export type CircuitState = 'CLOSED' | 'OPEN' | 'HALF_OPEN';
+
+export interface CircuitBreakerOptions {
+  /**
+   * Number of consecutive failures required to trip the breaker.
+   * @default 5
+   */
+  failureThreshold?: number;
+  /**
+   * Milliseconds the breaker stays OPEN before transitioning to HALF_OPEN.
+   * @default 30_000
+   */
+  cooldownMs?: number;
+  /**
+   * Injectable wall-clock provider.
+   * @default Date.now
+   * Pass a custom function in tests to advance time without fake timers.
+   */
+  now?: () => number;
+}
+
+export interface CircuitBreakerMetrics {
+  /** Current circuit state. */
+  state: CircuitState;
+  /** Number of consecutive failures since the last success (CLOSED) or trial failure (HALF_OPEN). */
+  failureCount: number;
+  /** Timestamp (ms) when the circuit was most recently tripped to OPEN. null if never opened. */
+  openedAt: number | null;
+  /** Total number of call() invocations (including OPEN rejections). */
+  totalCalls: number;
+  /** Number of calls that completed successfully. */
+  successfulCalls: number;
+  /** Number of calls that threw (excluding OPEN rejections). */
+  failedCalls: number;
+  /** Number of calls rejected because the circuit was OPEN. */
+  circuitOpenRejections: number;
+}
+
+// ── CircuitBreaker ────────────────────────────────────────────────────────────
+
+export class CircuitBreaker {
+  private state: CircuitState = 'CLOSED';
+  private failureCount  = 0;
+  private openedAt: number | null = null;
+
+  // Metrics counters
+  private totalCalls            = 0;
+  private successfulCalls       = 0;
+  private failedCalls           = 0;
+  private circuitOpenRejections = 0;
+
+  private readonly failureThreshold: number;
+  private readonly cooldownMs:        number;
+  private readonly now:               () => number;
+
+  constructor(options: CircuitBreakerOptions = {}) {
+    this.failureThreshold = options.failureThreshold ?? 5;
+    this.cooldownMs       = options.cooldownMs       ?? 30_000;
+    this.now              = options.now              ?? Date.now;
+  }
+
+  // ── Public API ──────────────────────────────────────────────────────────────
+
+  /** The current state (always up-to-date: evaluates OPEN→HALF_OPEN transition). */
+  get currentState(): CircuitState {
+    this.maybeTransitionToHalfOpen();
+    return this.state;
+  }
+
+  /**
+   * Execute `fn` through the circuit breaker.
+   *
+   * - CLOSED:    runs `fn`; records success or failure.
+   * - OPEN:      throws `CircuitOpenError` immediately (no call to `fn`).
+   * - HALF_OPEN: runs `fn` as a single trial; transitions on outcome.
+   *
+   * @throws {CircuitOpenError} when the circuit is OPEN.
+   * @throws any error thrown by `fn` after recording the failure.
+   */
+  async call<T>(fn: () => Promise<T>): Promise<T> {
+    this.totalCalls++;
+    this.maybeTransitionToHalfOpen();
+
+    if (this.state === 'OPEN') {
+      this.circuitOpenRejections++;
+      throw new CircuitOpenError();
+    }
+
+    try {
+      const result = await fn();
+      this.onSuccess();
+      return result;
+    } catch (err) {
+      // Re-throw CircuitOpenError without double-counting
+      if (err instanceof CircuitOpenError) throw err;
+      this.onFailure();
+      throw err;
+    }
+  }
+
+  /** Return a snapshot of the current metrics. */
+  getMetrics(): CircuitBreakerMetrics {
+    return {
+      state:                 this.currentState,
+      failureCount:          this.failureCount,
+      openedAt:              this.openedAt,
+      totalCalls:            this.totalCalls,
+      successfulCalls:       this.successfulCalls,
+      failedCalls:           this.failedCalls,
+      circuitOpenRejections: this.circuitOpenRejections,
+    };
+  }
+
+  /**
+   * Reset the breaker to its initial CLOSED state and zero all counters.
+   * Useful for tests and manual operator intervention.
+   */
+  reset(): void {
+    this.state                 = 'CLOSED';
+    this.failureCount          = 0;
+    this.openedAt              = null;
+    this.totalCalls            = 0;
+    this.successfulCalls       = 0;
+    this.failedCalls           = 0;
+    this.circuitOpenRejections = 0;
+  }
+
+  // ── Internal state machine ──────────────────────────────────────────────────
+
+  private maybeTransitionToHalfOpen(): void {
+    if (
+      this.state === 'OPEN' &&
+      this.openedAt !== null &&
+      this.now() - this.openedAt >= this.cooldownMs
+    ) {
+      this.state = 'HALF_OPEN';
+    }
+  }
+
+  private onSuccess(): void {
+    this.successfulCalls++;
+
+    if (this.state === 'HALF_OPEN') {
+      // Trial succeeded — fully recover.
+      this.state        = 'CLOSED';
+      this.failureCount = 0;
+      this.openedAt     = null;
+    } else if (this.state === 'CLOSED') {
+      // Reset consecutive-failure counter on any success.
+      this.failureCount = 0;
+    }
+  }
+
+  private onFailure(): void {
+    this.failedCalls++;
+
+    if (this.state === 'HALF_OPEN') {
+      // Trial failed — go back to OPEN and restart cooldown.
+      this.state    = 'OPEN';
+      this.openedAt = this.now();
+      return;
+    }
+
+    // CLOSED state: increment and maybe trip.
+    this.failureCount++;
+    if (this.failureCount >= this.failureThreshold) {
+      this.state    = 'OPEN';
+      this.openedAt = this.now();
+    }
+  }
+}

--- a/services/indexer/src/index.ts
+++ b/services/indexer/src/index.ts
@@ -119,6 +119,8 @@ app.get("/stats", (req, res) => {
     uptime: health.uptime,
     lastLedger: health.lastLedger,
     eventsProcessed: health.eventsProcessed,
+    // Circuit breaker metrics — expose for observability (Issue #906)
+    circuitBreaker: rpcClient.getCircuitBreakerMetrics(),
   });
 });
 

--- a/services/indexer/src/rpc-client.ts
+++ b/services/indexer/src/rpc-client.ts
@@ -1,10 +1,18 @@
 import { SorobanRpc } from "@stellar/stellar-sdk";
 import pino from "pino";
 import { createHttpClient, type HttpClientOptions } from "./http-client.js";
+import {
+  CircuitBreaker,
+  CircuitOpenError,
+  type CircuitBreakerOptions,
+  type CircuitBreakerMetrics,
+} from "./circuit-breaker.js";
 
 export interface SorobanRPCConfig {
   url: string;
   contractId: string;
+  /** Optional circuit breaker tuning. Defaults: failureThreshold=5, cooldownMs=30_000 */
+  circuitBreaker?: CircuitBreakerOptions;
 }
 
 export interface IndexerEvent {
@@ -44,6 +52,7 @@ export class SorobanRPCClient {
   private logger: pino.Logger;
   private config: SorobanRPCConfig;
   private lastLedger: number = 0;
+  private readonly circuitBreaker: CircuitBreaker;
 
   /**
    * Injectable sleep used by unit tests to skip real delays.
@@ -62,6 +71,7 @@ export class SorobanRPCClient {
     this.server = new SorobanRpc.Server(config.url, {
       allowHttp: config.url.startsWith("http://"),
     });
+    this.circuitBreaker = new CircuitBreaker(config.circuitBreaker ?? {});
   }
 
   /**
@@ -128,6 +138,11 @@ export class SorobanRPCClient {
   /**
    * Fetch contract events for a specific ledger sequence.
    *
+   * The outbound HTTP call is wrapped in the circuit breaker.  If the breaker
+   * is OPEN (i.e. Horizon/RPC has been repeatedly failing) the call is
+   * short-circuited and an empty array is returned immediately so the stream
+   * loop can continue without blocking.
+   *
    * Uses the shared HTTP client factory — timeout, retry count, and backoff
    * all follow the documented defaults in http-client.ts unless overridden
    * through RPC_HTTP_OPTIONS above.
@@ -143,22 +158,24 @@ export class SorobanRPCClient {
     const client = createHttpClient(RPC_HTTP_OPTIONS);
 
     try {
-      const result = await client.fetch<{
-        result?: { events: unknown[] };
-        error?: { message: string };
-      }>(this.config.url, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          jsonrpc: "2.0",
-          id: 1,
-          method: "getEvents",
-          params: {
-            startLedger: ledgerSequence,
-            filters: [{ type: "contract", contractIds: [this.config.contractId] }],
-          },
+      const result = await this.circuitBreaker.call(() =>
+        client.fetch<{
+          result?: { events: unknown[] };
+          error?: { message: string };
+        }>(this.config.url, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            jsonrpc: "2.0",
+            id: 1,
+            method: "getEvents",
+            params: {
+              startLedger: ledgerSequence,
+              filters: [{ type: "contract", contractIds: [this.config.contractId] }],
+            },
+          }),
         }),
-      });
+      );
 
       if (!result.ok) {
         // Non-retryable HTTP error (4xx other than 429 already exhausted retries).
@@ -176,6 +193,18 @@ export class SorobanRPCClient {
       const events = result.data?.result?.events ?? [];
       return events.map((e: unknown) => this.parseEvent(e));
     } catch (error) {
+      if (error instanceof CircuitOpenError) {
+        // Circuit is open — RPC is known-down; skip gracefully without noise.
+        this.logger.warn(
+          {
+            ledger: ledgerSequence,
+            circuitState: this.circuitBreaker.currentState,
+          },
+          "Circuit breaker OPEN — skipping RPC call for ledger",
+        );
+        return [];
+      }
+
       this.logger.warn(
         {
           ledger: ledgerSequence,
@@ -185,6 +214,14 @@ export class SorobanRPCClient {
       );
       return [];
     }
+  }
+
+  /**
+   * Return the current circuit breaker metrics.
+   * Useful for exposing via the /health or /stats endpoints.
+   */
+  getCircuitBreakerMetrics(): CircuitBreakerMetrics {
+    return this.circuitBreaker.getMetrics();
   }
 
   /**

--- a/services/monitoring-service/.env.example
+++ b/services/monitoring-service/.env.example
@@ -1,0 +1,19 @@
+# Monitoring Service Configuration
+
+# Server settings
+# Port the monitoring HTTP server listens on (Prometheus metrics, incident API)
+PORT=9091
+
+# PagerDuty integration
+# REST API key (Token auth) used for creating and managing incidents via the
+# PagerDuty REST API v2 — found under User Profile → API Access Keys
+PAGERDUTY_API_KEY=your-pagerduty-api-key
+
+# PagerDuty service ID that critical incidents are filed against
+# Found in PagerDuty → Services → <your service> → Integrations
+PAGERDUTY_SERVICE_ID=your-pagerduty-service-id
+
+# Integration/routing key for the PagerDuty Events API v2 (enqueue endpoint)
+# Used by PagerDutyIntegration.createEvent() to send triggered events
+# Found in PagerDuty → Services → <your service> → Integrations → Events API v2
+PAGERDUTY_INTEGRATION_KEY=your-pagerduty-integration-key

--- a/services/monitoring-service/src/__tests__/alert-rule.test.ts
+++ b/services/monitoring-service/src/__tests__/alert-rule.test.ts
@@ -1,0 +1,250 @@
+/**
+ * Unit tests for alert rule evaluation — Issue #907
+ *
+ * Key property verified: rule evaluation is fully decoupled from transport.
+ * Tests use MockAlertTransport (a test double) — no real email or Slack calls.
+ */
+
+import {
+  ThresholdAlertRule,
+  RateAlertRule,
+  AlertRuleEvaluator,
+  type AlertRuleContext,
+} from '../alert-rule';
+import type { AlertTransport, AlertPayload } from '../alert-transport';
+
+// ── Test double ───────────────────────────────────────────────────────────────
+
+/** Captures all delivered payloads without side-effects. */
+class MockAlertTransport implements AlertTransport {
+  readonly delivered: AlertPayload[] = [];
+
+  async deliver(payload: AlertPayload): Promise<void> {
+    this.delivered.push(payload);
+  }
+
+  get callCount(): number {
+    return this.delivered.length;
+  }
+
+  reset(): void {
+    this.delivered.length = 0;
+  }
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function makeCtx(overrides: Partial<AlertRuleContext> = {}): AlertRuleContext {
+  return {
+    metric:    'cpu_usage',
+    value:     50,
+    threshold: 80,
+    labels:    { service: 'api' },
+    ...overrides,
+  };
+}
+
+// ── ThresholdAlertRule ────────────────────────────────────────────────────────
+
+describe('ThresholdAlertRule', () => {
+  describe('direction: above', () => {
+    const rule = new ThresholdAlertRule({
+      ruleId:    'cpu-warning',
+      direction: 'above',
+      severity:  'warning',
+    });
+
+    it('does not trigger when value is below threshold', () => {
+      const result = rule.evaluate(makeCtx({ value: 70, threshold: 80 }));
+      expect(result.triggered).toBe(false);
+      expect(result.ruleId).toBe('cpu-warning');
+    });
+
+    it('does not trigger when value equals threshold', () => {
+      const result = rule.evaluate(makeCtx({ value: 80, threshold: 80 }));
+      expect(result.triggered).toBe(false);
+    });
+
+    it('triggers when value exceeds threshold', () => {
+      const result = rule.evaluate(makeCtx({ value: 81, threshold: 80 }));
+      expect(result.triggered).toBe(true);
+      expect(result.severity).toBe('warning');
+      expect(result.message).toContain('cpu_usage');
+      expect(result.message).toContain('above');
+    });
+  });
+
+  describe('direction: below', () => {
+    const rule = new ThresholdAlertRule({
+      ruleId:    'cache-hit-low',
+      direction: 'below',
+      severity:  'critical',
+    });
+
+    it('triggers when value is below threshold', () => {
+      const result = rule.evaluate(makeCtx({ metric: 'cache_hit_rate', value: 40, threshold: 50 }));
+      expect(result.triggered).toBe(true);
+      expect(result.severity).toBe('critical');
+    });
+
+    it('does not trigger when value is above threshold', () => {
+      const result = rule.evaluate(makeCtx({ metric: 'cache_hit_rate', value: 70, threshold: 50 }));
+      expect(result.triggered).toBe(false);
+    });
+  });
+
+  it('includes the original context in the result', () => {
+    const rule = new ThresholdAlertRule({ ruleId: 'test', direction: 'above', severity: 'info' });
+    const ctx  = makeCtx({ value: 99, threshold: 90, labels: { env: 'prod' } });
+    const result = rule.evaluate(ctx);
+    expect(result.context).toEqual(ctx);
+  });
+});
+
+// ── RateAlertRule ─────────────────────────────────────────────────────────────
+
+describe('RateAlertRule', () => {
+  const rule = new RateAlertRule({
+    ruleId:    'error-spike',
+    direction: 'increase',
+    severity:  'critical',
+  });
+
+  it('does not trigger when previousValue is missing', () => {
+    const result = rule.evaluate(makeCtx({ metric: 'errors', value: 100 }));
+    expect(result.triggered).toBe(false);
+    expect(result.message).toContain('insufficient data');
+  });
+
+  it('does not trigger when windowSeconds is zero', () => {
+    const result = rule.evaluate(
+      makeCtx({ metric: 'errors', value: 100, previousValue: 10, windowSeconds: 0 }),
+    );
+    expect(result.triggered).toBe(false);
+    expect(result.message).toContain('insufficient data');
+  });
+
+  it('triggers when rate of increase exceeds threshold', () => {
+    // value went from 10 to 110 in 10 seconds → rate = 10/s > threshold 5/s
+    const result = rule.evaluate(
+      makeCtx({ metric: 'errors', value: 110, previousValue: 10, windowSeconds: 10, threshold: 5 }),
+    );
+    expect(result.triggered).toBe(true);
+    expect(result.message).toContain('increased');
+  });
+
+  it('does not trigger when rate is below threshold', () => {
+    // value went from 10 to 20 in 10 seconds → rate = 1/s < threshold 5/s
+    const result = rule.evaluate(
+      makeCtx({ metric: 'errors', value: 20, previousValue: 10, windowSeconds: 10, threshold: 5 }),
+    );
+    expect(result.triggered).toBe(false);
+  });
+
+  it('triggers on decrease direction when rate falls below -threshold', () => {
+    const decreaseRule = new RateAlertRule({ ruleId: 'throughput-drop', direction: 'decrease', severity: 'warning' });
+    // value dropped from 100 to 10 in 10 seconds → rate = -9/s, threshold = 5 → -9 < -5 → triggered
+    const result = decreaseRule.evaluate(
+      makeCtx({ metric: 'throughput', value: 10, previousValue: 100, windowSeconds: 10, threshold: 5 }),
+    );
+    expect(result.triggered).toBe(true);
+  });
+});
+
+// ── AlertRuleEvaluator (transport decoupling) ─────────────────────────────────
+
+describe('AlertRuleEvaluator', () => {
+  let transport: MockAlertTransport;
+  let evaluator: AlertRuleEvaluator;
+
+  const cpuRule = new ThresholdAlertRule({ ruleId: 'cpu-warn', direction: 'above', severity: 'warning' });
+  const memRule = new ThresholdAlertRule({ ruleId: 'mem-crit', direction: 'above', severity: 'critical' });
+
+  beforeEach(() => {
+    transport = new MockAlertTransport();
+    evaluator  = new AlertRuleEvaluator([cpuRule, memRule], transport);
+  });
+
+  it('does not call transport when no rules trigger', async () => {
+    await evaluator.evaluate(makeCtx({ metric: 'cpu_usage', value: 50, threshold: 80 }));
+    expect(transport.callCount).toBe(0);
+  });
+
+  it('calls transport exactly once per triggered rule', async () => {
+    // value 90 > threshold 80 → cpu-warn triggers; mem-crit same ctx → also triggers
+    await evaluator.evaluate(makeCtx({ metric: 'cpu_usage', value: 90, threshold: 80 }));
+    expect(transport.callCount).toBe(2); // both rules share the same ctx and both trigger
+  });
+
+  it('delivers correct payload fields when a rule triggers', async () => {
+    await evaluator.evaluate(makeCtx({ metric: 'cpu_usage', value: 90, threshold: 80 }));
+
+    const payload = transport.delivered[0];
+    expect(payload.ruleId).toBe('cpu-warn');
+    expect(payload.severity).toBe('warning');
+    expect(payload.message).toBeTruthy();
+    expect(typeof payload.timestamp).toBe('string');
+    expect(payload.context).toBeDefined();
+  });
+
+  it('returns results for all rules including non-triggered ones', async () => {
+    const cpuOnlyRule = new ThresholdAlertRule({ ruleId: 'cpu-only', direction: 'above', severity: 'info' });
+    // neverRule has a very high threshold that the test value won't reach
+    const neverRule   = new ThresholdAlertRule({ ruleId: 'never',    direction: 'above', severity: 'info' });
+
+    const singleEval = new AlertRuleEvaluator([cpuOnlyRule, neverRule], transport);
+    // cpuOnlyRule: value 90 > threshold 80 → triggered
+    // neverRule:   value 90 > threshold 1000 → NOT triggered
+    const ctx1 = makeCtx({ value: 90, threshold: 80 });
+    const ctx2 = makeCtx({ value: 90, threshold: 1000 });
+
+    const results1 = await singleEval.evaluate(ctx1);
+    const results2 = await new AlertRuleEvaluator([cpuOnlyRule, neverRule], transport)
+      .evaluate(ctx2);
+
+    // With threshold=80: both cpuOnlyRule and neverRule evaluate the same ctx → both trigger
+    expect(results1).toHaveLength(2);
+    expect(results1.find(r => r.ruleId === 'cpu-only')?.triggered).toBe(true);
+
+    // With threshold=1000: neither triggers
+    expect(results2).toHaveLength(2);
+    expect(results2.find(r => r.ruleId === 'cpu-only')?.triggered).toBe(false);
+    expect(results2.find(r => r.ruleId === 'never')   ?.triggered).toBe(false);
+  });
+
+  it('passes transport call count asserts regardless of rule count', async () => {
+    // Only one rule, value does not cross threshold
+    const singleEval = new AlertRuleEvaluator([cpuRule], transport);
+    await singleEval.evaluate(makeCtx({ value: 30, threshold: 80 }));
+    expect(transport.callCount).toBe(0);
+
+    // Now cross the threshold
+    await singleEval.evaluate(makeCtx({ value: 90, threshold: 80 }));
+    expect(transport.callCount).toBe(1);
+  });
+
+  it('evaluator is transport-agnostic: swapping transport changes delivery only', async () => {
+    const anotherMock = new MockAlertTransport();
+    const anotherEval = new AlertRuleEvaluator([cpuRule], anotherMock);
+
+    await evaluator.evaluate(makeCtx({ value: 90, threshold: 80 }));
+    await anotherEval.evaluate(makeCtx({ value: 90, threshold: 80 }));
+
+    // Each evaluator's transport received the alert independently
+    expect(transport.callCount).toBe(2); // 2 rules in evaluator
+    expect(anotherMock.callCount).toBe(1); // 1 rule in anotherEval
+  });
+
+  it('handles mixed rule types in the same evaluator', async () => {
+    const rateRule = new RateAlertRule({ ruleId: 'spike', direction: 'increase', severity: 'warning' });
+    const mixedEval = new AlertRuleEvaluator([cpuRule, rateRule], transport);
+
+    // cpuRule triggers (90 > 80), rateRule skips (no previousValue)
+    const results = await mixedEval.evaluate(makeCtx({ value: 90, threshold: 80 }));
+
+    expect(results).toHaveLength(2);
+    expect(transport.callCount).toBe(1); // only cpuRule triggered
+    expect(results.find(r => r.ruleId === 'cpu-warn')?.triggered).toBe(true);
+    expect(results.find(r => r.ruleId === 'spike')   ?.triggered).toBe(false);
+  });
+});

--- a/services/monitoring-service/src/__tests__/alert-transport.test.ts
+++ b/services/monitoring-service/src/__tests__/alert-transport.test.ts
@@ -1,0 +1,250 @@
+/**
+ * Unit tests for alert transport implementations — Issue #907
+ *
+ * Tests confirm each transport correctly formats and "delivers" (to a test
+ * double / captured output) a sample alert payload.
+ */
+
+import {
+  EmailAlertTransport,
+  SlackAlertTransport,
+  CompositeAlertTransport,
+  type AlertPayload,
+} from '../alert-transport';
+
+// ── Sample payload ────────────────────────────────────────────────────────────
+
+const SAMPLE_PAYLOAD: AlertPayload = {
+  ruleId:    'cpu-critical',
+  severity:  'critical',
+  message:   'CPU usage is 95 (above threshold 80)',
+  context:   { metric: 'cpu_usage', value: 95, threshold: 80, service: 'api' },
+  timestamp: '2026-07-29T15:00:00.000Z',
+};
+
+// ── EmailAlertTransport ───────────────────────────────────────────────────────
+
+describe('EmailAlertTransport', () => {
+  let consoleSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    consoleSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleSpy.mockRestore();
+  });
+
+  it('resolves without throwing for a valid payload', async () => {
+    const transport = new EmailAlertTransport({ to: 'ops@example.com' });
+    await expect(transport.deliver(SAMPLE_PAYLOAD)).resolves.toBeUndefined();
+  });
+
+  it('logs the recipient address', async () => {
+    const transport = new EmailAlertTransport({ to: 'ops@example.com' });
+    await transport.deliver(SAMPLE_PAYLOAD);
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.stringContaining('ops@example.com'),
+    );
+  });
+
+  it('includes the rule ID and severity in logged output', async () => {
+    const transport = new EmailAlertTransport({ to: 'ops@example.com' });
+    await transport.deliver(SAMPLE_PAYLOAD);
+
+    const loggedText = consoleSpy.mock.calls.flat().join(' ');
+    expect(loggedText).toContain('cpu-critical');
+    expect(loggedText).toContain('critical');
+  });
+
+  it('uses the default subject prefix when none is specified', async () => {
+    const transport = new EmailAlertTransport({ to: 'ops@example.com' });
+    await transport.deliver(SAMPLE_PAYLOAD);
+    const loggedText = consoleSpy.mock.calls.flat().join(' ');
+    expect(loggedText).toContain('[Alert]');
+  });
+
+  it('uses a custom subject prefix when provided', async () => {
+    const transport = new EmailAlertTransport({ to: 'ops@example.com', subjectPrefix: '[PROD]' });
+    await transport.deliver(SAMPLE_PAYLOAD);
+    const loggedText = consoleSpy.mock.calls.flat().join(' ');
+    expect(loggedText).toContain('[PROD]');
+  });
+
+  it('includes the alert message in logged output', async () => {
+    const transport = new EmailAlertTransport({ to: 'ops@example.com' });
+    await transport.deliver(SAMPLE_PAYLOAD);
+    const loggedText = consoleSpy.mock.calls.flat().join(' ');
+    expect(loggedText).toContain(SAMPLE_PAYLOAD.message);
+  });
+
+  it('includes the ISO timestamp', async () => {
+    const transport = new EmailAlertTransport({ to: 'ops@example.com' });
+    await transport.deliver(SAMPLE_PAYLOAD);
+    const loggedText = consoleSpy.mock.calls.flat().join(' ');
+    expect(loggedText).toContain(SAMPLE_PAYLOAD.timestamp);
+  });
+});
+
+// ── SlackAlertTransport ───────────────────────────────────────────────────────
+
+describe('SlackAlertTransport', () => {
+  let consoleSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    consoleSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleSpy.mockRestore();
+  });
+
+  it('resolves without throwing when no webhookUrl is set (simulated mode)', async () => {
+    const transport = new SlackAlertTransport({ channel: '#alerts' });
+    await expect(transport.deliver(SAMPLE_PAYLOAD)).resolves.toBeUndefined();
+  });
+
+  it('logs the channel name', async () => {
+    const transport = new SlackAlertTransport({ channel: '#alerts-prod' });
+    await transport.deliver(SAMPLE_PAYLOAD);
+    expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('#alerts-prod'));
+  });
+
+  it('includes the critical severity emoji for critical alerts', async () => {
+    const transport = new SlackAlertTransport({ channel: '#alerts' });
+    await transport.deliver(SAMPLE_PAYLOAD);
+    const loggedText = consoleSpy.mock.calls.flat().join(' ');
+    expect(loggedText).toContain('🔴');
+  });
+
+  it('includes the warning emoji for warning severity', async () => {
+    const transport = new SlackAlertTransport({ channel: '#alerts' });
+    await transport.deliver({ ...SAMPLE_PAYLOAD, severity: 'warning' });
+    const loggedText = consoleSpy.mock.calls.flat().join(' ');
+    expect(loggedText).toContain('🟡');
+  });
+
+  it('includes the info emoji for info severity', async () => {
+    const transport = new SlackAlertTransport({ channel: '#alerts' });
+    await transport.deliver({ ...SAMPLE_PAYLOAD, severity: 'info' });
+    const loggedText = consoleSpy.mock.calls.flat().join(' ');
+    expect(loggedText).toContain('🔵');
+  });
+
+  it('includes the rule ID in logged output', async () => {
+    const transport = new SlackAlertTransport({ channel: '#alerts' });
+    await transport.deliver(SAMPLE_PAYLOAD);
+    const loggedText = consoleSpy.mock.calls.flat().join(' ');
+    expect(loggedText).toContain('cpu-critical');
+  });
+
+  it('uses fetch to POST when webhookUrl is provided', async () => {
+    const mockFetch = jest.fn().mockResolvedValue({ ok: true, status: 200 });
+    global.fetch = mockFetch as unknown as typeof fetch;
+
+    const transport = new SlackAlertTransport({
+      channel:    '#alerts',
+      webhookUrl: 'https://hooks.slack.com/services/T000/B000/test',
+    });
+    await transport.deliver(SAMPLE_PAYLOAD);
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    const [url, opts] = mockFetch.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe('https://hooks.slack.com/services/T000/B000/test');
+    expect(opts.method).toBe('POST');
+
+    // Restore
+    jest.restoreAllMocks();
+  });
+
+  it('throws when webhookUrl returns a non-ok response', async () => {
+    const mockFetch = jest.fn().mockResolvedValue({ ok: false, status: 500 });
+    global.fetch = mockFetch as unknown as typeof fetch;
+
+    const transport = new SlackAlertTransport({
+      channel:    '#alerts',
+      webhookUrl: 'https://hooks.slack.com/services/bad',
+    });
+
+    await expect(transport.deliver(SAMPLE_PAYLOAD)).rejects.toThrow('HTTP 500');
+    jest.restoreAllMocks();
+  });
+});
+
+// ── CompositeAlertTransport ───────────────────────────────────────────────────
+
+class CaptureTransport {
+  readonly received: AlertPayload[] = [];
+  async deliver(payload: AlertPayload): Promise<void> {
+    this.received.push(payload);
+  }
+}
+
+class FailingTransport {
+  async deliver(_payload: AlertPayload): Promise<void> {
+    throw new Error('Simulated transport failure');
+  }
+}
+
+describe('CompositeAlertTransport', () => {
+  let consoleErrorSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore();
+  });
+
+  it('throws when constructed with an empty transports array', () => {
+    expect(() => new CompositeAlertTransport([])).toThrow();
+  });
+
+  it('fans out to all transports', async () => {
+    const t1 = new CaptureTransport();
+    const t2 = new CaptureTransport();
+    const composite = new CompositeAlertTransport([t1, t2]);
+
+    await composite.deliver(SAMPLE_PAYLOAD);
+
+    expect(t1.received).toHaveLength(1);
+    expect(t2.received).toHaveLength(1);
+    expect(t1.received[0]).toEqual(SAMPLE_PAYLOAD);
+    expect(t2.received[0]).toEqual(SAMPLE_PAYLOAD);
+  });
+
+  it('delivers to healthy transports even when one fails', async () => {
+    const good    = new CaptureTransport();
+    const failing = new FailingTransport();
+    const composite = new CompositeAlertTransport([failing, good]);
+
+    await composite.deliver(SAMPLE_PAYLOAD);
+
+    expect(good.received).toHaveLength(1);
+    expect(consoleErrorSpy).toHaveBeenCalled();
+  });
+
+  it('logs failure details when a transport errors', async () => {
+    const composite = new CompositeAlertTransport([new FailingTransport()]);
+    await composite.deliver(SAMPLE_PAYLOAD);
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Simulated transport failure'),
+    );
+  });
+
+  it('resolves even if all transports fail', async () => {
+    const composite = new CompositeAlertTransport([new FailingTransport(), new FailingTransport()]);
+    await expect(composite.deliver(SAMPLE_PAYLOAD)).resolves.toBeUndefined();
+  });
+
+  it('delivers identical payload object to each transport', async () => {
+    const t1 = new CaptureTransport();
+    const t2 = new CaptureTransport();
+    const composite = new CompositeAlertTransport([t1, t2]);
+
+    await composite.deliver(SAMPLE_PAYLOAD);
+
+    expect(t1.received[0]).toEqual(t2.received[0]);
+  });
+});

--- a/services/monitoring-service/src/alert-rule.ts
+++ b/services/monitoring-service/src/alert-rule.ts
@@ -1,0 +1,237 @@
+/**
+ * Alert rule evaluation — Issue #907
+ *
+ * Rule evaluation is entirely decoupled from notification transport.
+ * Rules operate on raw metric values; when a rule fires it produces an
+ * `AlertRuleResult` and delegates delivery to whatever `AlertTransport` was
+ * injected at construction time.
+ *
+ * Structure:
+ *   AlertRuleContext   — metric reading passed to every rule
+ *   AlertRuleResult    — outcome of evaluating one rule
+ *   AlertRule          — interface that every rule implements
+ *   ThresholdAlertRule — fires when a value exceeds a static threshold
+ *   RateAlertRule      — fires when a rate of change exceeds a threshold
+ *   AlertRuleEvaluator — orchestrates a list of rules and calls transport on trigger
+ */
+
+import type { AlertTransport, AlertPayload } from './alert-transport.js';
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+/** Metric snapshot passed into every rule for evaluation. */
+export interface AlertRuleContext {
+  /** Name of the metric (e.g. "cpu_usage", "error_rate"). */
+  metric: string;
+  /** Current observed value. */
+  value: number;
+  /** Configured threshold value for this metric. */
+  threshold: number;
+  /**
+   * Optional previous value — required by rate-based rules.
+   * Ignored by threshold rules.
+   */
+  previousValue?: number;
+  /**
+   * Time window in seconds over which the rate is computed.
+   * Required by rate-based rules; ignored by threshold rules.
+   */
+  windowSeconds?: number;
+  /** Arbitrary key/value labels attached to this metric reading. */
+  labels?: Record<string, string>;
+}
+
+/** Outcome produced by evaluating a single rule. */
+export interface AlertRuleResult {
+  /** Unique identifier of the rule that was evaluated. */
+  ruleId: string;
+  /** `true` if the rule conditions were satisfied (alert should fire). */
+  triggered: boolean;
+  /** Severity to assign when `triggered` is true. */
+  severity: 'critical' | 'warning' | 'info';
+  /** Human-readable explanation of the outcome. */
+  message: string;
+  /** The context snapshot that was used for evaluation. */
+  context: AlertRuleContext;
+}
+
+/** Contract that every alert rule must satisfy. */
+export interface AlertRule {
+  /** Unique rule identifier. */
+  readonly ruleId: string;
+  /**
+   * Evaluate the rule against a metric context.
+   * Must not throw — malformed contexts produce a non-triggered result.
+   */
+  evaluate(ctx: AlertRuleContext): AlertRuleResult;
+}
+
+// ── ThresholdAlertRule ────────────────────────────────────────────────────────
+
+export interface ThresholdAlertRuleOptions {
+  /** Unique identifier for this rule instance. */
+  ruleId: string;
+  /**
+   * The comparison direction:
+   *   'above' — fires when value > threshold
+   *   'below' — fires when value < threshold
+   */
+  direction: 'above' | 'below';
+  /** Severity emitted when the rule fires. */
+  severity: 'critical' | 'warning' | 'info';
+}
+
+/**
+ * Fires when a metric value crosses a static threshold.
+ *
+ * Examples:
+ *   new ThresholdAlertRule({ ruleId: 'cpu-critical', direction: 'above', severity: 'critical' })
+ *   → triggers when ctx.value > ctx.threshold
+ */
+export class ThresholdAlertRule implements AlertRule {
+  readonly ruleId: string;
+  private readonly direction: 'above' | 'below';
+  private readonly severity: 'critical' | 'warning' | 'info';
+
+  constructor(options: ThresholdAlertRuleOptions) {
+    this.ruleId = options.ruleId;
+    this.direction = options.direction;
+    this.severity = options.severity;
+  }
+
+  evaluate(ctx: AlertRuleContext): AlertRuleResult {
+    const triggered =
+      this.direction === 'above' ? ctx.value > ctx.threshold : ctx.value < ctx.threshold;
+
+    const message = triggered
+      ? `${ctx.metric} is ${ctx.value} (${this.direction} threshold ${ctx.threshold})`
+      : `${ctx.metric} is within bounds (${ctx.value} vs threshold ${ctx.threshold})`;
+
+    return {
+      ruleId:    this.ruleId,
+      triggered,
+      severity:  this.severity,
+      message,
+      context:   ctx,
+    };
+  }
+}
+
+// ── RateAlertRule ─────────────────────────────────────────────────────────────
+
+export interface RateAlertRuleOptions {
+  /** Unique identifier for this rule instance. */
+  ruleId: string;
+  /**
+   * The rate direction:
+   *   'increase' — fires when the rate of change exceeds the threshold
+   *   'decrease' — fires when the rate of change falls below -threshold
+   */
+  direction: 'increase' | 'decrease';
+  /** Severity emitted when the rule fires. */
+  severity: 'critical' | 'warning' | 'info';
+}
+
+/**
+ * Fires when the per-second rate of change of a metric exceeds a threshold.
+ *
+ * Requires `ctx.previousValue` and `ctx.windowSeconds` to be set.
+ * Returns a non-triggered result with an explanatory message when they are absent.
+ */
+export class RateAlertRule implements AlertRule {
+  readonly ruleId: string;
+  private readonly direction: 'increase' | 'decrease';
+  private readonly severity: 'critical' | 'warning' | 'info';
+
+  constructor(options: RateAlertRuleOptions) {
+    this.ruleId = options.ruleId;
+    this.direction = options.direction;
+    this.severity = options.severity;
+  }
+
+  evaluate(ctx: AlertRuleContext): AlertRuleResult {
+    if (ctx.previousValue === undefined || !ctx.windowSeconds || ctx.windowSeconds <= 0) {
+      return {
+        ruleId:    this.ruleId,
+        triggered: false,
+        severity:  this.severity,
+        message:   `${ctx.metric}: insufficient data for rate calculation (need previousValue and windowSeconds)`,
+        context:   ctx,
+      };
+    }
+
+    const ratePerSecond = (ctx.value - ctx.previousValue) / ctx.windowSeconds;
+    const triggered =
+      this.direction === 'increase'
+        ? ratePerSecond > ctx.threshold
+        : ratePerSecond < -ctx.threshold;
+
+    const direction = this.direction === 'increase' ? 'increased' : 'decreased';
+    const message = triggered
+      ? `${ctx.metric} ${direction} at ${ratePerSecond.toFixed(4)}/s (threshold ${ctx.threshold}/s)`
+      : `${ctx.metric} rate is within bounds (${ratePerSecond.toFixed(4)}/s vs threshold ${ctx.threshold}/s)`;
+
+    return {
+      ruleId:    this.ruleId,
+      triggered,
+      severity:  this.severity,
+      message,
+      context:   ctx,
+    };
+  }
+}
+
+// ── AlertRuleEvaluator ────────────────────────────────────────────────────────
+
+/**
+ * Orchestrates evaluation of a list of alert rules against a metric context.
+ *
+ * The evaluator has no knowledge of how alerts are delivered — it delegates
+ * entirely to the injected `AlertTransport`.  This is the primary decoupling
+ * point addressed by Issue #907.
+ *
+ * Usage:
+ *   const transport = new CompositeAlertTransport([emailTransport, slackTransport]);
+ *   const evaluator = new AlertRuleEvaluator([rule1, rule2], transport);
+ *   await evaluator.evaluate({ metric: 'cpu_usage', value: 92, threshold: 80, labels: {} });
+ */
+export class AlertRuleEvaluator {
+  private readonly rules: AlertRule[];
+  private readonly transport: AlertTransport;
+
+  constructor(rules: AlertRule[], transport: AlertTransport) {
+    this.rules = rules;
+    this.transport = transport;
+  }
+
+  /**
+   * Evaluate all rules against the supplied context.
+   *
+   * Rules that trigger cause `transport.deliver()` to be called.
+   * Transport failures are surfaced as thrown errors so callers can decide
+   * whether to retry or log and continue.
+   *
+   * @returns All evaluation results (triggered and non-triggered).
+   */
+  async evaluate(ctx: AlertRuleContext): Promise<AlertRuleResult[]> {
+    const results: AlertRuleResult[] = [];
+
+    for (const rule of this.rules) {
+      const result = rule.evaluate(ctx);
+      results.push(result);
+
+      if (result.triggered) {
+        const payload: AlertPayload = {
+          ruleId:    result.ruleId,
+          severity:  result.severity,
+          message:   result.message,
+          context:   { ...ctx, ...ctx.labels },
+          timestamp: new Date().toISOString(),
+        };
+        await this.transport.deliver(payload);
+      }
+    }
+
+    return results;
+  }
+}

--- a/services/monitoring-service/src/alert-transport.ts
+++ b/services/monitoring-service/src/alert-transport.ts
@@ -1,0 +1,181 @@
+/**
+ * Alert transport abstraction — Issue #907
+ *
+ * Defines a transport-agnostic interface for delivering alerts so that
+ * rule-evaluation logic has no knowledge of how alerts are ultimately sent.
+ *
+ * Implementations:
+ *   - EmailAlertTransport   — formats and "sends" an email notification
+ *   - SlackAlertTransport   — formats and posts a Slack message
+ *   - CompositeAlertTransport — fans out to multiple transports simultaneously
+ */
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+/** The normalized payload that every transport receives. */
+export interface AlertPayload {
+  /** Identifier of the rule that fired. */
+  ruleId: string;
+  /** Severity of the alert. */
+  severity: 'critical' | 'warning' | 'info';
+  /** Human-readable message describing what fired. */
+  message: string;
+  /** Key/value context captured at evaluation time (metric name, value, threshold, etc.). */
+  context: Record<string, unknown>;
+  /** ISO-8601 timestamp of when the alert was generated. */
+  timestamp: string;
+}
+
+/**
+ * Transport-agnostic delivery interface.
+ *
+ * Rule evaluation calls `deliver()` with a fully formed `AlertPayload`.
+ * The transport is responsible for formatting and dispatching the payload
+ * to its specific channel — email, Slack, PagerDuty, webhook, etc.
+ */
+export interface AlertTransport {
+  /**
+   * Deliver an alert payload.
+   * Must resolve when delivery is complete (or immediately for fire-and-forget
+   * implementations that queue internally).
+   */
+  deliver(payload: AlertPayload): Promise<void>;
+}
+
+// ── Email ─────────────────────────────────────────────────────────────────────
+
+export interface EmailAlertTransportOptions {
+  /** Recipient address. */
+  to: string;
+  /** Optional prefix prepended to every subject line (e.g. "[PROD]"). */
+  subjectPrefix?: string;
+}
+
+/**
+ * Simulated email transport.
+ *
+ * In production this would call an SMTP library or an email API (e.g. SES,
+ * SendGrid).  Here it logs a formatted representation so the service can run
+ * without real mail credentials.
+ */
+export class EmailAlertTransport implements AlertTransport {
+  private readonly to: string;
+  private readonly subjectPrefix: string;
+
+  constructor(options: EmailAlertTransportOptions) {
+    this.to = options.to;
+    this.subjectPrefix = options.subjectPrefix ?? '[Alert]';
+  }
+
+  async deliver(payload: AlertPayload): Promise<void> {
+    const subject = `${this.subjectPrefix} [${payload.severity.toUpperCase()}] ${payload.message}`;
+    const body = [
+      `Rule:      ${payload.ruleId}`,
+      `Severity:  ${payload.severity}`,
+      `Message:   ${payload.message}`,
+      `Timestamp: ${payload.timestamp}`,
+      `Context:   ${JSON.stringify(payload.context, null, 2)}`,
+    ].join('\n');
+
+    // Simulated send — replace with real mailer in production.
+    console.log(`[EmailAlertTransport] Sending to: ${this.to}`);
+    console.log(`[EmailAlertTransport] Subject: ${subject}`);
+    console.log(`[EmailAlertTransport] Body:\n${body}`);
+  }
+}
+
+// ── Slack ─────────────────────────────────────────────────────────────────────
+
+export interface SlackAlertTransportOptions {
+  /** Slack channel name or ID (e.g. "#alerts-prod"). */
+  channel: string;
+  /**
+   * Incoming webhook URL.
+   * Required in production; may be omitted in tests/dev where delivery is
+   * simulated via console output.
+   */
+  webhookUrl?: string;
+}
+
+/** Emoji map for severity levels. */
+const SEVERITY_EMOJI: Record<AlertPayload['severity'], string> = {
+  critical: '🔴',
+  warning:  '🟡',
+  info:     '🔵',
+};
+
+/**
+ * Simulated Slack transport.
+ *
+ * In production this would POST a Block Kit payload to the configured
+ * Incoming Webhook URL.  Here it logs the formatted message.
+ */
+export class SlackAlertTransport implements AlertTransport {
+  private readonly channel: string;
+  private readonly webhookUrl: string | undefined;
+
+  constructor(options: SlackAlertTransportOptions) {
+    this.channel = options.channel;
+    this.webhookUrl = options.webhookUrl;
+  }
+
+  async deliver(payload: AlertPayload): Promise<void> {
+    const emoji = SEVERITY_EMOJI[payload.severity];
+    const text = [
+      `${emoji} *[${payload.severity.toUpperCase()}]* ${payload.message}`,
+      `*Rule:* ${payload.ruleId}`,
+      `*Time:* ${payload.timestamp}`,
+      `*Context:* \`${JSON.stringify(payload.context)}\``,
+    ].join('\n');
+
+    if (this.webhookUrl) {
+      // Production path — POST to Slack Incoming Webhook.
+      const res = await fetch(this.webhookUrl, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ channel: this.channel, text }),
+        signal: AbortSignal.timeout(10_000),
+      });
+      if (!res.ok) {
+        throw new Error(`Slack delivery failed: HTTP ${res.status}`);
+      }
+    } else {
+      // Simulated path — log to console.
+      console.log(`[SlackAlertTransport] Channel: ${this.channel}`);
+      console.log(`[SlackAlertTransport] Message:\n${text}`);
+    }
+  }
+}
+
+// ── Composite ─────────────────────────────────────────────────────────────────
+
+/**
+ * Fans out delivery to multiple transports simultaneously via Promise.allSettled.
+ *
+ * Individual transport failures are logged but do not prevent the other
+ * transports from receiving the alert.
+ */
+export class CompositeAlertTransport implements AlertTransport {
+  private readonly transports: AlertTransport[];
+
+  constructor(transports: AlertTransport[]) {
+    if (transports.length === 0) {
+      throw new Error('CompositeAlertTransport requires at least one transport');
+    }
+    this.transports = transports;
+  }
+
+  async deliver(payload: AlertPayload): Promise<void> {
+    const results = await Promise.allSettled(
+      this.transports.map((t) => t.deliver(payload)),
+    );
+
+    const failures = results.filter((r): r is PromiseRejectedResult => r.status === 'rejected');
+    if (failures.length > 0) {
+      const messages = failures.map((f) => String(f.reason)).join('; ');
+      console.error(
+        `[CompositeAlertTransport] ${failures.length}/${results.length} transport(s) failed: ${messages}`,
+      );
+    }
+  }
+}


### PR DESCRIPTION
## Summary
closes #907 
closes #906 
closes #905 
closes #819 
Implements four backend issues in a single branch.

---

### #907 — Split alert rule evaluation from transport (monitoring-service)

**Problem:** Alert rule evaluation was coupled to notification transport (email/Slack).

**Changes:**
- New `alert-transport.ts`: `AlertTransport` interface + `EmailAlertTransport`, `SlackAlertTransport`, `CompositeAlertTransport`
- New `alert-rule.ts`: `AlertRuleEvaluator` takes any `AlertTransport` via constructor injection
- Unit tests use `MockAlertTransport` (no real email/Slack calls)
- Per-transport tests verify formatting against test doubles

---

### #906 — Circuit breaker for Horizon/Soroban RPC calls (indexer)

**Problem:** `services/indexer` had no circuit breaker around Horizon calls.

**Changes:**
- New `circuit-breaker.ts`: CLOSED/OPEN/HALF\_OPEN states, configurable thresholds, injectable clock
- `SorobanRPCClient.fetchEvents()` wraps every RPC call in the breaker
- `CircuitOpenError` caught gracefully — stream returns `[]` and continues
- Breaker metrics exposed on `/stats` endpoint
- Tests simulate sustained downtime and full recovery cycle

---

### #905 — Remove unused env vars from backend configs

**Removed from `graphql-api/.env.example`:** `RATE_LIMIT_WINDOW`, `RATE_LIMIT_MAX_REQUESTS`, `RATE_LIMIT_IP_MAX_REQUESTS`, `RATE_LIMIT_USER_MAX_REQUESTS`, `ACHIEVEMENT_CONTRACT_ID` (never read by `process.env`)

**Added `monitoring-service/.env.example`:** only the four vars the service actually reads

---

### #819 — Remove dead webhook exports

**Removed from `webhook.service.ts`:**
- `WebhookSubscription`, `WebhookDelivery` interfaces (internal, never imported)
- `dispatchEvent`, `attemptDelivery` functions and their constants (no caller anywhere)

`scripts/check-dead-exports.js` now exits 0. Export surface guard test updated.

---

## Testing
- monitoring-service: alert-rule + alert-transport suites **39/39 pass**
- indexer: circuit-breaker suite covers all states + outage simulation
- `check-dead-exports.js`: exits 0
- Pre-commit (ESLint, secrets scan): ✅ pass

Closes #907, Closes #906, Closes #905, Closes #819