### PR TITLE
fix: cache-invalidation bug and cross-cutting perf/quality issues (P1)

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,9 @@
+{
+  "semi": true,
+  "singleQuote": false,
+  "trailingComma": "all",
+  "printWidth": 80,
+  "tabWidth": 2,
+  "arrowParens": "always",
+  "endOfLine": "lf"
+}

--- a/backend/fraud_detection/pipeline.py
+++ b/backend/fraud_detection/pipeline.py
@@ -210,6 +210,15 @@ SPIKE_WINDOW_SECONDS = 600          # 10-minute rolling window
 SPIKE_MAX_CONTRIBUTIONS = 50        # > 50 contributions in 10 min → spike
 DUPLICATE_JACCARD_THRESHOLD = 0.8   # titles ≥ 80 % token overlap → duplicate
 
+# scan_duplicate_content() is O(N²) in the number of campaigns and does not
+# change between contributions to the *same* set of campaigns — running it on
+# every single queued contribution (as run_full_scan() used to) makes
+# per-contribution scoring cost scale with the full campaign-content scan.
+# Rate-limit it instead: the worker's per-contribution calls skip it unless
+# this many seconds have passed since the last run; POST /scan bypasses the
+# limit for an explicit, on-demand full scan.
+DUPLICATE_SCAN_MIN_INTERVAL_SECONDS = 30
+
 # Scoring job queue settings
 SCORING_QUEUE_MAXSIZE = 1000        # bounded queue; 503 if full
 
@@ -400,15 +409,35 @@ def scan_duplicate_content() -> list[Flag]:
     return flags
 
 
-def run_full_scan() -> list[Flag]:
-    """Execute all heuristics and append new flags to the moderation queue."""
+#: Unix timestamp of the last time scan_duplicate_content() actually ran.
+_last_duplicate_scan_at: float = 0.0
+
+
+def run_full_scan(*, force_duplicate_scan: bool = False) -> list[Flag]:
+    """
+    Execute all heuristics and append new flags to the moderation queue.
+
+    The O(N²) duplicate-content pass is rate-limited (see
+    DUPLICATE_SCAN_MIN_INTERVAL_SECONDS) so that calling this once per
+    contribution — as the async scoring worker does — doesn't re-run the full
+    campaign-content scan on every single donation. Pass
+    force_duplicate_scan=True (used by the manual POST /scan trigger) to
+    bypass the rate limit and always run it.
+    """
+    global _last_duplicate_scan_at
+
     scan_log = log.bind(operation="run_full_scan")
     scan_log.info("scan_started")
 
     new_flags: list[Flag] = []
     new_flags.extend(scan_wash_contributions())
     new_flags.extend(scan_contribution_spikes())
-    new_flags.extend(scan_duplicate_content())
+
+    now = time.time()
+    if force_duplicate_scan or (now - _last_duplicate_scan_at) >= DUPLICATE_SCAN_MIN_INTERVAL_SECONDS:
+        new_flags.extend(scan_duplicate_content())
+        _last_duplicate_scan_at = now
+
     for f in new_flags:
         _enqueue(f)
 
@@ -619,9 +648,13 @@ async def ingest_contribution(request: Request) -> JSONResponse:
 
 @app.post("/scan")
 def trigger_scan(background_tasks: BackgroundTasks) -> dict:
-    """Trigger a full fraud scan asynchronously (manual trigger)."""
+    """Trigger a full fraud scan asynchronously (manual trigger).
+
+    Bypasses the duplicate-content scan's rate limit since this is an
+    explicit, on-demand request for a full scan.
+    """
     log.info("scan_scheduled")
-    background_tasks.add_task(run_full_scan)
+    background_tasks.add_task(run_full_scan, force_duplicate_scan=True)
     return {"status": "scan_scheduled"}
 
 

--- a/backend/fraud_detection/tests_pipeline.py
+++ b/backend/fraud_detection/tests_pipeline.py
@@ -11,6 +11,7 @@ from pipeline import (
     CampaignRecord,
     ContributionEvent,
     ContributionPayload,
+    DUPLICATE_SCAN_MIN_INTERVAL_SECONDS,
     FlagReason,
     RefundEvent,
     ScoringJob,
@@ -40,6 +41,7 @@ def _clear():
     _REFUNDS.clear()
     _CAMPAIGN_RECORDS.clear()
     _QUEUE.clear()
+    pipeline_module._last_duplicate_scan_at = 0.0
     # Drain the scoring queue
     while not _scoring_queue.empty():
         try:
@@ -440,3 +442,68 @@ def test_scan_endpoint_still_works():
     r = client.post("/scan")
     assert r.status_code == 200
     assert r.json()["status"] == "scan_scheduled"
+
+
+# ── Duplicate-content scan rate limiting ──────────────────────────────────────
+#
+# scan_duplicate_content() is O(N^2) in the number of campaigns. Running it on
+# every single queued contribution would make per-contribution scoring cost
+# scale with the full campaign-content scan. run_full_scan() rate-limits it.
+
+def test_duplicate_scan_is_rate_limited_across_repeated_calls():
+    """
+    Calling run_full_scan() repeatedly in quick succession (as the scoring
+    worker does, once per contribution) must not re-run the O(N^2)
+    duplicate-content scan every time.
+    """
+    _clear()
+    _CAMPAIGN_RECORDS.append(CampaignRecord("DUP_A", "Fund the Open Commons", "desc"))
+    _CAMPAIGN_RECORDS.append(CampaignRecord("DUP_B", "Fund the Open Commons", "desc2"))
+
+    first = run_full_scan()
+    assert any(f.reason == FlagReason.DUPLICATE_CONTENT for f in first), (
+        "First scan after a cold start should run the duplicate-content pass"
+    )
+
+    before = pipeline_module._last_duplicate_scan_at
+    second = run_full_scan()
+    after = pipeline_module._last_duplicate_scan_at
+
+    assert after == before, (
+        "A second run_full_scan() call within the rate-limit window must "
+        "skip scan_duplicate_content() (timestamp should not advance)"
+    )
+    assert not any(f.reason == FlagReason.DUPLICATE_CONTENT for f in second), (
+        "Duplicate-content flags should not be re-emitted within the "
+        "rate-limit window"
+    )
+
+
+def test_duplicate_scan_runs_again_after_interval_elapses():
+    """Once DUPLICATE_SCAN_MIN_INTERVAL_SECONDS has passed, the duplicate scan runs again."""
+    _clear()
+    _CAMPAIGN_RECORDS.append(CampaignRecord("DUP_A", "Fund the Open Commons", "desc"))
+    _CAMPAIGN_RECORDS.append(CampaignRecord("DUP_B", "Fund the Open Commons", "desc2"))
+
+    run_full_scan()
+    # Simulate the interval having elapsed.
+    pipeline_module._last_duplicate_scan_at -= DUPLICATE_SCAN_MIN_INTERVAL_SECONDS + 1
+
+    flags = run_full_scan()
+    assert any(f.reason == FlagReason.DUPLICATE_CONTENT for f in flags)
+
+
+def test_scan_endpoint_forces_duplicate_scan_bypassing_rate_limit():
+    """POST /scan (explicit manual trigger) must bypass the rate limit."""
+    _clear()
+    _CAMPAIGN_RECORDS.append(CampaignRecord("DUP_A", "Fund the Open Commons", "desc"))
+    _CAMPAIGN_RECORDS.append(CampaignRecord("DUP_B", "Fund the Open Commons", "desc2"))
+
+    run_full_scan()  # primes _last_duplicate_scan_at
+    before = pipeline_module._last_duplicate_scan_at
+
+    flags = run_full_scan(force_duplicate_scan=True)
+    after = pipeline_module._last_duplicate_scan_at
+
+    assert after > before
+    assert any(f.reason == FlagReason.DUPLICATE_CONTENT for f in flags)

--- a/backend/fraud_detection/tests_scoring.py
+++ b/backend/fraud_detection/tests_scoring.py
@@ -18,6 +18,7 @@ from pipeline import (
     _CAMPAIGN_RECORDS, _CONTRIBUTIONS, _QUEUE, _REFUNDS,
     run_full_scan, scan_contribution_spikes, scan_duplicate_content, scan_wash_contributions,
 )
+import pipeline as pipeline_module
 
 
 # ---------------------------------------------------------------------------
@@ -29,6 +30,12 @@ def _clear():
     _REFUNDS.clear()
     _CAMPAIGN_RECORDS.clear()
     _QUEUE.clear()
+    # run_full_scan() rate-limits scan_duplicate_content() (see
+    # DUPLICATE_SCAN_MIN_INTERVAL_SECONDS in pipeline.py); reset it here so
+    # every test in this file gets a fresh duplicate-content scan regardless
+    # of what other tests (possibly in other files, sharing this process)
+    # ran run_full_scan() before it.
+    pipeline_module._last_duplicate_scan_at = 0.0
 
 
 @pytest.fixture(autouse=True)

--- a/backend/recommendations/service.py
+++ b/backend/recommendations/service.py
@@ -159,6 +159,13 @@ class TraceIDMiddleware(BaseHTTPMiddleware):
 _CACHE: dict[str, tuple[float, object]] = {}
 CACHE_TTL_SECONDS = 300  # 5 minutes
 
+# _CACHE is keyed by distinct (wallet, limit) pairs, so an unbounded number of
+# distinct wallets querying the service would grow it without limit. Bound it
+# with simple FIFO eviction (dicts preserve insertion order in Python 3.7+),
+# mirroring the bounded-queue approach fraud_detection uses for its own
+# in-memory growth risk.
+CACHE_MAX_SIZE = 1000
+
 
 def _cache_get(key: str) -> object | None:
     entry = _CACHE.get(key)
@@ -168,6 +175,9 @@ def _cache_get(key: str) -> object | None:
 
 
 def _cache_set(key: str, value: object) -> None:
+    if key not in _CACHE and len(_CACHE) >= CACHE_MAX_SIZE:
+        oldest_key = next(iter(_CACHE))
+        del _CACHE[oldest_key]
     _CACHE[key] = (time.time(), value)
 
 
@@ -228,20 +238,22 @@ def _personalised_score(c: Campaign, activity: IndexedActivity) -> float:
 def _recommend(wallet: Optional[str], limit: int) -> list[dict]:
     activity = _ACTIVITY.get(wallet) if wallet else None
 
+    # Compute each campaign's score exactly once per request and reuse it for
+    # sorting, filtering, and the output payload — previously
+    # _personalised_score()/_trending_score() was called three separate times
+    # per campaign (once for each of those three uses).
     if activity:
-        scored = sorted(
-            _CAMPAIGNS,
-            key=lambda c: _personalised_score(c, activity),
-            reverse=True,
-        )
-        # Exclude campaigns the wallet has already contributed to (score == 0).
-        # Use activity.wallet as the recommendation key for auditability.
-        rec_wallet = activity.wallet
-        scored = [c for c in scored if _personalised_score(c, activity) > 0.0]
+        # Log the resolved activity record's wallet (not just the raw query
+        # param) for auditability — it's the key that actually drove scoring.
+        log.debug("personalising_recommendations", wallet=activity.wallet)
+        scores = {c.id: _personalised_score(c, activity) for c in _CAMPAIGNS}
     else:
-        # Cold-start: return trending
-        rec_wallet = wallet
-        scored = sorted(_CAMPAIGNS, key=_trending_score, reverse=True)
+        scores = {c.id: _trending_score(c) for c in _CAMPAIGNS}
+
+    scored = sorted(_CAMPAIGNS, key=lambda c: scores[c.id], reverse=True)
+    if activity:
+        # Exclude campaigns the wallet has already contributed to (score == 0).
+        scored = [c for c in scored if scores[c.id] > 0.0]
 
     return [
         {
@@ -250,9 +262,7 @@ def _recommend(wallet: Optional[str], limit: int) -> list[dict]:
             "category": c.category,
             "total_raised": c.total_raised,
             "contributor_count": c.contributor_count,
-            "score": round(
-                _personalised_score(c, activity) if activity else _trending_score(c), 4
-            ),
+            "score": round(scores[c.id], 4),
         }
         for c in scored[:limit]
     ]

--- a/backend/recommendations/tests_service.py
+++ b/backend/recommendations/tests_service.py
@@ -7,10 +7,14 @@ from service import (
     Campaign,
     IndexedActivity,
     _ACTIVITY,
+    _CACHE,
     _CAMPAIGNS,
+    _cache_set,
     _recommend,
     app,
+    CACHE_MAX_SIZE,
 )
+import service as svc
 
 client = TestClient(app)
 
@@ -142,3 +146,52 @@ def test_limit_too_large_rejected():
 def test_limit_zero_rejected():
     r = client.get("/recommendations?limit=0")
     assert r.status_code == 422
+
+
+# ── Scoring memoization ────────────────────────────────────────────────────────
+
+def test_personalised_score_computed_once_per_campaign_per_request(monkeypatch):
+    """
+    _personalised_score() must be called at most once per campaign per
+    _recommend() call — previously it was called three times per campaign
+    (sort key, filter, output) with no memoization.
+    """
+    wallet = "GTESTMEMO"
+    _ACTIVITY[wallet] = IndexedActivity(
+        wallet=wallet,
+        contributed_campaign_ids=[],
+        preferred_categories=["tech"],
+    )
+    calls: list[str] = []
+    original = svc._personalised_score
+
+    def counting(c, activity):
+        calls.append(c.id)
+        return original(c, activity)
+
+    monkeypatch.setattr(svc, "_personalised_score", counting)
+    try:
+        svc._recommend(wallet, len(_CAMPAIGNS))
+    finally:
+        del _ACTIVITY[wallet]
+
+    assert sorted(calls) == sorted(c.id for c in _CAMPAIGNS), (
+        f"Expected exactly one _personalised_score() call per campaign, got: {calls}"
+    )
+
+
+# ── Cache size bound ────────────────────────────────────────────────────────────
+
+def test_cache_is_bounded_and_evicts_oldest_entry():
+    """_CACHE must not grow without bound as distinct (wallet, limit) keys accumulate."""
+    _CACHE.clear()
+    try:
+        for i in range(CACHE_MAX_SIZE + 10):
+            _cache_set(f"wallet-{i}:5", {"dummy": i})
+
+        assert len(_CACHE) <= CACHE_MAX_SIZE
+        # The earliest keys should have been evicted first (FIFO).
+        assert "wallet-0:5" not in _CACHE
+        assert f"wallet-{CACHE_MAX_SIZE + 9}:5" in _CACHE
+    finally:
+        _CACHE.clear()

--- a/packages/shared-utils/src/index.ts
+++ b/packages/shared-utils/src/index.ts
@@ -2,4 +2,4 @@ export * from "./formatting";
 export * from "./campaign";
 export * from "./trace";
 export * from "./timestamps";
-
+export * from "./mappers";

--- a/packages/types/src/__tests__/validation.test.ts
+++ b/packages/types/src/__tests__/validation.test.ts
@@ -11,6 +11,8 @@ import {
   validateMinContribution,
   validateMaxContribution,
   validateFeeBps,
+  validateCampaignInput,
+  validateDonationAmount,
   sanitizeTitle,
   sanitizeDescription,
 } from "../validation";
@@ -18,27 +20,31 @@ import {
 describe("Validation Schemas & Utilities", () => {
   describe("isValidContractId & validateContractId", () => {
     it("should accept valid Stellar contract IDs", () => {
-      const validId = "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA2";
+      const validId =
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA2";
       expect(isValidContractId(validId)).toBe(true);
       expect(validateContractId(validId)).toBeNull();
     });
 
     it("should reject contract IDs with incorrect length", () => {
       const shortId = "CAAAAAAAA";
-      const longId = "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA22";
+      const longId =
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA22";
       expect(isValidContractId(shortId)).toBe(false);
       expect(isValidContractId(longId)).toBe(false);
       expect(validateContractId(shortId)).toBe("Contract ID is invalid.");
     });
 
     it("should reject contract IDs that do not start with C", () => {
-      const wrongStart = "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA2";
+      const wrongStart =
+        "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA2";
       expect(isValidContractId(wrongStart)).toBe(false);
       expect(validateContractId(wrongStart)).toBe("Contract ID is invalid.");
     });
 
     it("should reject invalid base32 characters", () => {
-      const invalidChars = "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA1"; // '1' is not base32
+      const invalidChars =
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA1"; // '1' is not base32
       expect(isValidContractId(invalidChars)).toBe(false);
       expect(validateContractId(invalidChars)).toBe("Contract ID is invalid.");
     });
@@ -51,7 +57,9 @@ describe("Validation Schemas & Utilities", () => {
 
   describe("stripHtmlTags", () => {
     it("should strip HTML tags correctly", () => {
-      expect(stripHtmlTags("<p>Hello <strong>World</strong></p>")).toBe("Hello World");
+      expect(stripHtmlTags("<p>Hello <strong>World</strong></p>")).toBe(
+        "Hello World",
+      );
       expect(stripHtmlTags("Plain Text")).toBe("Plain Text");
     });
   });
@@ -68,7 +76,9 @@ describe("Validation Schemas & Utilities", () => {
 
     it("should reject titles exceeding 100 characters", () => {
       const longTitle = "a".repeat(101);
-      expect(validateTitle(longTitle)).toBe("Title must be 100 characters or less.");
+      expect(validateTitle(longTitle)).toBe(
+        "Title must be 100 characters or less.",
+      );
     });
 
     it("should enforce boundaries correctly", () => {
@@ -83,7 +93,9 @@ describe("Validation Schemas & Utilities", () => {
 
   describe("validateDescription & sanitizeDescription", () => {
     it("should accept valid descriptions", () => {
-      expect(validateDescription("This is a valid campaign description.")).toBeNull();
+      expect(
+        validateDescription("This is a valid campaign description."),
+      ).toBeNull();
     });
 
     it("should reject empty descriptions", () => {
@@ -93,7 +105,9 @@ describe("Validation Schemas & Utilities", () => {
 
     it("should reject descriptions exceeding 1000 characters", () => {
       const longDesc = "a".repeat(1001);
-      expect(validateDescription(longDesc)).toBe("Description must be 1000 characters or less.");
+      expect(validateDescription(longDesc)).toBe(
+        "Description must be 1000 characters or less.",
+      );
     });
 
     it("should enforce boundaries correctly", () => {
@@ -128,7 +142,9 @@ describe("Validation Schemas & Utilities", () => {
       // Goal input is multiplied by 10,000,000 (stroops)
       // Maximum goal in XLM is MAX_GOAL / 10,000,000
       const hugeGoal = "9223372036854775807";
-      expect(validateGoal(hugeGoal)).toBe("Goal exceeds maximum allowed value.");
+      expect(validateGoal(hugeGoal)).toBe(
+        "Goal exceeds maximum allowed value.",
+      );
     });
   });
 
@@ -144,7 +160,9 @@ describe("Validation Schemas & Utilities", () => {
     });
 
     it("should reject non-https URLs", () => {
-      expect(validateVideoUrl("http://example.com/video.mp4")).toBe("Enter a valid URL starting with https://");
+      expect(validateVideoUrl("http://example.com/video.mp4")).toBe(
+        "Enter a valid URL starting with https://",
+      );
     });
 
     it("should reject malformed URLs", () => {
@@ -166,16 +184,22 @@ describe("Validation Schemas & Utilities", () => {
     it("should reject deadlines in the past or too close in the future", () => {
       const past = new Date();
       past.setDate(past.getDate() - 1);
-      expect(validateDeadline(past.toISOString())).toBe("Deadline must be at least 1 hour in the future.");
+      expect(validateDeadline(past.toISOString())).toBe(
+        "Deadline must be at least 1 hour in the future.",
+      );
 
       const justNow = new Date();
-      expect(validateDeadline(justNow.toISOString())).toBe("Deadline must be at least 1 hour in the future.");
+      expect(validateDeadline(justNow.toISOString())).toBe(
+        "Deadline must be at least 1 hour in the future.",
+      );
     });
 
     it("should reject deadlines more than 1 year in the future", () => {
       const farFuture = new Date();
       farFuture.setFullYear(farFuture.getFullYear() + 2);
-      expect(validateDeadline(farFuture.toISOString())).toBe("Deadline cannot be more than 1 year in the future.");
+      expect(validateDeadline(farFuture.toISOString())).toBe(
+        "Deadline cannot be more than 1 year in the future.",
+      );
     });
   });
 
@@ -186,18 +210,30 @@ describe("Validation Schemas & Utilities", () => {
     });
 
     it("should reject empty minimum contributions", () => {
-      expect(validateMinContribution("", "100")).toBe("Minimum contribution is required.");
+      expect(validateMinContribution("", "100")).toBe(
+        "Minimum contribution is required.",
+      );
     });
 
     it("should reject minimum contributions less than 1", () => {
-      expect(validateMinContribution("0.5", "100")).toBe("Minimum contribution must be at least 1.");
-      expect(validateMinContribution("0", "100")).toBe("Minimum contribution must be at least 1.");
-      expect(validateMinContribution("-5", "100")).toBe("Minimum contribution must be at least 1.");
-      expect(validateMinContribution("abc", "100")).toBe("Minimum contribution must be at least 1.");
+      expect(validateMinContribution("0.5", "100")).toBe(
+        "Minimum contribution must be at least 1.",
+      );
+      expect(validateMinContribution("0", "100")).toBe(
+        "Minimum contribution must be at least 1.",
+      );
+      expect(validateMinContribution("-5", "100")).toBe(
+        "Minimum contribution must be at least 1.",
+      );
+      expect(validateMinContribution("abc", "100")).toBe(
+        "Minimum contribution must be at least 1.",
+      );
     });
 
     it("should reject minimum contributions exceeding the goal", () => {
-      expect(validateMinContribution("150", "100")).toBe("Minimum contribution cannot exceed goal.");
+      expect(validateMinContribution("150", "100")).toBe(
+        "Minimum contribution cannot exceed goal.",
+      );
     });
   });
 
@@ -212,12 +248,18 @@ describe("Validation Schemas & Utilities", () => {
     });
 
     it("should reject negative maximum contributions", () => {
-      expect(validateMaxContribution("-5", "10")).toBe("Maximum contribution must be a non-negative number.");
-      expect(validateMaxContribution("abc", "10")).toBe("Maximum contribution must be a non-negative number.");
+      expect(validateMaxContribution("-5", "10")).toBe(
+        "Maximum contribution must be a non-negative number.",
+      );
+      expect(validateMaxContribution("abc", "10")).toBe(
+        "Maximum contribution must be a non-negative number.",
+      );
     });
 
     it("should reject maximum contributions less than minimum contribution", () => {
-      expect(validateMaxContribution("5", "10")).toBe("Maximum contribution cannot be less than minimum contribution.");
+      expect(validateMaxContribution("5", "10")).toBe(
+        "Maximum contribution cannot be less than minimum contribution.",
+      );
     });
   });
 
@@ -233,9 +275,79 @@ describe("Validation Schemas & Utilities", () => {
     });
 
     it("should reject out-of-range basis points", () => {
-      expect(validateFeeBps("-1")).toBe("Fee must be between 0 and 10000 basis points.");
-      expect(validateFeeBps("10001")).toBe("Fee must be between 0 and 10000 basis points.");
-      expect(validateFeeBps("abc")).toBe("Fee must be between 0 and 10000 basis points.");
+      expect(validateFeeBps("-1")).toBe(
+        "Fee must be between 0 and 10000 basis points.",
+      );
+      expect(validateFeeBps("10001")).toBe(
+        "Fee must be between 0 and 10000 basis points.",
+      );
+      expect(validateFeeBps("abc")).toBe(
+        "Fee must be between 0 and 10000 basis points.",
+      );
+    });
+  });
+
+  describe("validateCampaignInput", () => {
+    const validInput = {
+      title: "A Great Cause",
+      description: "A description of the cause worth funding.",
+      goal: "1000",
+      deadline: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString(),
+      minContribution: "10",
+    };
+
+    it("should return an empty object for fully valid input", () => {
+      expect(validateCampaignInput(validInput)).toEqual({});
+    });
+
+    it("should collect one error per invalid field, keyed by field name", () => {
+      const errors = validateCampaignInput({
+        title: "",
+        description: "",
+        goal: "",
+        deadline: "",
+        minContribution: "",
+      });
+      expect(Object.keys(errors).sort()).toEqual(
+        ["deadline", "description", "goal", "minContribution", "title"].sort(),
+      );
+    });
+
+    it("should not report errors for fields that are individually valid", () => {
+      const errors = validateCampaignInput({ ...validInput, title: "" });
+      expect(errors).toEqual({ title: "Title is required." });
+    });
+  });
+
+  describe("validateDonationAmount", () => {
+    it("should accept an amount at or above the minimum", () => {
+      expect(validateDonationAmount("1")).toBeNull();
+      expect(validateDonationAmount("100")).toBeNull();
+    });
+
+    it("should reject an empty amount", () => {
+      expect(validateDonationAmount("")).toBe("Donation amount is required.");
+    });
+
+    it("should reject a non-numeric amount", () => {
+      expect(validateDonationAmount("abc")).toBe(
+        "Donation amount must be a positive number.",
+      );
+    });
+
+    it("should reject zero or negative amounts", () => {
+      expect(validateDonationAmount("0")).toBe(
+        "Donation amount must be a positive number.",
+      );
+      expect(validateDonationAmount("-5")).toBe(
+        "Donation amount must be a positive number.",
+      );
+    });
+
+    it("should reject an amount below the minimum donation", () => {
+      expect(validateDonationAmount("0.5")).toBe(
+        "Donation amount must be at least 1 XLM.",
+      );
     });
   });
 });

--- a/packages/types/src/validation.ts
+++ b/packages/types/src/validation.ts
@@ -7,6 +7,9 @@ const MAX_DESCRIPTION_LENGTH = 1000;
 const MAX_GOAL = BigInt(9223372036854775807) / BigInt(10); // i128::MAX / 10
 const MIN_DEADLINE_HOURS = 1;
 const MAX_DEADLINE_YEARS = 1;
+// Must stay in sync with DONATION_MIN_XLM in index.ts (kept local to avoid a
+// circular import, matching this file's existing self-contained constants).
+const MIN_DONATION_XLM = 1;
 
 /**
  * Validate that a string is a valid Stellar contract ID.
@@ -165,7 +168,11 @@ export function validateMaxContribution(
   maxContribution: string,
   minContribution: string,
 ): string | null {
-  if (!maxContribution || maxContribution.trim() === "" || maxContribution === "0") {
+  if (
+    !maxContribution ||
+    maxContribution.trim() === "" ||
+    maxContribution === "0"
+  ) {
     return null; // 0 = no limit, optional field
   }
   const num = Number(maxContribution);
@@ -190,6 +197,66 @@ export function validateFeeBps(feeBps: string): string | null {
   const num = Number(feeBps);
   if (isNaN(num) || num < 0 || num > 10000) {
     return "Fee must be between 0 and 10000 basis points.";
+  }
+  return null;
+}
+
+/** Shape accepted by validateCampaignInput — all fields as raw strings. */
+export interface CampaignInputToValidate {
+  title: string;
+  description: string;
+  goal: string;
+  deadline: string;
+  minContribution: string;
+}
+
+/**
+ * Validate a full campaign-creation input in one call.
+ *
+ * Runs the individual field validators (title, description, goal, deadline,
+ * minContribution) and collects their errors into a single field-name →
+ * message map. An empty object means the input is valid.
+ */
+export function validateCampaignInput(
+  input: CampaignInputToValidate,
+): Record<string, string> {
+  const errors: Record<string, string> = {};
+
+  const titleError = validateTitle(input.title);
+  if (titleError) errors.title = titleError;
+
+  const descriptionError = validateDescription(input.description);
+  if (descriptionError) errors.description = descriptionError;
+
+  const goalError = validateGoal(input.goal);
+  if (goalError) errors.goal = goalError;
+
+  const deadlineError = validateDeadline(input.deadline);
+  if (deadlineError) errors.deadline = deadlineError;
+
+  const minContributionError = validateMinContribution(
+    input.minContribution,
+    input.goal,
+  );
+  if (minContributionError) errors.minContribution = minContributionError;
+
+  return errors;
+}
+
+/**
+ * Validate a donation/contribution amount, expressed in whole XLM.
+ * @returns Error message if invalid, null if valid
+ */
+export function validateDonationAmount(amountXlm: string): string | null {
+  if (!amountXlm || amountXlm.trim() === "") {
+    return "Donation amount is required.";
+  }
+  const num = Number(amountXlm);
+  if (isNaN(num) || num <= 0) {
+    return "Donation amount must be a positive number.";
+  }
+  if (num < MIN_DONATION_XLM) {
+    return `Donation amount must be at least ${MIN_DONATION_XLM} XLM.`;
   }
   return null;
 }

--- a/services/graphql-api/src/resolvers.cache-invalidation.test.ts
+++ b/services/graphql-api/src/resolvers.cache-invalidation.test.ts
@@ -1,0 +1,172 @@
+import { describe, it, expect, vi } from "vitest";
+import { resolvers } from "./resolvers.js";
+import { CacheService } from "./services/cache.js";
+import type { Context } from "./types.js";
+
+/**
+ * Regression test for the del() vs delPattern() cache-invalidation bug.
+ *
+ * Real Redis DEL does not glob-match wildcard keys — `del("campaigns:*")`
+ * is a no-op against a key literally named "campaigns:*". This fake mirrors
+ * that exact semantic (unlike a plain vi.fn() mock, which can't catch the
+ * bug because it doesn't care what string was passed to del()) so the test
+ * only passes if the resolver actually calls delPattern() for wildcard keys.
+ */
+class FakeRedis {
+  private store = new Map<string, string>();
+
+  async get(key: string): Promise<string | null> {
+    return this.store.has(key) ? this.store.get(key)! : null;
+  }
+
+  async setEx(key: string, _ttl: number, value: string): Promise<void> {
+    this.store.set(key, value);
+  }
+
+  async del(key: string | string[]): Promise<number> {
+    const keys = Array.isArray(key) ? key : [key];
+    let count = 0;
+    for (const k of keys) {
+      if (this.store.delete(k)) count++;
+    }
+    return count;
+  }
+
+  async keys(pattern: string): Promise<string[]> {
+    const escaped = pattern.replace(/[.+^${}()|[\]\\]/g, "\\$&");
+    const regex = new RegExp(`^${escaped.replace(/\*/g, ".*")}$`);
+    return Array.from(this.store.keys()).filter((k) => regex.test(k));
+  }
+
+  has(key: string): boolean {
+    return this.store.has(key);
+  }
+}
+
+const mockLog = {
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  debug: vi.fn(),
+  fatal: vi.fn(),
+  trace: vi.fn(),
+  child: vi.fn().mockReturnThis(),
+} as any;
+
+function buildContext(
+  redis: FakeRedis,
+  overrides: Partial<Context> = {},
+): Context {
+  return {
+    cache: new CacheService(redis as any),
+    contractService: {
+      createCampaign: vi.fn(),
+      updateCampaign: vi.fn(),
+      recordContribution: vi.fn(),
+      getCampaign: vi.fn().mockResolvedValue(null),
+    },
+    dataLoader: {} as any,
+    pubsub: { publish: vi.fn().mockResolvedValue(undefined) } as any,
+    authService: {} as any,
+    user: { address: "GCREATOR", isAuthenticated: true },
+    redis: redis as any,
+    traceId: "fmc-00000000-0000000000000000",
+    log: mockLog,
+    ...overrides,
+  } as Context;
+}
+
+describe("cache-invalidation regression (del() vs delPattern())", () => {
+  it("actually evicts cached campaign lists and trending after createCampaign", async () => {
+    const redis = new FakeRedis();
+    const context = buildContext(redis);
+
+    // Seed the exact list/trending cache entries the Query resolvers would
+    // have written on a prior read.
+    await context.cache.set("campaigns:{}", [{ id: "old" }], 600);
+    await context.cache.set("trending:10", [{ id: "old" }], 1800);
+
+    (context.contractService.createCampaign as any).mockResolvedValue({
+      id: "new",
+    });
+
+    await (resolvers.Mutation as any).createCampaign(
+      null,
+      {
+        input: {
+          title: "New Campaign",
+          description: "A great cause worth funding.",
+          goal: 10000n,
+          deadline: new Date(
+            Date.now() + 30 * 24 * 60 * 60 * 1000,
+          ).toISOString(),
+          category: "Technology",
+          minContribution: 10n,
+        },
+      },
+      context,
+    );
+
+    expect(redis.has("campaigns:{}")).toBe(false);
+    expect(redis.has("trending:10")).toBe(false);
+  });
+
+  it("actually evicts cached campaign lists and trending after updateCampaign", async () => {
+    const redis = new FakeRedis();
+    const context = buildContext(redis);
+
+    await context.cache.set("campaign:camp_1", { id: "camp_1" }, 300);
+    await context.cache.set("campaigns:{}", [{ id: "camp_1" }], 600);
+    await context.cache.set("trending:10", [{ id: "camp_1" }], 1800);
+
+    (context.contractService.updateCampaign as any).mockResolvedValue({
+      id: "camp_1",
+    });
+
+    await (resolvers.Mutation as any).updateCampaign(
+      null,
+      { id: "camp_1", input: { title: "Updated" } },
+      context,
+    );
+
+    expect(redis.has("campaign:camp_1")).toBe(false);
+    expect(redis.has("campaigns:{}")).toBe(false);
+    expect(redis.has("trending:10")).toBe(false);
+  });
+
+  it("actually evicts cached campaign lists and trending after recordContribution", async () => {
+    const redis = new FakeRedis();
+    const context = buildContext(redis, {
+      user: { address: "GCONTRIBUTOR", isAuthenticated: true },
+    });
+
+    await context.cache.set("campaign:camp_1", { id: "camp_1" }, 300);
+    await context.cache.set("platform:stats", { totalCampaigns: 1 }, 1800);
+    await context.cache.set("user:GCONTRIBUTOR", { address: "G" }, 600);
+    await context.cache.set("campaigns:{}", [{ id: "camp_1" }], 600);
+    await context.cache.set("trending:10", [{ id: "camp_1" }], 1800);
+
+    const input = {
+      campaignId: "camp_1",
+      contributor: "GCONTRIBUTOR",
+      amount: 20000000n, // 2 XLM in stroops
+      transactionHash: "hash",
+    };
+    (context.contractService.recordContribution as any).mockResolvedValue({
+      id: "contrib_1",
+      ...input,
+    });
+
+    await (resolvers.Mutation as any).recordContribution(
+      null,
+      { input },
+      context,
+    );
+
+    expect(redis.has("campaign:camp_1")).toBe(false);
+    expect(redis.has("platform:stats")).toBe(false);
+    expect(redis.has("user:GCONTRIBUTOR")).toBe(false);
+    expect(redis.has("campaigns:{}")).toBe(false);
+    expect(redis.has("trending:10")).toBe(false);
+  });
+});

--- a/services/graphql-api/src/resolvers.test.ts
+++ b/services/graphql-api/src/resolvers.test.ts
@@ -32,6 +32,7 @@ function createMockContext(overrides: Partial<Context> = {}): Context {
       get: vi.fn().mockResolvedValue(null),
       set: vi.fn().mockResolvedValue(undefined),
       del: vi.fn().mockResolvedValue(undefined),
+      delPattern: vi.fn().mockResolvedValue(undefined),
     },
     contractService: {
       getCampaign: vi.fn(),
@@ -125,7 +126,7 @@ describe("resolvers", () => {
 
       await expect(
         (resolvers.Query as any).campaign(null, { id: "missing" }, context),
-      ).rejects.toThrow(GraphQLError);
+      ).rejects.toMatchObject({ extensions: { code: "NOT_FOUND" } });
       expect(context.cache.set).not.toHaveBeenCalled();
     });
   });
@@ -380,7 +381,7 @@ describe("resolvers", () => {
           { id: "missing" },
           context,
         ),
-      ).rejects.toThrow(GraphQLError);
+      ).rejects.toMatchObject({ extensions: { code: "NOT_FOUND" } });
     });
   });
 
@@ -480,7 +481,7 @@ describe("resolvers", () => {
 
       await expect(
         (resolvers.Query as any).user(null, { address: "unknown" }, context),
-      ).rejects.toThrow(GraphQLError);
+      ).rejects.toMatchObject({ extensions: { code: "NOT_FOUND" } });
     });
   });
 
@@ -724,21 +725,28 @@ describe("resolvers", () => {
         campaign,
       );
 
+      const validInput = {
+        title: "New Campaign",
+        description: "A great cause worth funding.",
+        goal: 10000n,
+        deadline: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString(),
+        category: "Technology",
+        minContribution: 10n,
+      };
+
       const result = await (resolvers.Mutation as any).createCampaign(
         null,
-        { input: { title: "New" } },
+        { input: validInput },
         context,
       );
 
       expect(result).toBe(campaign);
       expect(context.contractService.createCampaign).toHaveBeenCalledWith(
         context.user,
-        {
-          title: "New",
-        },
+        validInput,
       );
-      expect(context.cache.del).toHaveBeenCalledWith("campaigns:*");
-      expect(context.cache.del).toHaveBeenCalledWith("trending:*");
+      expect(context.cache.delPattern).toHaveBeenCalledWith("campaigns:*");
+      expect(context.cache.delPattern).toHaveBeenCalledWith("trending:*");
     });
   });
 
@@ -773,7 +781,8 @@ describe("resolvers", () => {
 
       expect(result).toBe(campaign);
       expect(context.cache.del).toHaveBeenCalledWith("campaign:camp_1");
-      expect(context.cache.del).toHaveBeenCalledWith("campaigns:*");
+      expect(context.cache.delPattern).toHaveBeenCalledWith("campaigns:*");
+      expect(context.cache.delPattern).toHaveBeenCalledWith("trending:*");
       expect(context.pubsub.publish).toHaveBeenCalledWith(
         "campaign_updated:camp_1",
         campaign,
@@ -802,7 +811,7 @@ describe("resolvers", () => {
       const input = {
         campaignId: "camp_1",
         contributor: "GCONTRIBUTOR",
-        amount: 1000n,
+        amount: 20000000n, // 2 XLM in stroops
         transactionHash: "hash",
       };
       const contribution = { id: "contrib_1", ...input };
@@ -827,6 +836,8 @@ describe("resolvers", () => {
       expect(context.cache.del).toHaveBeenCalledWith("campaign:camp_1");
       expect(context.cache.del).toHaveBeenCalledWith("platform:stats");
       expect(context.cache.del).toHaveBeenCalledWith("user:GCONTRIBUTOR");
+      expect(context.cache.delPattern).toHaveBeenCalledWith("campaigns:*");
+      expect(context.cache.delPattern).toHaveBeenCalledWith("trending:*");
       expect(context.pubsub.publish).toHaveBeenCalledWith(
         "contribution:camp_1",
         contribution,
@@ -844,7 +855,7 @@ describe("resolvers", () => {
       const input = {
         campaignId: "camp_missing",
         contributor: "GCONTRIBUTOR",
-        amount: 1000n,
+        amount: 20000000n, // 2 XLM in stroops
         transactionHash: "hash",
       };
       const contribution = { id: "contrib_1", ...input };

--- a/services/graphql-api/src/resolvers.ts
+++ b/services/graphql-api/src/resolvers.ts
@@ -104,7 +104,9 @@ export const resolvers: IResolvers<any, Context> = {
 
       const campaign = await context.contractService.getCampaign(id);
       if (!campaign) {
-        throw new GraphQLError(`Campaign not found: ${id}`);
+        throw new GraphQLError(`Campaign not found: ${id}`, {
+          extensions: { code: "NOT_FOUND" },
+        });
       }
 
       await context.cache.set(cacheKey, campaign, 300); // Cache for 5 minutes
@@ -219,7 +221,9 @@ export const resolvers: IResolvers<any, Context> = {
       const campaign = await context.dataLoader.campaigns.load(id);
 
       if (!campaign) {
-        throw new GraphQLError(`Campaign not found: ${id}`);
+        throw new GraphQLError(`Campaign not found: ${id}`, {
+          extensions: { code: "NOT_FOUND" },
+        });
       }
 
       const [contributors, updates, milestones] = await Promise.all([
@@ -264,7 +268,9 @@ export const resolvers: IResolvers<any, Context> = {
 
       const user = await context.contractService.getUser(address);
       if (!user) {
-        throw new GraphQLError(`User not found: ${address}`);
+        throw new GraphQLError(`User not found: ${address}`, {
+          extensions: { code: "NOT_FOUND" },
+        });
       }
 
       await context.cache.set(cacheKey, user, 600); // Cache for 10 minutes
@@ -433,8 +439,8 @@ export const resolvers: IResolvers<any, Context> = {
       );
 
       // Invalidate cache
-      await context.cache.del("campaigns:*");
-      await context.cache.del("trending:*");
+      await context.cache.delPattern("campaigns:*");
+      await context.cache.delPattern("trending:*");
 
       return campaign;
     },
@@ -452,7 +458,8 @@ export const resolvers: IResolvers<any, Context> = {
 
       // Invalidate cache
       await context.cache.del(`campaign:${id}`);
-      await context.cache.del("campaigns:*");
+      await context.cache.delPattern("campaigns:*");
+      await context.cache.delPattern("trending:*");
 
       // Publish update
       await context.pubsub.publish(`campaign_updated:${id}`, campaign);
@@ -517,6 +524,11 @@ export const resolvers: IResolvers<any, Context> = {
       await context.cache.del(`campaign:${input.campaignId}`);
       await context.cache.del("platform:stats");
       await context.cache.del(`user:${input.contributor}`);
+      // A new contribution changes each campaign's `raised` total, which is
+      // embedded in cached list/trending payloads — those must be busted too
+      // or campaign lists show stale progress after every contribution.
+      await context.cache.delPattern("campaigns:*");
+      await context.cache.delPattern("trending:*");
 
       // Publish events
       await context.pubsub.publish(

--- a/services/graphql-api/src/server.integration.test.ts
+++ b/services/graphql-api/src/server.integration.test.ts
@@ -29,6 +29,7 @@ function createMockContext(overrides: Partial<Context> = {}): Context {
       get: vi.fn().mockResolvedValue(null),
       set: vi.fn().mockResolvedValue(undefined),
       del: vi.fn().mockResolvedValue(undefined),
+      delPattern: vi.fn().mockResolvedValue(undefined),
     },
     contractService: {
       getCampaign: vi.fn(),
@@ -78,8 +79,16 @@ const sampleCampaign = (overrides: Record<string, any> = {}) => ({
   ...overrides,
 });
 
-async function execute(server: ApolloServer<Context>, query: string, variables: Record<string, any>, context: Context) {
-  const response = await server.executeOperation({ query, variables }, { contextValue: context });
+async function execute(
+  server: ApolloServer<Context>,
+  query: string,
+  variables: Record<string, any>,
+  context: Context,
+) {
+  const response = await server.executeOperation(
+    { query, variables },
+    { contextValue: context },
+  );
   if (response.body.kind !== "single") {
     throw new Error("Expected a single GraphQL response");
   }
@@ -116,7 +125,7 @@ describe("GraphQL API integration", () => {
         }
       }`,
       { id: "camp_1" },
-      context
+      context,
     );
 
     expect(result.errors).toBeUndefined();
@@ -138,11 +147,13 @@ describe("GraphQL API integration", () => {
       server,
       `query GetCampaign($id: ID!) { campaign(id: $id) { id } }`,
       { id: "missing" },
-      context
+      context,
     );
 
     expect(result.data?.campaign).toBeNull();
-    expect(result.errors?.[0]?.message).toContain("Campaign not found: missing");
+    expect(result.errors?.[0]?.message).toContain(
+      "Campaign not found: missing",
+    );
   });
 
   it("rejects an invalid GraphQL query with a validation error rather than crashing the server", async () => {
@@ -152,7 +163,7 @@ describe("GraphQL API integration", () => {
       server,
       `query { campaign(id: "camp_1") { fieldThatDoesNotExist } }`,
       {},
-      context
+      context,
     );
 
     expect(result.data).toBeUndefined();
@@ -161,7 +172,10 @@ describe("GraphQL API integration", () => {
 
   it("runs a full paginated campaigns query end-to-end", async () => {
     const context = createMockContext();
-    const campaigns = [sampleCampaign({ id: "a" }), sampleCampaign({ id: "b" })];
+    const campaigns = [
+      sampleCampaign({ id: "a" }),
+      sampleCampaign({ id: "b" }),
+    ];
     (context.contractService.getCampaigns as any).mockResolvedValue(campaigns);
     (context.contractService.getCampaignCount as any).mockResolvedValue(2);
 
@@ -175,7 +189,7 @@ describe("GraphQL API integration", () => {
         }
       }`,
       {},
-      context
+      context,
     );
 
     expect(result.errors).toBeUndefined();
@@ -204,7 +218,7 @@ describe("GraphQL API integration", () => {
           minContribution: "10",
         },
       },
-      context
+      context,
     );
 
     // createCampaign is non-null in the schema, so the thrown error nullifies
@@ -231,17 +245,22 @@ describe("GraphQL API integration", () => {
           title: "New Campaign",
           description: "desc",
           goal: "1000",
-          deadline: new Date().toISOString(),
+          deadline: new Date(
+            Date.now() + 30 * 24 * 60 * 60 * 1000,
+          ).toISOString(),
           category: "Health",
           minContribution: "10",
         },
       },
-      context
+      context,
     );
 
     expect(result.errors).toBeUndefined();
-    expect(result.data?.createCampaign).toMatchObject({ id: "new_1", raised: "0" });
-    expect(context.cache.del).toHaveBeenCalledWith("campaigns:*");
+    expect(result.data?.createCampaign).toMatchObject({
+      id: "new_1",
+      raised: "0",
+    });
+    expect(context.cache.delPattern).toHaveBeenCalledWith("campaigns:*");
   });
 
   it("runs a full authenticate mutation end-to-end for a valid signature", async () => {
@@ -265,8 +284,12 @@ describe("GraphQL API integration", () => {
           user { address }
         }
       }`,
-      { signature: "a-long-enough-signature", message: "msg", address: "GADDR" },
-      context
+      {
+        signature: "a-long-enough-signature",
+        message: "msg",
+        address: "GADDR",
+      },
+      context,
     );
 
     expect(result.errors).toBeUndefined();

--- a/services/graphql-api/src/services/contract.ts
+++ b/services/graphql-api/src/services/contract.ts
@@ -10,7 +10,9 @@ import {
 } from "@stellar/stellar-sdk";
 import type { CampaignStatus } from "../types.js";
 import type {
+  AuthenticatedUser,
   Campaign,
+  CampaignFilter,
   Contribution,
   User,
   GetCampaignsParams,
@@ -21,7 +23,32 @@ import type {
   RawCampaignInfo,
   RawCampaignStats,
 } from "../types.js";
-import { nowUtcIso } from "@fund-my-cause/shared-utils";
+import { mapCampaignStatus, nowUtcIso } from "@fund-my-cause/shared-utils";
+import { logger } from "../logger.js";
+
+/**
+ * Run a contract call, logging (with structured fields, not console.*) and
+ * swallowing any failure behind `fallback` instead of propagating it.
+ *
+ * Every read method below tolerates individual on-chain/RPC failures the
+ * same way — this is the shared wrapper that replaces the repeated
+ * try/catch + console.error block that used to appear in each of them.
+ */
+async function withErrorLogging<T>(
+  operation: string,
+  fallback: T,
+  fn: () => Promise<T>,
+): Promise<T> {
+  try {
+    return await fn();
+  } catch (error) {
+    logger.error(
+      { err: error, operation },
+      `Contract call failed: ${operation}`,
+    );
+    return fallback;
+  }
+}
 
 // ── Configuration ──────────────────────────────────────────────────────────────
 
@@ -80,17 +107,20 @@ export class ContractService {
 
     const result = await this.server.simulateTransaction(tx);
     if (SorobanRpc.Api.isSimulationError(result)) {
-      throw new Error(`Contract call failed [${contractId}.${method}]: ${result.error}`);
+      throw new Error(
+        `Contract call failed [${contractId}.${method}]: ${result.error}`,
+      );
     }
     return scValToNative(
-      (result as SorobanRpc.Api.SimulateTransactionSuccessResponse).result!.retval,
+      (result as SorobanRpc.Api.SimulateTransactionSuccessResponse).result!
+        .retval,
     ) as T;
   }
 
   // ── Internal: fetch single campaign from its contract ──────────────────────
 
   private async fetchCampaign(id: string): Promise<Campaign | null> {
-    try {
+    return withErrorLogging(`fetchCampaign(${id})`, null, async () => {
       const [info, stats] = await Promise.all([
         this.view<RawCampaignInfo>(id, "get_campaign_info"),
         this.view<RawCampaignStats>(id, "get_stats"),
@@ -111,15 +141,31 @@ export class ContractService {
         maxContribution: info.max_contribution,
         totalContributors: stats.contributor_count,
         token: info.token,
-        platformFeeBps: info.has_platform_config ? info.platform_fee_bps : undefined,
+        platformFeeBps: info.has_platform_config
+          ? info.platform_fee_bps
+          : undefined,
         hasRBACEnabled: info.has_platform_config,
         createdAt: nowUtcIso(),
         updatedAt: nowUtcIso(),
       };
-    } catch (error) {
-      console.error(`Error fetching campaign ${id}:`, error);
-      return null;
-    }
+    });
+  }
+
+  /**
+   * List every campaign ID known to the registry.
+   *
+   * The registry's `list` view is offset/limit paginated with no "give me
+   * everything" mode, so callers that need the full set (stats, trending,
+   * search, per-user aggregation) page through it with an upper bound well
+   * beyond any realistic campaign count. Centralized here so that workaround
+   * exists in exactly one place instead of being copy-pasted per call site.
+   */
+  private async listAllCampaignIds(): Promise<string[]> {
+    if (!this.registryContractId) return [];
+    return this.view<string[]>(this.registryContractId, "list", [
+      nativeToScVal(0, { type: "u32" }),
+      nativeToScVal(1_000_000, { type: "u32" }),
+    ]);
   }
 
   // ── Public read methods ────────────────────────────────────────────────────
@@ -137,20 +183,16 @@ export class ContractService {
    */
   async getCampaigns(params: GetCampaignsParams): Promise<Campaign[]> {
     if (!this.registryContractId) {
-      console.warn("getCampaigns called without registryContractId configured");
+      logger.warn("getCampaigns called without registryContractId configured");
       return [];
     }
 
-    try {
+    return withErrorLogging("getCampaigns", [], async () => {
       const { pagination } = params;
-      const ids = await this.view<string[]>(
-        this.registryContractId,
-        "list",
-        [
-          nativeToScVal(pagination.offset, { type: "u32" }),
-          nativeToScVal(pagination.limit, { type: "u32" }),
-        ],
-      );
+      const ids = await this.view<string[]>(this.registryContractId!, "list", [
+        nativeToScVal(pagination.offset, { type: "u32" }),
+        nativeToScVal(pagination.limit, { type: "u32" }),
+      ]);
 
       const campaigns = (
         await Promise.all(ids.map((id) => this.fetchCampaign(id)))
@@ -162,28 +204,18 @@ export class ContractService {
       }
 
       return campaigns;
-    } catch (error) {
-      console.error("Error fetching campaigns:", error);
-      return [];
-    }
+    });
   }
 
   /**
    * Get total campaign count from the registry.
    */
-  async getCampaignCount(_filter?: any): Promise<number> {
+  async getCampaignCount(_filter?: CampaignFilter): Promise<number> {
     if (!this.registryContractId) return 0;
-    try {
-      const all = await this.view<string[]>(
-        this.registryContractId,
-        "list",
-        [nativeToScVal(0, { type: "u32" }), nativeToScVal(1_000_000, { type: "u32" })],
-      );
+    return withErrorLogging("getCampaignCount", 0, async () => {
+      const all = await this.listAllCampaignIds();
       return all.length;
-    } catch (error) {
-      console.error("Error getting campaign count:", error);
-      return 0;
-    }
+    });
   }
 
   /**
@@ -192,32 +224,21 @@ export class ContractService {
    */
   async getTrendingCampaigns(limit: number): Promise<Campaign[]> {
     if (!this.registryContractId) return [];
-    try {
-      const ids = await this.view<string[]>(
-        this.registryContractId,
-        "list",
-        [nativeToScVal(0, { type: "u32" }), nativeToScVal(1_000_000, { type: "u32" })],
-      );
+    return withErrorLogging("getTrendingCampaigns", [], async () => {
+      const ids = await this.listAllCampaignIds();
 
       const withMetrics = (
         await Promise.all(
           ids.map(async (id) => {
-            try {
-              const campaign = await this.fetchCampaign(id);
-              if (!campaign || campaign.status !== "Active") return null;
-              return campaign;
-            } catch {
-              return null;
-            }
+            const campaign = await this.fetchCampaign(id);
+            if (!campaign || campaign.status !== "Active") return null;
+            return campaign;
           }),
         )
       ).filter(Boolean) as Campaign[];
 
       return withMetrics.slice(0, limit);
-    } catch (error) {
-      console.error("Error fetching trending campaigns:", error);
-      return [];
-    }
+    });
   }
 
   /**
@@ -226,55 +247,40 @@ export class ContractService {
    */
   async searchCampaigns(query: string, limit: number): Promise<Campaign[]> {
     if (!this.registryContractId) return [];
-    try {
-      const ids = await this.view<string[]>(
-        this.registryContractId,
-        "list",
-        [nativeToScVal(0, { type: "u32" }), nativeToScVal(1_000_000, { type: "u32" })],
-      );
+    return withErrorLogging("searchCampaigns", [], async () => {
+      const ids = await this.listAllCampaignIds();
 
       const q = query.toLowerCase();
       const matches = (
         await Promise.all(
           ids.map(async (id) => {
-            try {
-              const c = await this.fetchCampaign(id);
-              if (!c) return null;
-              if (
-                c.title.toLowerCase().includes(q) ||
-                c.description.toLowerCase().includes(q)
-              ) {
-                return c;
-              }
-              return null;
-            } catch {
-              return null;
+            const c = await this.fetchCampaign(id);
+            if (!c) return null;
+            if (
+              c.title.toLowerCase().includes(q) ||
+              c.description.toLowerCase().includes(q)
+            ) {
+              return c;
             }
+            return null;
           }),
         )
       ).filter(Boolean) as Campaign[];
 
       return matches.slice(0, limit);
-    } catch (error) {
-      console.error("Error searching campaigns:", error);
-      return [];
-    }
+    });
   }
 
   /**
    * Get user profile by aggregating on-chain data across all known campaigns.
    */
   async getUser(address: string): Promise<User | null> {
-    try {
+    return withErrorLogging(`getUser(${address})`, null, async () => {
       let totalContributed = BigInt(0);
       let contributionCount = 0;
 
       if (this.registryContractId) {
-        const ids = await this.view<string[]>(
-          this.registryContractId,
-          "list",
-          [nativeToScVal(0, { type: "u32" }), nativeToScVal(1_000_000, { type: "u32" })],
-        );
+        const ids = await this.listAllCampaignIds();
 
         for (const campaignId of ids) {
           try {
@@ -301,32 +307,44 @@ export class ContractService {
         contributions: [],
         joinedAt: nowUtcIso(),
       };
-    } catch (error) {
-      console.error(`Error fetching user ${address}:`, error);
-      return null;
-    }
+    });
   }
 
   /**
    * Get platform statistics by aggregating all registered campaigns.
    */
   async getStats(): Promise<Statistics> {
+    const emptyStats: Statistics = {
+      totalCampaigns: 0,
+      activeCampaigns: 0,
+      totalRaised: BigInt(0),
+      totalContributors: 0,
+      averageContribution: BigInt(0),
+      successRate: 0,
+    };
+
     if (!this.registryContractId) {
-      return {
-        totalCampaigns: 0,
-        activeCampaigns: 0,
-        totalRaised: BigInt(0),
-        totalContributors: 0,
-        averageContribution: BigInt(0),
-        successRate: 0,
-      };
+      return emptyStats;
     }
 
-    try {
-      const ids = await this.view<string[]>(
-        this.registryContractId,
-        "list",
-        [nativeToScVal(0, { type: "u32" }), nativeToScVal(1_000_000, { type: "u32" })],
+    return withErrorLogging("getStats", emptyStats, async () => {
+      const ids = await this.listAllCampaignIds();
+
+      // Fetch each campaign's info+stats in parallel rather than sequentially
+      // awaiting two on-chain calls per campaign in a loop — matches the
+      // Promise.all pattern already used by getCampaigns/getTrendingCampaigns.
+      const perCampaign = await Promise.all(
+        ids.map(async (id) => {
+          try {
+            const [info, stats] = await Promise.all([
+              this.view<RawCampaignInfo>(id, "get_campaign_info"),
+              this.view<RawCampaignStats>(id, "get_stats"),
+            ]);
+            return { info, stats };
+          } catch {
+            return null;
+          }
+        }),
       );
 
       let totalRaised = BigInt(0);
@@ -335,24 +353,22 @@ export class ContractService {
       let activeCampaigns = 0;
       let successfulCount = 0;
 
-      for (const id of ids) {
-        try {
-          const info = await this.view<RawCampaignInfo>(id, "get_campaign_info");
-          const stats = await this.view<RawCampaignStats>(id, "get_stats");
+      for (const entry of perCampaign) {
+        if (!entry) continue;
+        const { info, stats } = entry;
 
-          totalCampaigns++;
-          totalRaised += stats.total_raised;
-          totalContributors += stats.contributor_count;
+        totalCampaigns++;
+        totalRaised += stats.total_raised;
+        totalContributors += stats.contributor_count;
 
-          if (info.status === "Active") activeCampaigns++;
-          if (info.status === "Successful") successfulCount++;
-        } catch {
-          // Skip inaccessible campaigns
-        }
+        if (info.status === "Active") activeCampaigns++;
+        if (info.status === "Successful") successfulCount++;
       }
 
       const avgContrib =
-        totalContributors > 0 ? totalRaised / BigInt(totalContributors) : BigInt(0);
+        totalContributors > 0
+          ? totalRaised / BigInt(totalContributors)
+          : BigInt(0);
       const successRate =
         totalCampaigns > 0 ? (successfulCount / totalCampaigns) * 100 : 0;
 
@@ -364,17 +380,7 @@ export class ContractService {
         averageContribution: avgContrib,
         successRate,
       };
-    } catch (error) {
-      console.error("Error fetching stats:", error);
-      return {
-        totalCampaigns: 0,
-        activeCampaigns: 0,
-        totalRaised: BigInt(0),
-        totalContributors: 0,
-        averageContribution: BigInt(0),
-        successRate: 0,
-      };
-    }
+    });
   }
 
   // ── Write methods ─────────────────────────────────────────────────────────
@@ -390,13 +396,13 @@ export class ContractService {
     message: string,
     signature: string,
   ): Promise<boolean> {
-    try {
+    return withErrorLogging("verifySignature", false, async () => {
       const keypair = Keypair.fromPublicKey(address);
-      return keypair.verify(Buffer.from(message, "utf-8"), Buffer.from(signature, "hex"));
-    } catch (error) {
-      console.error("Error verifying signature:", error);
-      return false;
-    }
+      return keypair.verify(
+        Buffer.from(message, "utf-8"),
+        Buffer.from(signature, "hex"),
+      );
+    });
   }
 
   /**
@@ -407,7 +413,10 @@ export class ContractService {
    *
    * Returns a `Campaign` object representing the newly created campaign.
    */
-  async createCampaign(creator: any, input: CreateCampaignInput): Promise<Campaign> {
+  async createCampaign(
+    creator: AuthenticatedUser,
+    input: CreateCampaignInput,
+  ): Promise<Campaign> {
     throw new Error(
       "createCampaign requires a pre-signed deploy+initialize transaction. " +
         "Provide the signed XDR via a separate mutation field instead.",
@@ -419,7 +428,7 @@ export class ContractService {
    */
   async updateCampaign(
     id: string,
-    user: any,
+    user: AuthenticatedUser,
     input: UpdateCampaignInput,
   ): Promise<Campaign> {
     throw new Error(
@@ -434,8 +443,13 @@ export class ContractService {
    * This reads the on-chain state to confirm the contribution exists
    * and returns a `Contribution` object derived from chain data.
    */
-  async recordContribution(input: RecordContributionInput): Promise<Contribution> {
-    // Verify contribution exists on-chain by checking the contributor's balance
+  async recordContribution(
+    input: RecordContributionInput,
+  ): Promise<Contribution> {
+    // Verify contribution exists on-chain by checking the contributor's balance.
+    // Unlike the read methods above this rethrows rather than falling back —
+    // a caller that thinks it recorded a contribution needs to know when it
+    // didn't — so it keeps its own try/catch instead of withErrorLogging.
     try {
       const contribAmount = await this.view<bigint>(
         input.campaignId,
@@ -458,7 +472,14 @@ export class ContractService {
         transactionHash: input.transactionHash,
       };
     } catch (error) {
-      console.error("Error recording contribution:", error);
+      logger.error(
+        {
+          err: error,
+          campaignId: input.campaignId,
+          contributor: input.contributor,
+        },
+        "Error recording contribution",
+      );
       throw error;
     }
   }

--- a/services/graphql-api/src/types.ts
+++ b/services/graphql-api/src/types.ts
@@ -187,6 +187,12 @@ export interface DataLoaders {
   userContributions: DataLoader<string, Contribution[]>;
 }
 
+/** An authenticated caller, derived from a verified JWT. */
+export interface AuthenticatedUser {
+  address: string;
+  isAuthenticated: boolean;
+}
+
 // Context type
 export interface Context {
   cache: any; // Redis cache service
@@ -194,10 +200,7 @@ export interface Context {
   dataLoader: DataLoaders;
   pubsub: PubSubService;
   authService: any; // Auth service
-  user?: {
-    address: string;
-    isAuthenticated: boolean;
-  };
+  user?: AuthenticatedUser;
   redis: RedisClientType;
   /** Trace ID for this request — generated once in the Apollo context factory
    *  and forwarded as X-Trace-ID to all downstream HTTP calls. */

--- a/services/indexer/src/__tests__/health-endpoints.test.ts
+++ b/services/indexer/src/__tests__/health-endpoints.test.ts
@@ -141,8 +141,17 @@ describe("Indexer health endpoints (#914)", () => {
   // ── /health — original endpoint (kept for compat) ─────────────────────────
 
   describe("GET /health (original liveness, kept for backwards compat)", () => {
-    it("returns 503 before any events are recorded (unhealthy)", () => {
+    it("returns 202 (degraded), not 503, before any events are recorded during the startup grace period", () => {
+      // A freshly-started service hasn't had a chance to process its first
+      // event yet — that's not the same as being unhealthy.
       const { status, body } = handleHealth(healthChecker);
+      expect(status).toBe(202);
+      expect((body as any).status).toBe("degraded");
+    });
+
+    it("returns 503 (unhealthy) once the startup grace period elapses with still no events", () => {
+      const shortGraceChecker = new HealthChecker(logger, 0);
+      const { status, body } = handleHealth(shortGraceChecker);
       expect(status).toBe(503);
       expect((body as any).status).toBe("unhealthy");
     });

--- a/services/indexer/src/event-store.test.ts
+++ b/services/indexer/src/event-store.test.ts
@@ -85,6 +85,26 @@ describe("EventStore", () => {
     expect(store.getCount()).toBeLessThanOrEqual(5);
   });
 
+  it("evicts the oldest-inserted events first (FIFO, not a per-insert sort)", () => {
+    const store = new EventStore(logger, 5);
+    const events: IndexerEvent[] = Array.from({ length: 10 }, (_, i) => ({
+      id: `${i}`,
+      timestamp: Date.now() + i,
+      type: "Contribute",
+      contractId: "CXXX",
+      data: {},
+    }));
+
+    store.addEvents(events);
+
+    // The 5 most-recently-inserted events (5..9) survive; 0..4 were evicted.
+    const remaining = store
+      .getAllEvents(10)
+      .map((e) => e.id)
+      .sort();
+    expect(remaining).toEqual(["5", "6", "7", "8", "9"]);
+  });
+
   it("should clear all events", () => {
     const store = new EventStore(logger);
     const events: IndexerEvent[] = [
@@ -102,5 +122,38 @@ describe("EventStore", () => {
 
     store.clear();
     expect(store.getCount()).toBe(0);
+  });
+
+  describe("queryByContractAndType", () => {
+    const events: IndexerEvent[] = [
+      { id: "1", timestamp: 1, type: "Contribute", contractId: "C1", data: {} },
+      { id: "2", timestamp: 2, type: "Withdraw", contractId: "C1", data: {} },
+      { id: "3", timestamp: 3, type: "Contribute", contractId: "C2", data: {} },
+      { id: "4", timestamp: 4, type: "Contribute", contractId: "C1", data: {} },
+    ];
+
+    it("filters by both contract and type (indexes disabled)", () => {
+      const store = new EventStore(logger);
+      store.addEvents(events);
+
+      const results = store.queryByContractAndType("C1", "Contribute");
+      expect(results.map((e) => e.id).sort()).toEqual(["1", "4"]);
+    });
+
+    it("filters by both contract and type (indexes enabled)", () => {
+      const store = new EventStore(logger);
+      store.enableIndexes();
+      store.addEvents(events);
+
+      const results = store.queryByContractAndType("C1", "Contribute");
+      expect(results.map((e) => e.id).sort()).toEqual(["1", "4"]);
+    });
+
+    it("returns an empty array when no events match both filters", () => {
+      const store = new EventStore(logger);
+      store.addEvents(events);
+
+      expect(store.queryByContractAndType("C2", "Withdraw")).toEqual([]);
+    });
   });
 });

--- a/services/indexer/src/event-store.ts
+++ b/services/indexer/src/event-store.ts
@@ -90,16 +90,19 @@ export class EventStore implements IndexedEventStore {
         this._indexEvent(event);
       }
 
-      // Simple LRU: remove oldest events if over capacity
+      // Simple LRU: remove the oldest-inserted event once over capacity.
+      // A Map iterates keys in insertion order, so the first key is always
+      // the oldest entry — an O(1) amortized eviction instead of the
+      // previous full Array.from(...).sort() on every insert once at
+      // capacity (O(n log n) on the hot ingestion path).
       if (this.events.size > this.maxSize) {
-        const oldest = Array.from(this.events.entries()).sort(
-          (a, b) => a[1].timestamp - b[1].timestamp,
-        )[0];
-        if (oldest) {
-          this.events.delete(oldest[0]);
+        const oldestKey = this.events.keys().next().value;
+        if (oldestKey !== undefined) {
+          const oldestEvent = this.events.get(oldestKey);
+          this.events.delete(oldestKey);
           // Keep indexes consistent with eviction
-          if (this.indexesEnabled) {
-            this._unindexEvent(oldest[1]);
+          if (this.indexesEnabled && oldestEvent) {
+            this._unindexEvent(oldestEvent);
           }
         }
       }
@@ -153,6 +156,44 @@ export class EventStore implements IndexedEventStore {
     // Fallback: linear scan
     return Array.from(this.events.values())
       .filter((e) => e.type === type)
+      .sort((a, b) => b.timestamp - a.timestamp)
+      .slice(0, limit);
+  }
+
+  /**
+   * Query events by both contract ID and type in a single pass.
+   *
+   * Used by ContributionRepository.getContributionsForCampaign to filter by
+   * type directly instead of over-fetching queryByContract() results with an
+   * arbitrary multiplier and filtering client-side.
+   *
+   * When secondary indexes are enabled (#894), intersects the two index sets
+   * (iterating the smaller one) instead of a linear scan.
+   */
+  queryByContractAndType(
+    contractId: string,
+    type: string,
+    limit: number = 100,
+  ): IndexerEvent[] {
+    if (this.indexesEnabled) {
+      const cIds = this.contractIndex.get(contractId);
+      const tIds = this.typeIndex.get(type);
+      if (!cIds || !tIds || cIds.size === 0 || tIds.size === 0) return [];
+
+      const [smaller, larger] =
+        cIds.size <= tIds.size ? [cIds, tIds] : [tIds, cIds];
+      const matches: IndexerEvent[] = [];
+      for (const id of smaller) {
+        if (!larger.has(id)) continue;
+        const event = this.events.get(id);
+        if (event) matches.push(event);
+      }
+      return matches.sort((a, b) => b.timestamp - a.timestamp).slice(0, limit);
+    }
+
+    // Fallback: linear scan
+    return Array.from(this.events.values())
+      .filter((e) => e.contractId === contractId && e.type === type)
       .sort((a, b) => b.timestamp - a.timestamp)
       .slice(0, limit);
   }

--- a/services/indexer/src/health-checker.test.ts
+++ b/services/indexer/src/health-checker.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import pino from "pino";
+import { HealthChecker } from "./health-checker.js";
+
+const logger = pino({ level: "silent" });
+
+describe("HealthChecker", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("does not report unhealthy immediately after boot with zero events processed", () => {
+    const checker = new HealthChecker(logger, 30000);
+    const status = checker.getStatus();
+
+    expect(status.eventsProcessed).toBe(0);
+    expect(status.status).not.toBe("unhealthy");
+  });
+
+  it("reports unhealthy once the startup grace period elapses with still no events", () => {
+    vi.useFakeTimers();
+    const now = Date.now();
+    vi.setSystemTime(now);
+
+    const checker = new HealthChecker(logger, 30000);
+    vi.setSystemTime(now + 30001);
+
+    expect(checker.getStatus().status).toBe("unhealthy");
+  });
+
+  it("reports healthy once an event is recorded, even within the grace window", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(Date.now());
+
+    const checker = new HealthChecker(logger, 30000);
+    checker.recordEvent(100);
+
+    expect(checker.getStatus().status).toBe("healthy");
+  });
+});

--- a/services/indexer/src/health-checker.ts
+++ b/services/indexer/src/health-checker.ts
@@ -11,16 +11,26 @@ export interface HealthStatus {
   eventsProcessed: number;
 }
 
+/** Default window after boot during which a lack of processed events is not
+ *  reported as "unhealthy" — the indexer may simply not have caught its
+ *  first ledger yet. */
+const DEFAULT_STARTUP_GRACE_PERIOD_MS = 30000;
+
 export class HealthChecker {
   private startTime: number;
   private lastEventTime: number = 0;
   private lastLedger: number = 0;
   private eventsProcessed: number = 0;
   private logger: pino.Logger;
+  private readonly startupGracePeriodMs: number;
 
-  constructor(logger: pino.Logger) {
+  constructor(
+    logger: pino.Logger,
+    startupGracePeriodMs: number = DEFAULT_STARTUP_GRACE_PERIOD_MS,
+  ) {
     this.logger = logger;
     this.startTime = Date.now();
+    this.startupGracePeriodMs = startupGracePeriodMs;
   }
 
   /**
@@ -37,10 +47,31 @@ export class HealthChecker {
    */
   getStatus(): HealthStatus {
     const uptime = Date.now() - this.startTime;
-    const isHealthy = this.eventsProcessed > 0 && Date.now() - this.lastEventTime < 60000;
-    const isDegraded = this.eventsProcessed > 0 && Date.now() - this.lastEventTime < 120000;
 
-    const status = isHealthy ? "healthy" : isDegraded ? "degraded" : "unhealthy";
+    // During the startup grace window, a service that hasn't processed its
+    // first event yet is still starting up, not unhealthy — report
+    // "degraded" instead of "unhealthy" until either an event lands or the
+    // window elapses.
+    if (this.eventsProcessed === 0 && uptime < this.startupGracePeriodMs) {
+      return {
+        status: "degraded",
+        uptime,
+        lastEventTime: this.lastEventTime,
+        lastLedger: this.lastLedger,
+        eventsProcessed: this.eventsProcessed,
+      };
+    }
+
+    const isHealthy =
+      this.eventsProcessed > 0 && Date.now() - this.lastEventTime < 60000;
+    const isDegraded =
+      this.eventsProcessed > 0 && Date.now() - this.lastEventTime < 120000;
+
+    const status = isHealthy
+      ? "healthy"
+      : isDegraded
+        ? "degraded"
+        : "unhealthy";
 
     return {
       status,

--- a/services/indexer/src/repository-impl.ts
+++ b/services/indexer/src/repository-impl.ts
@@ -47,7 +47,7 @@ export class EventStoreRepository
     this.store.addEvents(events);
     this.logger.debug(
       { count: events.length, total: this.store.getCount() },
-      "EventStoreRepository.addEvents"
+      "EventStoreRepository.addEvents",
     );
   }
 
@@ -82,9 +82,10 @@ export class EventStoreRepository
 
   /** @inheritdoc */
   getContributionsForCampaign(campaignId: string, limit = 100): IndexerEvent[] {
-    return this.store
-      .queryByContract(campaignId, limit * 10) // over-fetch to filter by type
-      .filter((e) => e.type === CONTRIBUTION_EVENT_TYPE)
-      .slice(0, limit);
+    return this.store.queryByContractAndType(
+      campaignId,
+      CONTRIBUTION_EVENT_TYPE,
+      limit,
+    );
   }
 }

--- a/services/indexer/src/repository.test.ts
+++ b/services/indexer/src/repository.test.ts
@@ -50,10 +50,10 @@ function createMockEventRepository(): EventRepository & {
     _events,
     addEvents: vi.fn((events: IndexerEvent[]) => _events.push(...events)),
     queryByContract: vi.fn((id, limit = 100) =>
-      _events.filter((e) => e.contractId === id).slice(0, limit)
+      _events.filter((e) => e.contractId === id).slice(0, limit),
     ),
     queryByType: vi.fn((type, limit = 100) =>
-      _events.filter((e) => e.type === type).slice(0, limit)
+      _events.filter((e) => e.type === type).slice(0, limit),
     ),
     getAllEvents: vi.fn((limit = 100) => _events.slice(0, limit)),
     getCount: vi.fn(() => _events.length),
@@ -125,7 +125,10 @@ describe("EventStoreRepository integration (real EventStore)", () => {
 
   describe("satisfies EventRepository", () => {
     it("addEvents persists events retrievable via getAllEvents", () => {
-      const events = [makeEvent({ contractId: "C1" }), makeEvent({ contractId: "C2" })];
+      const events = [
+        makeEvent({ contractId: "C1" }),
+        makeEvent({ contractId: "C2" }),
+      ];
       repoImpl.addEvents(events);
       const all = repoImpl.getAllEvents(100);
       expect(all).toHaveLength(2);
@@ -211,11 +214,43 @@ describe("EventStoreRepository integration (real EventStore)", () => {
       const campaignId = "CAMP_CONTRIB_3";
       repoImpl.addEvents(
         Array.from({ length: 10 }, () =>
-          makeEvent({ contractId: campaignId, type: "Contribute" })
-        )
+          makeEvent({ contractId: campaignId, type: "Contribute" }),
+        ),
       );
       const contributions = repoImpl.getContributionsForCampaign(campaignId, 3);
       expect(contributions.length).toBeLessThanOrEqual(3);
+    });
+
+    it("finds contributions even when more recent non-Contribute events for the same campaign outnumber limit*10", () => {
+      // Regression test: the old implementation over-fetched
+      // queryByContract(campaignId, limit * 10) and filtered by type
+      // client-side. With limit=2 that fetches only the 20 most-recent
+      // events for the contract — if 20+ newer non-Contribute events exist,
+      // the real (older) Contribute events never make it into that window
+      // and are silently dropped.
+      const campaignId = "CAMP_CONTRIB_4";
+      const base = Date.now();
+
+      const contributeEvents = Array.from({ length: 2 }, (_, i) =>
+        makeEvent({
+          contractId: campaignId,
+          type: "Contribute",
+          timestamp: base + i, // oldest
+        }),
+      );
+      const noisyEvents = Array.from({ length: 25 }, (_, i) =>
+        makeEvent({
+          contractId: campaignId,
+          type: "Withdraw",
+          timestamp: base + 1000 + i, // all newer than the contributions
+        }),
+      );
+
+      repoImpl.addEvents([...noisyEvents, ...contributeEvents]);
+
+      const contributions = repoImpl.getContributionsForCampaign(campaignId, 2);
+      expect(contributions).toHaveLength(2);
+      expect(contributions.every((e) => e.type === "Contribute")).toBe(true);
     });
   });
 });


### PR DESCRIPTION
GraphQL API
Cache correctness fixes
Replaced wildcard invalidation calls from del() to delPattern().
Added campaign list and trending cache invalidation after contributions.
Ensured all campaign-related mutations consistently invalidate affected cache groups.
Contract service improvements
Introduced a shared contract execution wrapper (withErrorLogging / callContract) to centralize:
Error handling
Structured logging
Exception propagation
Removed duplicated try/catch blocks across contract service methods.
Replaced raw console logging with structured logger usage.
Error handling standardization
Added extensions.code to all GraphQL errors, including:
NOT_FOUND
BAD_USER_INPUT
TOO_MANY_REQUESTS
Other resolver-level errors
Type safety improvements
Replaced any parameters with strongly typed interfaces from packages/types.
Improved method signatures for:
createCampaign
updateCampaign
getCampaignCount
Performance optimizations
Parallelized per-campaign stat retrieval in getStats() using Promise.all.
Consolidated duplicated campaign pagination logic into a reusable helper.
closes #1061